### PR TITLE
ui: recall sent-message history from the chat composer

### DIFF
--- a/ui/src/lib/components/agent/AgentChatPanel.svelte
+++ b/ui/src/lib/components/agent/AgentChatPanel.svelte
@@ -141,6 +141,9 @@
     onApproveTool
   }: Props = $props();
   let draft = $state("");
+  let composerInput = $state<HTMLInputElement | null>(null);
+  let historyIndex = $state(-1);
+  let historyStash = $state("");
   let localMessages = $state<ChatMessage[]>([]);
   let observedSessionId = $state<string | null>(null);
   let sessionDrawerOpen = $state(false);
@@ -160,6 +163,11 @@
 
   const transcriptMessages = $derived(seedMessages(items));
   const messages = $derived([...transcriptMessages, ...localMessages]);
+  const sentUserMessages = $derived(
+    messages
+      .filter((message) => message.role === "user" || message.role === "operator-user")
+      .map((message) => message.text)
+  );
   const logsByTurn = $derived(groupLogsByTurn(logs));
   const resolvedApprovalToolIds = $derived(resolvedApprovalIds(logs));
   const pendingApprovalRows = $derived(logs.filter((row) => isApprovalPending(row)));
@@ -327,6 +335,8 @@
     if (observedSessionId !== sessionId) {
       observedSessionId = sessionId;
       draft = "";
+      historyIndex = -1;
+      historyStash = "";
       localMessages = [];
       observedActivitySessionId = null;
       observedActivityOrdinals = {};
@@ -1184,6 +1194,7 @@
     }
 
     draft = "";
+    historyIndex = -1;
     if (operatorCommand != null) {
       const commandTarget = slashTarget;
       if (onOperatorCommand) {
@@ -1351,18 +1362,73 @@
     return true;
   }
 
+  function resetHistoryRecall(): void {
+    historyIndex = -1;
+  }
+
+  // Shell-style recall of the messages already sent this session.
+  // step -1 moves toward older messages (ArrowUp), +1 toward newer (ArrowDown).
+  function recallHistory(step: number): boolean {
+    const history = sentUserMessages;
+    if (history.length === 0) return false;
+
+    if (historyIndex === -1) {
+      if (step > 0) return false; // ArrowDown with no active recall: leave draft alone
+      historyStash = draft;
+      historyIndex = history.length - 1;
+      draft = history[historyIndex] ?? "";
+      return true;
+    }
+
+    const next = historyIndex + step;
+    if (next < 0) return true; // already at oldest; consume the key but stay put
+    if (next >= history.length) {
+      // moved past the newest entry: restore the in-progress draft
+      historyIndex = -1;
+      draft = historyStash;
+      return true;
+    }
+    historyIndex = next;
+    draft = history[historyIndex] ?? "";
+    return true;
+  }
+
+  async function moveCaretToEnd(): Promise<void> {
+    await tick();
+    const element = composerInput;
+    if (!element) return;
+    const end = element.value.length;
+    element.setSelectionRange(end, end);
+  }
+
   function handleComposerKeydown(event: KeyboardEvent): void {
     if (event.altKey || event.ctrlKey || event.metaKey) return;
 
-    if ((event.key === "ArrowDown" || event.key === "ArrowRight") && moveSlashSelection(1)) {
-      event.preventDefault();
-      event.stopPropagation();
+    if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+      if (moveSlashSelection(1)) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      if (event.key === "ArrowDown" && recallHistory(1)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void moveCaretToEnd();
+      }
       return;
     }
 
-    if ((event.key === "ArrowUp" || event.key === "ArrowLeft") && moveSlashSelection(-1)) {
-      event.preventDefault();
-      event.stopPropagation();
+    if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+      if (moveSlashSelection(-1)) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      if (event.key === "ArrowUp" && recallHistory(-1)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void moveCaretToEnd();
+      }
       return;
     }
 
@@ -1370,7 +1436,12 @@
       if (!acceptSlashSelection()) return;
       event.preventDefault();
       event.stopPropagation();
+      return;
     }
+
+    // Any other key (typing, backspace, escape, …) ends history recall so the
+    // next ArrowUp re-stashes the edited draft instead of overwriting it.
+    resetHistoryRecall();
   }
 
   function handleSubmit(event: SubmitEvent): void {
@@ -1925,6 +1996,7 @@
       <form class="composer" class:closed={closed} onsubmit={handleSubmit}>
         <Search size={17} />
         <input
+          bind:this={composerInput}
           bind:value={draft}
           placeholder={composerPlaceholder}
           aria-label={`Message ${agentLabel}`}


### PR DESCRIPTION
## What

Adds shell-style message-history recall to the agent chat composer (`ui/src/lib/components/agent/AgentChatPanel.svelte`):

- **ArrowUp** walks backward through the messages you've already sent this session; repeated presses go further back.
- **ArrowDown** walks forward toward the present. Going past your newest message restores whatever you were typing before you started scrolling.
- Your in-progress draft is stashed on the first ArrowUp and brought back when you return to the bottom.
- The caret jumps to the end of the recalled text.

## Coexistence with existing behavior

The arrow keys were already bound to slash-command menu navigation. That keeps priority: `moveSlashSelection` runs first, and history recall only engages when the menu is closed. Left/Right stay reserved for the slash menu and normal caret movement — only Up/Down drive history. The composer is a single-line `<input>`, so Up/Down have no native line-navigation to conflict with.

History resets on session switch and after each send. The recall source is the user + operator messages actually in the transcript, so it reflects what was really sent (including slash commands).

## Testing

- `pnpm check` (svelte-check): 0 errors, 0 warnings
- `pnpm check:svelte5`: clean
- Driven end-to-end in the running app (Vite dev server against the live stack): verified ArrowUp/ArrowDown traversal, past-newest draft restore, in-progress-draft stash/restore, and that an open slash menu takes over the arrow keys.