### PR TITLE
Add configurable slash command registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ from temporalio import workflow
 from temporalio.contrib.workflow_streams import WorkflowStream
 from temporalio.workflow import ActivityConfig
 
-from temporal_agent_harness.harness import AgentWorkflowRunner, agent
+from temporal_agent_harness.harness import AgentWorkflowRunner, agent, slash_commands
 from temporal_agent_harness.harness.agent_protocol import AgentConfig, ToolApprovalPolicy
 
 
@@ -127,6 +127,7 @@ class TravelAgent:
             config,
             stream=WorkflowStream(),
             approval_policy_default=ToolApprovalPolicy.allow_inherently_safe(),
+            slash_commands=slash_commands.default_commands(),
         )
 
     @workflow.run
@@ -140,6 +141,64 @@ class TravelAgent:
     @agent.accepts
     async def plan_trip(self, request: PlanTrip) -> Itinerary:
         ...
+```
+
+## Slash Commands
+
+Agents can expose human/operator slash commands through a small library of
+workflow-safe command definitions. A command bundles the UI metadata returned by
+the `operator_interface` query with the deterministic handler that runs inside
+the workflow.
+
+If `slash_commands` is omitted, `AgentWorkflowRunner` enables the packaged
+defaults:
+
+| Command | Effect |
+| --- | --- |
+| `/approvals strict\|safe\|skip` | Change the live tool-approval policy. |
+| `/allow-tools tool_name` | Auto-approve one or more named tools for this session. |
+| `/status` | Show the current harness status. |
+| `/stop` | Stop the agent workflow. |
+
+Configure exactly the packaged commands you want in one place:
+
+```python
+from temporal_agent_harness.harness import slash_commands
+
+self._runner = AgentWorkflowRunner(
+    config,
+    stream=WorkflowStream(),
+    approval_policy_default=ToolApprovalPolicy.always_require_approvals(),
+    slash_commands=slash_commands.commands("approvals", "status", "stop"),
+)
+```
+
+Pass an empty list to disable packaged slash commands:
+
+```python
+slash_commands=[]
+```
+
+Custom commands use the same registry. For example, a model selector can share
+one implementation across the first-class operator update path and the normal
+`slash` turn path:
+
+```python
+SUPPORTED_MODELS = ("gemini-3.5-flash", "gemini-3.1-flash-lite")
+
+self._runner = AgentWorkflowRunner(
+    config,
+    stream=WorkflowStream(),
+    approval_policy_default=ToolApprovalPolicy.always_require_approvals(),
+    slash_commands=[
+        *slash_commands.default_commands(),
+        slash_commands.model_selector(
+            choices=SUPPORTED_MODELS,
+            set_model=lambda model: setattr(self, "_model", model),
+            description="Set the model for this session.",
+        ),
+    ],
+)
 ```
 
 ## Repository layout

--- a/examples/monty/conversational_subagent_workflow.py
+++ b/examples/monty/conversational_subagent_workflow.py
@@ -67,7 +67,7 @@ with workflow.unsafe.imports_passed_through():
     from temporal_agent_harness.ai_sdks.google_genai_plugin import function_param, google_genai_client
     from pydantic import BaseModel
 
-    from temporal_agent_harness.harness import agent
+    from temporal_agent_harness.harness import agent, slash_commands
     from temporal_agent_harness.harness.agent_protocol import (
         AgentConfig,
         SlashCommand,
@@ -80,10 +80,9 @@ with workflow.unsafe.imports_passed_through():
     # Reuse the script-writing contract verbatim from the inline agent — the rules the model
     # must follow to author a Monty script are identical; only the tool it calls differs.
     from .conversational_workflow import (
-        MODEL_OPERATOR_COMMAND,
         SUPPORTED_MODELS,
-        SET_MODEL_COMMAND,
         _SCRIPT_CONTRACT,
+        model_slash_command,
     )
     from .workflow import TASK_QUEUE, MontyDynamicAgentWorkflow
 
@@ -137,8 +136,10 @@ class MontyChatSubagentWorkflow:
             # escalates to a human (same stance as the inline MontyChatAgent). The script's
             # host calls run inside the child, which has its own dangerously_skip_all policy.
             approval_policy_default=ToolApprovalPolicy.always_require_approvals(),
-            operator_commands=[MODEL_OPERATOR_COMMAND],
-            operator_command_handler=self._handle_operator_command,
+            slash_commands=[
+                *slash_commands.default_commands(),
+                model_slash_command(self._set_model),
+            ],
         )
         self._model: str = DEFAULT_MODEL
         # Server-side conversation chaining id (Interactions API); updated each turn. Safe to
@@ -178,9 +179,6 @@ class MontyChatSubagentWorkflow:
     @agent.accepts
     async def slash(self, command: SlashCommand) -> TextReply:
         """Apply a slash command to this parent agent session."""
-        reply = self._handle_operator_command(command)
-        if reply is not None:
-            return reply
         return TextReply(
             text=(
                 f"Unknown Monty slash command: `{command.name}`. Try `/model`. "
@@ -188,17 +186,8 @@ class MontyChatSubagentWorkflow:
             )
         )
 
-    def _handle_operator_command(self, command: SlashCommand) -> TextReply | None:
-        if command.name == SET_MODEL_COMMAND:
-            return self._set_model(command.arg)
-        return None
-
-    def _set_model(self, model: str | None) -> TextReply:
-        if model is None or model not in SUPPORTED_MODELS:
-            choices = ", ".join(f"`{model}`" for model in SUPPORTED_MODELS)
-            return TextReply(text=f"Choose one of: {choices}.")
+    def _set_model(self, model: str) -> None:
         self._model = model
-        return TextReply(text=f"Model set to **{self._model}**.")
 
     # ------------------------------------------------------------------ chat loop
 

--- a/examples/monty/conversational_workflow.py
+++ b/examples/monty/conversational_workflow.py
@@ -50,11 +50,9 @@ with workflow.unsafe.imports_passed_through():
     )
     from google.genai.client import AsyncClient
     from temporal_agent_harness.ai_sdks.google_genai_plugin import function_param, google_genai_client
-    from temporal_agent_harness.harness import agent
+    from temporal_agent_harness.harness import agent, slash_commands
     from temporal_agent_harness.harness.agent_protocol import (
         AgentConfig,
-        OperatorCommand,
-        OperatorCommandArgument,
         SlashCommand,
         TextMessage,
         TextReply,
@@ -68,19 +66,14 @@ with workflow.unsafe.imports_passed_through():
 TASK_QUEUE = "monty-dynamic-agent"
 SUPPORTED_MODELS = ("gemini-3.5-flash", "gemini-3.1-flash-lite")
 DEFAULT_MODEL = SUPPORTED_MODELS[0]
-SET_MODEL_COMMAND = "set-model"
-MODEL_OPERATOR_COMMAND = OperatorCommand(
-    name="model",
-    payload_name=SET_MODEL_COMMAND,
-    label="/model",
-    description="Set the model for this Monty session.",
-    argument=OperatorCommandArgument(
-        kind="enum",
+
+
+def model_slash_command(set_model) -> slash_commands.SlashCommandDefinition:
+    return slash_commands.model_selector(
         choices=SUPPORTED_MODELS,
-        placeholder="model",
-    ),
-    source="agent",
-)
+        set_model=set_model,
+        description="Set the model for this Monty session.",
+    )
 
 
 # The script-writing contract the model must follow. The host functions are ASYNC — the
@@ -187,8 +180,10 @@ class MontyChatAgentWorkflow:
             # flights & hotels), since every call is dispatched through run_tool and gated.
             # always_require_approvals does not auto-approve even inherently_safe tools.
             approval_policy_default=ToolApprovalPolicy.always_require_approvals(),
-            operator_commands=[MODEL_OPERATOR_COMMAND],
-            operator_command_handler=self._handle_operator_command,
+            slash_commands=[
+                *slash_commands.default_commands(),
+                model_slash_command(self._set_model),
+            ],
         )
         self._model: str = DEFAULT_MODEL
         # Server-side conversation chaining id (Interactions API); updated each turn. Safe to
@@ -224,9 +219,6 @@ class MontyChatAgentWorkflow:
     @agent.accepts
     async def slash(self, command: SlashCommand) -> TextReply:
         """Apply a slash command to this parent agent session."""
-        reply = self._handle_operator_command(command)
-        if reply is not None:
-            return reply
         return TextReply(
             text=(
                 f"Unknown Monty slash command: `{command.name}`. Try `/model`. "
@@ -234,17 +226,8 @@ class MontyChatAgentWorkflow:
             )
         )
 
-    def _handle_operator_command(self, command: SlashCommand) -> TextReply | None:
-        if command.name == SET_MODEL_COMMAND:
-            return self._set_model(command.arg)
-        return None
-
-    def _set_model(self, model: str | None) -> TextReply:
-        if model is None or model not in SUPPORTED_MODELS:
-            choices = ", ".join(f"`{model}`" for model in SUPPORTED_MODELS)
-            return TextReply(text=f"Choose one of: {choices}.")
+    def _set_model(self, model: str) -> None:
         self._model = model
-        return TextReply(text=f"Model set to **{self._model}**.")
 
     # ------------------------------------------------------------------ chat loop
 

--- a/temporal_agent_harness/harness/__init__.py
+++ b/temporal_agent_harness/harness/__init__.py
@@ -4,7 +4,7 @@
 # construct a runner via ``AgentWorkflowRunner(config, stream=..., approval_policy_default=...)``
 # in ``@workflow.init`` and drive it with ``await runner.run(self)`` in ``@workflow.run``.
 
-from temporal_agent_harness.harness import agent
+from temporal_agent_harness.harness import agent, slash_commands
 from temporal_agent_harness.harness.agent_workflow import (
     AgentToolContext,
     AgentWorkflowRunner,
@@ -12,6 +12,7 @@ from temporal_agent_harness.harness.agent_workflow import (
 
 __all__ = [
     "agent",
+    "slash_commands",
     "AgentToolContext",
     "AgentWorkflowRunner",
 ]

--- a/temporal_agent_harness/harness/agent_workflow.py
+++ b/temporal_agent_harness/harness/agent_workflow.py
@@ -66,7 +66,6 @@ from temporal_agent_harness.harness.agent_protocol import (
     AgentStreamItem,
     MessageQueued,
     OperatorCommand,
-    OperatorCommandArgument,
     OperatorCommandCompleted,
     OperatorCommandFailed,
     OperatorCommandRequest,
@@ -94,6 +93,11 @@ from temporal_agent_harness.harness.agent_protocol import (
     TurnEnded,
     TurnStarted,
     AgentMessageReply,
+)
+from temporal_agent_harness.harness.slash_commands import (
+    SlashCommandContext,
+    SlashCommandDefinition,
+    default_commands,
 )
 
 # TurnStreamContext (the activity-side stream-publishing carrier this runner builds + consumes)
@@ -132,61 +136,8 @@ _INJECTED = _InjectedMarker()
 # Passed to the runner via its ``custom_approval_fallback=`` constructor arg; it is
 # non-serializable (a closure), so it is never carried in ``AgentConfig`` or status.
 CustomApprovalFallback = Callable[[ToolApprovalContext], bool]
-OperatorCommandHandler = Callable[[SlashCommand], TextReply | None]
 
 _SLASH_MESSAGE_TYPE = "slash"
-_SLASH_SET_APPROVALS = "set-approvals"
-_SLASH_SET_APPROVALS_ALIAS = "approvals"
-_SLASH_ALLOW_TOOLS = "allow-tools"
-_SLASH_ALLOW_TOOL_ALIAS = "allow-tool"
-_SLASH_STATUS = "status"
-_SLASH_STOP = "stop-agent"
-_SLASH_STOP_ALIAS = "stop"
-_APPROVAL_MODE_CHOICES = ("strict", "safe", "skip")
-
-_HARNESS_OPERATOR_COMMANDS = (
-    OperatorCommand(
-        name=_SLASH_SET_APPROVALS_ALIAS,
-        payload_name=_SLASH_SET_APPROVALS,
-        label="/approvals",
-        description="Set the tool approval policy for this session.",
-        aliases=(_SLASH_SET_APPROVALS,),
-        argument=OperatorCommandArgument(
-            kind="enum",
-            choices=_APPROVAL_MODE_CHOICES,
-            placeholder="strict | safe | skip",
-        ),
-        source="harness",
-    ),
-    OperatorCommand(
-        name=_SLASH_ALLOW_TOOLS,
-        payload_name=_SLASH_ALLOW_TOOLS,
-        label="/allow-tools",
-        description="Auto-approve one or more named tools for this session.",
-        aliases=(_SLASH_ALLOW_TOOL_ALIAS,),
-        argument=OperatorCommandArgument(
-            kind="tool_names",
-            placeholder="tool_name",
-            allow_multiple=True,
-        ),
-        source="harness",
-    ),
-    OperatorCommand(
-        name=_SLASH_STATUS,
-        payload_name=_SLASH_STATUS,
-        label="/status",
-        description="Show the current harness status for this session.",
-        source="harness",
-    ),
-    OperatorCommand(
-        name=_SLASH_STOP_ALIAS,
-        payload_name=_SLASH_STOP,
-        label="/stop",
-        description="Stop this agent workflow.",
-        aliases=(_SLASH_STOP,),
-        source="harness",
-    ),
-)
 
 _InjectedT = TypeVar("_InjectedT")
 
@@ -406,69 +357,6 @@ def _render_message(message: AgentMessage) -> str:
     representation of the message. Consumers that want structure can parse it back.
     """
     return message.model_dump_json(include={"type", "payload"})
-
-
-def _normalize_slash_arg(arg: str | None) -> str:
-    return (arg or "").strip()
-
-
-def _approval_policy_for_mode(mode: str | None) -> ToolApprovalPolicy | None:
-    match _normalize_slash_arg(mode).lower():
-        case "strict":
-            return ToolApprovalPolicy.always_require_approvals()
-        case "safe":
-            return ToolApprovalPolicy.allow_inherently_safe()
-        case "skip":
-            return ToolApprovalPolicy.dangerously_skip_all()
-        case _:
-            return None
-
-
-def _approval_policy_label(policy: ToolApprovalPolicy) -> str:
-    if policy.dangerously_skip_all_approvals:
-        return "skip"
-    base = "safe" if policy.auto_approve_inherently_safe else "strict"
-    if policy.auto_approve_tools:
-        return f"{base} + allow-list"
-    return base
-
-
-def _format_inline_code(values: Iterable[str]) -> str:
-    return ", ".join(f"`{value}`" for value in values)
-
-
-def _parse_tool_names(arg: str | None) -> tuple[str, ...]:
-    normalized = _normalize_slash_arg(arg).replace(",", " ")
-    return tuple(part for part in normalized.split() if part)
-
-
-def _render_harness_status(status: AgentStatus) -> str:
-    allowed = tuple(sorted(status.approval_policy.auto_approve_tools))
-    pending_approvals = sorted(
-        {
-            f"`{approval.tool_name}` (turn {approval.turn_number})"
-            for approval in status.pending_approvals
-        }
-    )
-    if status.subagents:
-        subagents = ", ".join(
-            f"`{item.subagent_id}` ({item.agent_key}, next turn {item.next_expected_turn})"
-            for item in status.subagents
-        )
-    else:
-        subagents = "none"
-
-    lines = [
-        f"- Agent id: `{status.agent_id}`",
-        f"- Turn: `{status.current_turn}` ({'active' if status.turn_active else 'idle'})",
-        f"- Queued turns: `{len(status.pending_turns)}`",
-        f"- Message queueing: `{'on' if status.is_message_queuing_enabled else 'off'}`",
-        f"- Approvals: `{_approval_policy_label(status.approval_policy)}`",
-        f"- Auto-approved tools: {_format_inline_code(allowed) if allowed else 'none'}",
-        f"- Pending approvals: {', '.join(pending_approvals) if pending_approvals else 'none'}",
-        f"- Active subagents: {subagents}",
-    ]
-    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -1180,8 +1068,7 @@ class AgentWorkflowRunner:
         approval_policy_default: ToolApprovalPolicy,
         enable_message_queuing_default: bool = False,
         custom_approval_fallback: CustomApprovalFallback | None = None,
-        operator_commands: Iterable[OperatorCommand] | None = None,
-        operator_command_handler: OperatorCommandHandler | None = None,
+        slash_commands: Iterable[SlashCommandDefinition] | None = None,
     ) -> None:
         """Construct the runner inside the agent's ``@workflow.init``::
 
@@ -1197,11 +1084,10 @@ class AgentWorkflowRunner:
         safe-by-default choice; ``enable_message_queuing_default`` defaults to the harness
         baseline of disabled). The accepted messages are NOT configured here — they are
         discovered from the agent's ``@agent.accepts`` handler methods. Registers the
-        workflow's update/query/signal handlers. ``operator_commands`` extends the
-        harness-owned operator slash commands with agent-specific slash metadata for
-        interactive clients; it is never exposed through ``agent_interface``.
-        ``operator_command_handler`` executes agent-owned operator commands through the
-        first-class operator update path, after harness-owned commands get first chance.
+        workflow's update/query/signal handlers. ``slash_commands`` configures the
+        human/operator slash command registry used by both first-class operator updates
+        and normal ``slash`` turns. If omitted, the packaged harness defaults are enabled;
+        pass an empty iterable to disable packaged slash commands.
         """
         # The runner is built inside the agent's @workflow.init; enforce here that the
         # enclosing workflow honors the standardized agent-input contract (run/__init__
@@ -1214,11 +1100,9 @@ class AgentWorkflowRunner:
         self._handlers: dict[str, _AcceptedHandler] = (
             agent_handlers(cls) if cls is not None else {}
         )
-        self._operator_commands: tuple[OperatorCommand, ...] = tuple(
-            OperatorCommand.model_validate(command)
-            for command in (operator_commands or ())
+        self._slash_commands: tuple[SlashCommandDefinition, ...] = tuple(
+            slash_commands if slash_commands is not None else default_commands()
         )
-        self._operator_command_handler = operator_command_handler
         # Resolve each knob: the caller's config value wins when given; otherwise fall back
         # to the agent's default. The caller can never be overridden — the agent only fills
         # gaps.
@@ -1448,8 +1332,8 @@ class AgentWorkflowRunner:
 
         This is the first-class execution counterpart to ``operator_interface``. It does
         not enqueue ``send_agent_message``, increment the turn counter, or publish a model
-        reply. Built-in harness commands mutate runner state directly; agent-specific
-        extensions can opt in with ``operator_command_handler``.
+        reply. Configured slash commands mutate runner state directly through a small
+        workflow-safe command context.
         """
         command = SlashCommand(name=request.name, arg=request.arg)
         operator_command_id = str(workflow.uuid4())
@@ -1464,24 +1348,22 @@ class AgentWorkflowRunner:
                 arg=command.arg,
             ),
         )
-        reply = self._handle_harness_slash(command)
-        if reply is None and self._operator_command_handler is not None:
-            try:
-                reply = self._operator_command_handler(command)
-            except Exception as e:  # noqa: BLE001 — make operator failures durable
-                message = str(e) or type(e).__name__
-                self._pub(
-                    operator_command_id,
-                    0,
-                    OperatorCommandFailed(
-                        operator_command_id=operator_command_id,
-                        command_name=command.name,
-                        command_label=command_label,
-                        arg=command.arg,
-                        message=message,
-                    ),
-                )
-                return OperatorCommandResult(text=f"Operator command failed: {message}")
+        try:
+            reply = self._handle_slash_command(command)
+        except Exception as e:  # noqa: BLE001 — make operator failures durable
+            message = str(e) or type(e).__name__
+            self._pub(
+                operator_command_id,
+                0,
+                OperatorCommandFailed(
+                    operator_command_id=operator_command_id,
+                    command_name=command.name,
+                    command_label=command_label,
+                    arg=command.arg,
+                    message=message,
+                ),
+            )
+            return OperatorCommandResult(text=f"Operator command failed: {message}")
         if reply is None:
             text = f"Unknown operator command: `{command.name}`."
             self._pub(
@@ -1646,17 +1528,27 @@ class AgentWorkflowRunner:
         Unlike ``agent_interface``, this surface is for human/client control planes. It is
         intentionally not consumed by generated subagent tools.
         """
-        return [*_HARNESS_OPERATOR_COMMANDS, *self._operator_commands]
+        return [definition.command for definition in self._slash_commands]
 
     def _operator_command_label(self, command_name: str) -> str:
-        for command in self._handle_operator_interface():
-            if (
-                command.payload_name == command_name
-                or command.name == command_name
-                or command_name in command.aliases
-            ):
-                return command.label
+        definition = self._find_slash_command(command_name)
+        if definition is not None:
+            return definition.command.label
         return f"/{command_name}"
+
+    def _find_slash_command(self, command_name: str) -> SlashCommandDefinition | None:
+        for definition in self._slash_commands:
+            if definition.matches(command_name):
+                return definition
+        return None
+
+    def _slash_command_context(self) -> SlashCommandContext:
+        return SlashCommandContext(
+            current_status=self.current_status,
+            current_approval_policy=self.current_approval_policy,
+            set_approval_policy=self.set_approval_policy,
+            close=self._handle_close,
+        )
 
     @property
     def current_stream_context(self) -> TurnStreamContext | None:
@@ -1724,9 +1616,9 @@ class AgentWorkflowRunner:
         """Dispatch one already-validated turn envelope and return its reply model."""
         if envelope.type == _SLASH_MESSAGE_TYPE:
             command = SlashCommand.model_validate(envelope.payload)
-            built_in = self._handle_harness_slash(command)
-            if built_in is not None:
-                return built_in
+            reply = self._handle_slash_command(command)
+            if reply is not None:
+                return reply
             handler = self._handlers.get(_SLASH_MESSAGE_TYPE)
             if handler is None:
                 return TextReply(text=f"Unknown slash command: `{command.name}`.")
@@ -1741,55 +1633,14 @@ class AgentWorkflowRunner:
                 f"expected {handler.output_type.__name__}",
                 type="BadHandlerReturn",
                 non_retryable=True,
-            )
+        )
         return result
 
-    def _handle_harness_slash(self, command: SlashCommand) -> TextReply | None:
-        """Handle harness-owned operator slash commands, or return ``None`` to let an
-        agent-defined slash handler handle an extension command."""
-        match command.name:
-            case _ if command.name in {_SLASH_SET_APPROVALS, _SLASH_SET_APPROVALS_ALIAS}:
-                return self._slash_set_approvals(command.arg)
-            case _ if command.name in {_SLASH_ALLOW_TOOLS, _SLASH_ALLOW_TOOL_ALIAS}:
-                return self._slash_allow_tools(command.arg)
-            case _ if command.name == _SLASH_STATUS:
-                return self._slash_status()
-            case _ if command.name in {_SLASH_STOP, _SLASH_STOP_ALIAS}:
-                return self._slash_stop()
-            case _:
-                return None
-
-    def _slash_set_approvals(self, mode: str | None) -> TextReply:
-        selected = _normalize_slash_arg(mode).lower()
-        policy = _approval_policy_for_mode(mode)
-        if policy is None:
-            return TextReply(
-                text=f"Choose one of: {_format_inline_code(_APPROVAL_MODE_CHOICES)}."
-            )
-        self.set_approval_policy(policy)
-        return TextReply(text=f"Approvals set to **{selected}**.")
-
-    def _slash_allow_tools(self, arg: str | None) -> TextReply:
-        tool_names = _parse_tool_names(arg)
-        if not tool_names:
-            return TextReply(
-                text="Choose one or more tool names to auto-approve for this session."
-            )
-        policy = self.current_approval_policy
-        for tool_name in tool_names:
-            policy = policy.with_tool_allowed(tool_name)
-        self.set_approval_policy(policy)
-        noun = "Tool" if len(tool_names) == 1 else "Tools"
-        return TextReply(
-            text=f"{noun} {_format_inline_code(tool_names)} will be auto-approved."
-        )
-
-    def _slash_status(self) -> TextReply:
-        return TextReply(text=_render_harness_status(self.current_status))
-
-    def _slash_stop(self) -> TextReply:
-        self._handle_close()
-        return TextReply(text="Agent stop requested.")
+    def _handle_slash_command(self, command: SlashCommand) -> TextReply | None:
+        definition = self._find_slash_command(command.name)
+        if definition is None:
+            return None
+        return definition.execute(self._slash_command_context(), command)
 
     # -- Subagents ----------------------------------------------------------
     #

--- a/temporal_agent_harness/harness/slash_commands.py
+++ b/temporal_agent_harness/harness/slash_commands.py
@@ -1,0 +1,378 @@
+# ABOUTME: Reusable workflow-side slash/operator command definitions for the harness.
+# Commands bundle discovery metadata with deterministic in-workflow execution.
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+from temporal_agent_harness.harness.agent_protocol import (
+    AgentStatus,
+    OperatorCommand,
+    OperatorCommandArgument,
+    SlashCommand,
+    TextReply,
+    ToolApprovalPolicy,
+)
+
+APPROVAL_MODE_CHOICES = ("strict", "safe", "skip")
+DEFAULT_COMMAND_NAMES = ("approvals", "allow-tools", "status", "stop")
+
+
+@dataclass(frozen=True)
+class SlashCommandContext:
+    """Workflow-side state and mutators available to slash command handlers."""
+
+    current_status: AgentStatus
+    current_approval_policy: ToolApprovalPolicy
+    set_approval_policy: Callable[[ToolApprovalPolicy], None]
+    close: Callable[[], None]
+
+
+SlashCommandHandler = Callable[[SlashCommandContext, SlashCommand], TextReply]
+
+
+@dataclass(frozen=True)
+class SlashCommandDefinition:
+    """A slash/operator command: UI metadata plus its workflow-side handler."""
+
+    command: OperatorCommand
+    handler: SlashCommandHandler
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "command", OperatorCommand.model_validate(self.command)
+        )
+
+    def matches(self, name: str) -> bool:
+        return (
+            name == self.command.name
+            or name == self.command.payload_name
+            or name in self.command.aliases
+        )
+
+    def execute(
+        self, context: SlashCommandContext, command: SlashCommand
+    ) -> TextReply:
+        return self.handler(context, command)
+
+
+def enum_arg(
+    choices: Iterable[str],
+    *,
+    placeholder: str | None = None,
+    required: bool = True,
+) -> OperatorCommandArgument:
+    return OperatorCommandArgument(
+        kind="enum",
+        required=required,
+        choices=tuple(choices),
+        placeholder=placeholder,
+    )
+
+
+def text_arg(
+    *,
+    placeholder: str | None = None,
+    required: bool = True,
+) -> OperatorCommandArgument:
+    return OperatorCommandArgument(
+        kind="text",
+        required=required,
+        placeholder=placeholder,
+    )
+
+
+def tool_names_arg(
+    *,
+    placeholder: str | None = "tool_name",
+    required: bool = True,
+    allow_multiple: bool = True,
+) -> OperatorCommandArgument:
+    return OperatorCommandArgument(
+        kind="tool_names",
+        required=required,
+        placeholder=placeholder,
+        allow_multiple=allow_multiple,
+    )
+
+
+def command(
+    *,
+    name: str,
+    payload_name: str,
+    label: str,
+    description: str,
+    handler: SlashCommandHandler,
+    aliases: Iterable[str] = (),
+    argument: OperatorCommandArgument | None = None,
+    source: Literal["harness", "agent"] = "agent",
+) -> SlashCommandDefinition:
+    return SlashCommandDefinition(
+        command=OperatorCommand(
+            name=name,
+            payload_name=payload_name,
+            label=label,
+            description=description,
+            aliases=tuple(aliases),
+            argument=argument,
+            source=source,
+        ),
+        handler=handler,
+    )
+
+
+def approvals() -> SlashCommandDefinition:
+    return command(
+        name="approvals",
+        payload_name="set-approvals",
+        label="/approvals",
+        description="Set the tool approval policy for this session.",
+        aliases=("set-approvals",),
+        argument=enum_arg(
+            APPROVAL_MODE_CHOICES,
+            placeholder="strict | safe | skip",
+        ),
+        source="harness",
+        handler=_handle_approvals,
+    )
+
+
+def allow_tools() -> SlashCommandDefinition:
+    return command(
+        name="allow-tools",
+        payload_name="allow-tools",
+        label="/allow-tools",
+        description="Auto-approve one or more named tools for this session.",
+        aliases=("allow-tool",),
+        argument=tool_names_arg(),
+        source="harness",
+        handler=_handle_allow_tools,
+    )
+
+
+def status() -> SlashCommandDefinition:
+    return command(
+        name="status",
+        payload_name="status",
+        label="/status",
+        description="Show the current harness status for this session.",
+        source="harness",
+        handler=_handle_status,
+    )
+
+
+def stop() -> SlashCommandDefinition:
+    return command(
+        name="stop",
+        payload_name="stop-agent",
+        label="/stop",
+        description="Stop this agent workflow.",
+        aliases=("stop-agent",),
+        source="harness",
+        handler=_handle_stop,
+    )
+
+
+def model_selector(
+    *,
+    choices: Iterable[str],
+    set_model: Callable[[str], None],
+    name: str = "model",
+    payload_name: str = "set-model",
+    label: str = "/model",
+    description: str = "Set the model for this session.",
+    placeholder: str = "model",
+    source: Literal["harness", "agent"] = "agent",
+) -> SlashCommandDefinition:
+    model_choices = tuple(choices)
+
+    def handle(
+        _context: SlashCommandContext, slash_command: SlashCommand
+    ) -> TextReply:
+        selected = _normalize_slash_arg(slash_command.arg)
+        if selected not in model_choices:
+            return TextReply(
+                text=f"Choose one of: {_format_inline_code(model_choices)}."
+            )
+        set_model(selected)
+        return TextReply(text=f"Model set to **{selected}**.")
+
+    return command(
+        name=name,
+        payload_name=payload_name,
+        label=label,
+        description=description,
+        argument=enum_arg(model_choices, placeholder=placeholder),
+        source=source,
+        handler=handle,
+    )
+
+
+def commands(*names: str) -> tuple[SlashCommandDefinition, ...]:
+    selected = names or DEFAULT_COMMAND_NAMES
+    definitions: list[SlashCommandDefinition] = []
+    seen: set[str] = set()
+    for name in selected:
+        canonical = _canonical_command_name(name)
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        definitions.append(_BUILTIN_COMMAND_FACTORIES[canonical]())
+    return tuple(definitions)
+
+
+def default_commands() -> tuple[SlashCommandDefinition, ...]:
+    return commands(*DEFAULT_COMMAND_NAMES)
+
+
+def _canonical_command_name(name: str) -> str:
+    normalized = name.strip().removeprefix("/")
+    aliases = {
+        "set-approvals": "approvals",
+        "allow-tool": "allow-tools",
+        "stop-agent": "stop",
+    }
+    canonical = aliases.get(normalized, normalized)
+    if canonical not in _BUILTIN_COMMAND_FACTORIES:
+        choices = ", ".join(DEFAULT_COMMAND_NAMES)
+        raise ValueError(
+            f"unknown packaged slash command {name!r}; choose one of: {choices}"
+        )
+    return canonical
+
+
+def _normalize_slash_arg(arg: str | None) -> str:
+    return (arg or "").strip()
+
+
+def _approval_policy_for_mode(mode: str | None) -> ToolApprovalPolicy | None:
+    match _normalize_slash_arg(mode).lower():
+        case "strict":
+            return ToolApprovalPolicy.always_require_approvals()
+        case "safe":
+            return ToolApprovalPolicy.allow_inherently_safe()
+        case "skip":
+            return ToolApprovalPolicy.dangerously_skip_all()
+        case _:
+            return None
+
+
+def _approval_policy_label(policy: ToolApprovalPolicy) -> str:
+    if policy.dangerously_skip_all_approvals:
+        return "skip"
+    base = "safe" if policy.auto_approve_inherently_safe else "strict"
+    if policy.auto_approve_tools:
+        return f"{base} + allow-list"
+    return base
+
+
+def _format_inline_code(values: Iterable[str]) -> str:
+    return ", ".join(f"`{value}`" for value in values)
+
+
+def _parse_tool_names(arg: str | None) -> tuple[str, ...]:
+    normalized = _normalize_slash_arg(arg).replace(",", " ")
+    return tuple(part for part in normalized.split() if part)
+
+
+def _render_harness_status(status: AgentStatus) -> str:
+    allowed = tuple(sorted(status.approval_policy.auto_approve_tools))
+    pending_approvals = sorted(
+        {
+            f"`{approval.tool_name}` (turn {approval.turn_number})"
+            for approval in status.pending_approvals
+        }
+    )
+    if status.subagents:
+        subagents = ", ".join(
+            f"`{item.subagent_id}` ({item.agent_key}, next turn {item.next_expected_turn})"
+            for item in status.subagents
+        )
+    else:
+        subagents = "none"
+
+    lines = [
+        f"- Agent id: `{status.agent_id}`",
+        f"- Turn: `{status.current_turn}` ({'active' if status.turn_active else 'idle'})",
+        f"- Queued turns: `{len(status.pending_turns)}`",
+        f"- Message queueing: `{'on' if status.is_message_queuing_enabled else 'off'}`",
+        f"- Approvals: `{_approval_policy_label(status.approval_policy)}`",
+        f"- Auto-approved tools: {_format_inline_code(allowed) if allowed else 'none'}",
+        f"- Pending approvals: {', '.join(pending_approvals) if pending_approvals else 'none'}",
+        f"- Active subagents: {subagents}",
+    ]
+    return "\n".join(lines)
+
+
+def _handle_approvals(
+    context: SlashCommandContext, slash_command: SlashCommand
+) -> TextReply:
+    selected = _normalize_slash_arg(slash_command.arg).lower()
+    policy = _approval_policy_for_mode(slash_command.arg)
+    if policy is None:
+        return TextReply(
+            text=f"Choose one of: {_format_inline_code(APPROVAL_MODE_CHOICES)}."
+        )
+    context.set_approval_policy(policy)
+    return TextReply(text=f"Approvals set to **{selected}**.")
+
+
+def _handle_allow_tools(
+    context: SlashCommandContext, slash_command: SlashCommand
+) -> TextReply:
+    tool_names = _parse_tool_names(slash_command.arg)
+    if not tool_names:
+        return TextReply(
+            text="Choose one or more tool names to auto-approve for this session."
+        )
+    policy = context.current_approval_policy
+    for tool_name in tool_names:
+        policy = policy.with_tool_allowed(tool_name)
+    context.set_approval_policy(policy)
+    noun = "Tool" if len(tool_names) == 1 else "Tools"
+    return TextReply(
+        text=f"{noun} {_format_inline_code(tool_names)} will be auto-approved."
+    )
+
+
+def _handle_status(
+    context: SlashCommandContext, _slash_command: SlashCommand
+) -> TextReply:
+    return TextReply(text=_render_harness_status(context.current_status))
+
+
+def _handle_stop(
+    context: SlashCommandContext, _slash_command: SlashCommand
+) -> TextReply:
+    context.close()
+    return TextReply(text="Agent stop requested.")
+
+
+_BUILTIN_COMMAND_FACTORIES: dict[str, Callable[[], SlashCommandDefinition]] = {
+    "approvals": approvals,
+    "allow-tools": allow_tools,
+    "status": status,
+    "stop": stop,
+}
+
+
+__all__ = [
+    "APPROVAL_MODE_CHOICES",
+    "DEFAULT_COMMAND_NAMES",
+    "SlashCommandContext",
+    "SlashCommandDefinition",
+    "SlashCommandHandler",
+    "allow_tools",
+    "approvals",
+    "command",
+    "commands",
+    "default_commands",
+    "enum_arg",
+    "model_selector",
+    "status",
+    "stop",
+    "text_arg",
+    "tool_names_arg",
+]

--- a/tests/harness/test_agent_workflow_runner.py
+++ b/tests/harness/test_agent_workflow_runner.py
@@ -30,7 +30,7 @@ from temporalio.contrib.workflow_streams import WorkflowStream
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
-from temporal_agent_harness.harness import AgentWorkflowRunner, agent
+from temporal_agent_harness.harness import AgentWorkflowRunner, agent, slash_commands
 from temporal_agent_harness.harness.agent_protocol import (
     AGENT_INTERFACE_QUERY,
     AGENT_STATUS_QUERY,
@@ -44,7 +44,6 @@ from temporal_agent_harness.harness.agent_protocol import (
     AgentMessage,
     AgentStatus,
     OperatorCommand,
-    OperatorCommandArgument,
     OperatorCommandRequest,
     OperatorCommandResult,
     SubagentReplyReceived,
@@ -88,18 +87,15 @@ class Picked(BaseModel):
     model: str
 
 
-PROBE_MODEL_OPERATOR_COMMAND = OperatorCommand(
-    name="model",
-    payload_name="set-model",
-    label="/model",
-    description="Set the probe model.",
-    argument=OperatorCommandArgument(
-        kind="enum",
-        choices=("alpha", "beta"),
-        placeholder="model",
-    ),
-    source="agent",
-)
+def probe_model_command(handler) -> slash_commands.SlashCommandDefinition:
+    return slash_commands.command(
+        name="model",
+        payload_name="set-model",
+        label="/model",
+        description="Set the probe model.",
+        argument=slash_commands.enum_arg(("alpha", "beta"), placeholder="model"),
+        handler=handler,
+    )
 
 
 @workflow.defn
@@ -160,8 +156,10 @@ class SlashExtensionProbeAgent:
             config,
             stream=WorkflowStream(),
             approval_policy_default=ToolApprovalPolicy.always_require_approvals(),
-            operator_commands=[PROBE_MODEL_OPERATOR_COMMAND],
-            operator_command_handler=self._handle_operator_command,
+            slash_commands=[
+                *slash_commands.default_commands(),
+                probe_model_command(self._handle_model_command),
+            ],
         )
 
     @workflow.run
@@ -173,10 +171,10 @@ class SlashExtensionProbeAgent:
         """Handle agent-specific slash commands."""
         return TextReply(text=f"custom:{command.name}:{command.arg or ''}")
 
-    def _handle_operator_command(self, command: SlashCommand) -> TextReply | None:
-        if command.name == "set-model":
-            return TextReply(text=f"operator:{command.name}:{command.arg or ''}")
-        return None
+    def _handle_model_command(
+        self, _context: slash_commands.SlashCommandContext, command: SlashCommand
+    ) -> TextReply:
+        return TextReply(text=f"operator:{command.name}:{command.arg or ''}")
 
 
 # ---------------------------------------------------------------------------
@@ -348,6 +346,20 @@ async def test_operator_interface_lists_harness_commands_for_every_agent(client_
     assert "stop-agent" in by_name["stop"].aliases
 
 
+def test_slash_commands_can_select_or_disable_packaged_commands(offline_build):
+    runner = offline_build(
+        AgentConfig(),
+        slash_commands=slash_commands.commands("status", "stop-agent"),
+    )
+    assert [command.name for command in runner._handle_operator_interface()] == [
+        "status",
+        "stop",
+    ]
+
+    runner = offline_build(AgentConfig(), slash_commands=[])
+    assert runner._handle_operator_interface() == []
+
+
 async def test_operator_interface_includes_agent_extension_commands(client_and_queue):
     client, task_queue = client_and_queue
     handle = await _start(client, task_queue, SlashExtensionProbeAgent)
@@ -492,7 +504,7 @@ async def test_operator_command_allow_tools_updates_policy_without_turn(
     assert status.current_turn == 0
 
 
-async def test_operator_command_uses_agent_extension_callback(client_and_queue):
+async def test_operator_command_uses_configured_slash_command(client_and_queue):
     client, task_queue = client_and_queue
     handle = await _start(client, task_queue, SlashExtensionProbeAgent)
 
@@ -503,7 +515,7 @@ async def test_operator_command_uses_agent_extension_callback(client_and_queue):
     assert status.current_turn == 0
 
 
-async def test_operator_command_preempts_agent_extension_for_core_commands(
+async def test_configured_core_command_preempts_agent_extension(
     client_and_queue,
 ):
     client, task_queue = client_and_queue
@@ -626,14 +638,24 @@ async def test_harness_slash_unknown_without_agent_handler_returns_reply(client_
     assert text == "Unknown slash command: `not-real`."
 
 
-async def test_harness_slash_falls_back_to_agent_extension(client_and_queue):
+async def test_configured_slash_command_handles_normal_slash_turn(client_and_queue):
     client, task_queue = client_and_queue
     handle = await _start(client, task_queue, SlashExtensionProbeAgent)
 
     await _send(handle, "slash", {"name": "set-model", "arg": "gemini"})
 
     text = _reply_text(await _collect_until_turn_end(client, handle.id))
-    assert text == "custom:set-model:gemini"
+    assert text == "operator:set-model:gemini"
+
+
+async def test_unknown_slash_falls_back_to_agent_extension(client_and_queue):
+    client, task_queue = client_and_queue
+    handle = await _start(client, task_queue, SlashExtensionProbeAgent)
+
+    await _send(handle, "slash", {"name": "unknown-extension", "arg": "value"})
+
+    text = _reply_text(await _collect_until_turn_end(client, handle.id))
+    assert text == "custom:unknown-extension:value"
 
 
 async def test_harness_slash_preempts_agent_extension_for_core_commands(client_and_queue):
@@ -959,12 +981,19 @@ def offline_build(monkeypatch):
     # no workflow loop, so stub it with a plain uuid.
     monkeypatch.setattr(aw.workflow, "uuid4", lambda: uuid.uuid4())
 
-    def build(config: AgentConfig, *, default: bool | None = None):
+    def build(
+        config: AgentConfig,
+        *,
+        default: bool | None = None,
+        slash_commands=None,
+    ):
         stream = MagicMock()
         stream.topic.return_value = MagicMock()
         kwargs: dict[str, Any] = {}
         if default is not None:
             kwargs["enable_message_queuing_default"] = default
+        if slash_commands is not None:
+            kwargs["slash_commands"] = slash_commands
         return AgentWorkflowRunner(
             config,
             stream=stream,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Added a configurable slash command registry with SlashCommandDefinition, packaged defaults, argument helpers, and model_selector.
  - Replaced legacy operator_commands / operator_command_handler runner knobs with a single slash_commands argument.
  - Moved built-in /approvals, /allow-tools, /status, and /stop behavior out of agent_workflow.py into harness/slash_commands.py.
  - Updated Monty examples and README docs to use the new slash-command API.
  - Updated tests to cover default commands, subset/disable configuration, custom commands, operator updates, and slash-turn execution.

Use with default commands plus agent specific:

```
        self._runner = AgentWorkflowRunner(
            config,
            stream=WorkflowStream(),
            approval_policy_default=ToolApprovalPolicy.always_require_approvals(),
            slash_commands=[
                *slash_commands.default_commands(),
                model_slash_command(self._set_model),
            ],
        )
```


## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
