### PR TITLE
Fix Monty Gemini tool continuations

### DIFF
--- a/examples/monty/conversational_subagent_workflow.py
+++ b/examples/monty/conversational_subagent_workflow.py
@@ -102,7 +102,6 @@ this ONCE at the start of the conversation, then reuse the same handle for every
 - `{SUBAGENT_KEY}_run_script`: send a script to a running script-runner. Pass the handle from \
 `start_{SUBAGENT_KEY}` as `subagent`, and the script in `message` (a RunScript object with a \
 `script` field). The reply carries the script's printed output and final value.
-- `stop_{SUBAGENT_KEY}`: stop a script-runner when the conversation's work is fully done.
 
 {_SCRIPT_CONTRACT}
 
@@ -176,7 +175,11 @@ class MontyChatSubagentWorkflow:
 
         Updates ``self._previous_interaction_id`` for chaining the next turn (no file_search
         here, so chaining is safe)."""
-        tools = [function_param(fn) for fn in self._tools]
+        tools = [
+            function_param(fn)
+            for fn in self._tools
+            if fn.__name__ != f"stop_{SUBAGENT_KEY}"
+        ]
         next_input: Input = user_text
         while True:
             (
@@ -221,7 +224,7 @@ class MontyChatSubagentWorkflow:
                 else {}
             )
             result = await self._runner.run_tool(call.id, tool_callable, **arguments)
-            return {
+            response: FunctionResultStepParam = {
                 "type": "function_result",
                 "call_id": call.id,
                 "name": call.name,
@@ -229,14 +232,20 @@ class MontyChatSubagentWorkflow:
                 if isinstance(result, BaseModel)
                 else str(result),
             }
+            if call.signature:
+                response["signature"] = call.signature
+            return response
         except Exception as e:
-            return {
+            response = {
                 "type": "function_result",
                 "call_id": call.id,
                 "name": call.name,
                 "result": str(e),
                 "is_error": True,
             }
+            if call.signature:
+                response["signature"] = call.signature
+            return response
 
     async def _execute_agent_interaction(
         self,
@@ -263,7 +272,6 @@ class MontyChatSubagentWorkflow:
             system_instruction=system_instruction,
             tools=tools,
             stream=True,
-            generation_config={"thinking_summaries": "auto"},
         )
         if previous_interaction_id:
             stream = await interactions_create_fn(

--- a/examples/monty/conversational_workflow.py
+++ b/examples/monty/conversational_workflow.py
@@ -265,20 +265,26 @@ class MontyChatAgentWorkflow:
             result = await self._runner.run_tool(
                 call.id, self._monty_tool, **call.arguments
             )
-            return {
+            response: FunctionResultStepParam = {
                 "type": "function_result",
                 "call_id": call.id,
                 "name": call.name,
                 "result": str(result),
             }
+            if call.signature:
+                response["signature"] = call.signature
+            return response
         except Exception as e:
-            return {
+            response = {
                 "type": "function_result",
                 "call_id": call.id,
                 "name": call.name,
                 "result": str(e),
                 "is_error": True,
             }
+            if call.signature:
+                response["signature"] = call.signature
+            return response
 
     async def _execute_agent_interaction(
         self,
@@ -305,7 +311,6 @@ class MontyChatAgentWorkflow:
             system_instruction=system_instruction,
             tools=tools,
             stream=True,
-            generation_config={"thinking_summaries": "auto"},
         )
         if previous_interaction_id:
             stream = await interactions_create_fn(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Remove stop_monty from Gemini due to 2.10.0 upgrade to keep Monty subagents open

The bad interaction is:

  1. The prompt tells Gemini: start monty once and reuse the returned handle across turns.
  2. The workflow chains Gemini state with previous_interaction_id, so the model can remember that handle.
  3. If stop_monty is available, the model may reasonably call it after finishing the current user request.
  4. stop_monty calls runner.stop_subagent, which signals the child close and removes the handle from the runner registry.
  5. On a later turn, Gemini may continue with the remembered handle and call monty_run_script, but Temporal now rejects it as
     UnknownSubagent.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
