### PR TITLE
[Demo] OpenAI nexus model router

### DIFF
--- a/examples/openai_nexus/README.md
+++ b/examples/openai_nexus/README.md
@@ -1,0 +1,89 @@
+# OpenAI agent, LLM calls over Nexus (prototype)
+
+The sibling of [`openai_hello`](../openai_hello): the same harness agent (chat +
+one `get_weather` tool, driven through the shared web UI), but its **LLM calls
+travel over Temporal Nexus** to a standalone **model router** instead of hitting
+the provider from a model activity.
+
+Streaming is intentionally **not** implemented — this uses `Runner.run`.
+
+## The pieces
+
+```
+ examples/openai_nexus/            the agent (this dir)
+   workflow.py   OpenAINexusAgent — harness agent, Runner.run
+   worker.py     wires the plugin's workflow_model_provider = nexus_model_provider
+   nexus_transport.py   the transport swap (below)
+
+ nexus/model_router/               the "LLM API over Nexus" (standalone)
+   models.py / service.py   ChatCompletionRequest -> ChatCompletion (its own wire types)
+   handler.py               forwards to OpenAI today; the seam for LiteLLM/multi-provider
+   worker.py                `just router` — creates the endpoint, calls OpenAI
+```
+
+## How it works (and why a custom model provider isn't enough)
+
+The OpenAI Agents SDK supports custom model providers, but in the Temporal
+integration the model call runs inside a **Temporal activity** — and
+`workflow.create_nexus_client(...)` only works in **workflow** context. So a
+provider dropped into the activity path can't reach Nexus.
+
+Instead the plugin grew a small, Nexus-agnostic seam:
+`ModelActivityParameters.workflow_model_provider` — `(model_name) -> Model`,
+resolved and called by the model stub **in the workflow**, with the live
+`tools`/`handoffs`/`model_settings` (no serialization, no reconstruction).
+
+`nexus_transport.py` provides that model: an `OpenAIChatCompletionsModel` whose
+OpenAI client is a stand-in whose `chat.completions.create` goes **over Nexus**.
+The SDK does all the Responses↔ChatCompletions translation; the only thing swapped
+is the transport. So:
+
+```
+Runner.run (workflow)
+  └─ model stub → workflow_model_provider(name)
+       └─ OpenAIChatCompletionsModel(client = NexusChatClient)
+            └─ chat.completions.create(...)                 # LiteLLM/OpenAI-shaped request
+                 └─ create_nexus_client(ModelRouterService) → chat_completion op
+                      └─ nexus/model_router handler → OpenAI → ChatCompletion
+```
+
+The wire format is the OpenAI Chat Completions shape (what LiteLLM/OpenRouter
+standardize on); `nexus/model_router` owns those wire types. LiteLLM's real value
+(multi-provider fan-out) belongs **in the router handler**, server-side, where it
+can run unrestricted — today it just calls OpenAI.
+
+Because `get_weather` is adapted with `as_openai_agent_tool`, a weather question
+is two model calls over Nexus: request the tool → run it in the workflow →
+second call for the final answer. Both go to the router.
+
+## Run it (shared web UI stack)
+
+`OPENAI_API_KEY` is needed by the **router** (it calls OpenAI), not by this agent
+worker. Each in its own terminal, from `examples/openai_nexus`:
+
+```sh
+just temporal          # 1. local Temporal dev server (or bring your own)
+just router            # 2. the model router (LLM API over Nexus); creates the endpoint
+just session-manager   # 3. packaged session-manager worker
+just server            # 4. FastAPI API + UI on :8000
+just worker            # 5. this agent worker
+```
+
+Open http://localhost:8000, pick **"OpenAI over Nexus"**, and ask
+`What's the weather in Paris?`. The reply arrives when the turn completes
+(non-streaming); the tool call shows up via `tool_start` / `tool_end`.
+
+The turn's UI-visible event sequence is
+`turn_started → tool_start → tool_end → reply → turn_end`.
+
+## Notes & limitations (it's a prototype)
+
+- **No streaming.** Only `Runner.run`; no live token / `model_interaction_*`
+  events (those come from the activity streaming observer, which this path skips).
+- The agent tool is `async` on purpose — a sync `@function_tool` would be invoked
+  in a thread executor, which the workflow sandbox forbids.
+- The SDK's `OpenAIChatCompletionsModel.get_response` runs in the workflow so the
+  Nexus call can originate there. Its converters are pure/deterministic and the
+  only workflow command is the Nexus op, so the run is replay-safe.
+- The router forwards to OpenAI with retries disabled; making it multi-provider is
+  a `handler.py` change (drop in `litellm.acompletion`), no client changes.

--- a/examples/openai_nexus/README.md
+++ b/examples/openai_nexus/README.md
@@ -17,7 +17,8 @@ Streaming is intentionally **not** implemented — this uses `Runner.run`.
 
  nexus/model_router/               the "LLM API over Nexus" (standalone)
    models.py / service.py   ChatCompletionRequest -> ChatCompletion (its own wire types)
-   handler.py               forwards to OpenAI today; the seam for LiteLLM/multi-provider
+   handler.py / workflow.py  async, workflow-backed operation (model calls exceed sync's ~10s)
+   activities.py            the OpenAI call; the seam for LiteLLM/multi-provider
    worker.py                `just router` — creates the endpoint, calls OpenAI
 ```
 
@@ -44,12 +45,17 @@ Runner.run (workflow)
        └─ OpenAIChatCompletionsModel(client = NexusChatClient)
             └─ chat.completions.create(...)                 # LiteLLM/OpenAI-shaped request
                  └─ create_nexus_client(ModelRouterService) → chat_completion op
-                      └─ nexus/model_router handler → OpenAI → ChatCompletion
+                      └─ ModelRouterWorkflow → invoke_chat_completion activity → OpenAI
 ```
+
+The `chat_completion` operation is asynchronous (workflow-backed), not sync,
+because model calls exceed the ~10s a Nexus sync operation allows — so the router
+starts a `ModelRouterWorkflow` that runs the call as a retryable activity, and the
+caller's `execute_operation` durably waits for it.
 
 The wire format is the OpenAI Chat Completions shape (what LiteLLM/OpenRouter
 standardize on); `nexus/model_router` owns those wire types. LiteLLM's real value
-(multi-provider fan-out) belongs **in the router handler**, server-side, where it
+(multi-provider fan-out) belongs **in the router's activity**, server-side, where it
 can run unrestricted — today it just calls OpenAI.
 
 Because `get_weather` is adapted with `as_openai_agent_tool`, a weather question
@@ -86,4 +92,4 @@ The turn's UI-visible event sequence is
   Nexus call can originate there. Its converters are pure/deterministic and the
   only workflow command is the Nexus op, so the run is replay-safe.
 - The router forwards to OpenAI with retries disabled; making it multi-provider is
-  a `handler.py` change (drop in `litellm.acompletion`), no client changes.
+  an `activities.py` change (drop in `litellm.acompletion`), no client changes.

--- a/examples/openai_nexus/agents.toml
+++ b/examples/openai_nexus/agents.toml
@@ -16,6 +16,6 @@ label = "OpenAI over Nexus"
 description = """
 A hello-world OpenAI Agents SDK agent whose LLM calls travel over Temporal Nexus (not
 HTTP). Chat in plain text; it replies in prose and can call one tool (get_weather). Each
-model call is dispatched from the workflow over a Nexus sync operation to a standalone
+model call is dispatched from the workflow over a Nexus operation to a standalone
 model router (nexus/model_router) that calls OpenAI. Non-streaming (Runner.run), so the
 UI shows the final reply plus tool_start / tool_end — but no live token stream."""

--- a/examples/openai_nexus/agents.toml
+++ b/examples/openai_nexus/agents.toml
@@ -1,0 +1,21 @@
+# Registry of agents the OpenAI-over-Nexus example UI can launch.
+#
+# The shared FastAPI server (examples/app.py) reads this file and passes the parsed
+# registry into the packaged SessionManagerWorkflow as its workflow init arg. The
+# manager then serves it back over the `available_agents` query, so the app server
+# can expose it at /api/agents without hardcoding the agent list.
+#
+# To expose a new agent: register its @workflow.defn on a worker, then add a
+# [[agents]] entry here.
+
+[[agents]]
+key = "openai-nexus"
+workflow_type = "OpenAINexusAgent"
+task_queue = "openai-nexus"
+label = "OpenAI over Nexus"
+description = """
+A hello-world OpenAI Agents SDK agent whose LLM calls travel over Temporal Nexus (not
+HTTP). Chat in plain text; it replies in prose and can call one tool (get_weather). Each
+model call is dispatched from the workflow over a Nexus sync operation to a standalone
+model router (nexus/model_router) that calls OpenAI. Non-streaming (Runner.run), so the
+UI shows the final reply plus tool_start / tool_end — but no live token stream."""

--- a/examples/openai_nexus/justfile
+++ b/examples/openai_nexus/justfile
@@ -1,0 +1,71 @@
+# Scoped justfile for the OpenAI-agent-over-Nexus example (examples/openai_nexus).
+# Run from this directory: `just <recipe>`.
+#
+# Self-contained local stack (each in its own terminal):
+#   just temporal          # 1. local Temporal dev server (or bring your own)
+#   just router            # 2. the model router (LLM API over Nexus) — see nexus/model_router
+#   just session-manager   # 3. packaged session-manager worker
+#   just server            # 4. FastAPI API + UI on :8000
+#   just worker            # 5. this example's agent worker
+#
+# Then open http://localhost:8000, pick "OpenAI over Nexus", and chat (e.g. "What's the weather
+# in Paris?"). The reply arrives when the turn completes (non-streaming), and the get_weather
+# tool call shows up via tool_start / tool_end. Every model call is made over Nexus to the router.
+# `just server` builds the Svelte UI first (needs `pnpm`); `just ui-dev` runs it on Vite instead.
+# OPENAI_API_KEY is needed by the ROUTER (`just router`), which calls OpenAI — not by this worker.
+#
+# uv installs the project's `examples` dependency group (incl. the OpenAI Agents SDK) on demand,
+# so there's no separate install step. First-time setup: `cp .env.example .env.local` from the
+# repo root and fill it in (Temporal connection + OPENAI_API_KEY). See README.md.
+
+# Read the single shared env file at the repo root (resolved relative to this justfile).
+set dotenv-path := "../../.env.local"
+set dotenv-load := true
+
+root := justfile_directory() / ".." / ".."
+ui := root / "ui"
+
+# List available recipes (bare `just`).
+default:
+    @just --list
+
+# Show the Temporal connection these recipes will use (read from the repo-root .env.local).
+config:
+    @echo "TEMPORAL_CONFIG_FILE = ${TEMPORAL_CONFIG_FILE:-<unset — set it in the repo-root .env.local>}"
+    @echo "TEMPORAL_PROFILE     = ${TEMPORAL_PROFILE:-default}"
+
+# Start a local Temporal dev server (Web UI: http://localhost:8233; needs the `temporal` CLI).
+temporal:
+    temporal server start-dev
+
+# Run the model router (the LLM API over Nexus). Creates the Nexus endpoint on startup.
+# Defined in nexus/model_router; this is a convenience alias.
+router:
+    cd "{{root}}" && uv run --group examples python -m nexus.model_router.worker
+
+# Run the shared session-manager worker (examples/session_manager_worker.py).
+session-manager:
+    cd "{{root}}" && uv run --group examples python -m examples.session_manager_worker
+
+# Serve the packaged FastAPI API + UI on http://localhost:8000, pointed at this example's registry
+# via the shared examples app entrypoint. Builds the Svelte UI first (app-build).
+server: app-build
+    cd "{{root}}" && uv run --group examples python -m examples.app "{{justfile_directory()}}/agents.toml" --host 0.0.0.0 --port 8000
+
+# Build the shared Svelte UI into temporal_agent_harness/ui/dist for the server to serve.
+# Runs FROM the ui dir (not `pnpm --dir`) so corepack reads ui/package.json's pinned pnpm
+# version instead of the repo root's (which has none) — avoids a corepack version mismatch.
+app-build:
+    cd "{{ui}}" && pnpm run build
+
+# Install the shared Svelte UI dependencies (run once if the build complains about missing modules).
+app-install:
+    cd "{{ui}}" && pnpm install
+
+# Run the shared Svelte UI on Vite for hot reloading. /api is proxied to the FastAPI server on :8000.
+ui-dev:
+    cd "{{ui}}" && pnpm run dev
+
+# Run the OpenAINexusAgent worker. Routes model calls over Nexus to the router (run `just router`).
+worker:
+    cd "{{root}}" && uv run --group examples python -m examples.openai_nexus.worker

--- a/examples/openai_nexus/nexus_transport.py
+++ b/examples/openai_nexus/nexus_transport.py
@@ -18,6 +18,7 @@ and the router owns the wire types.
 from __future__ import annotations
 
 from datetime import timedelta
+from types import SimpleNamespace
 from typing import Any
 
 from openai import NotGiven, Omit
@@ -28,14 +29,12 @@ with workflow.unsafe.imports_passed_through():
     from agents import Model, OpenAIChatCompletionsModel
     from openai.types.chat import ChatCompletion
 
-    from nexus.model_router import (
-        NEXUS_ENDPOINT,
-        ChatCompletionRequest,
-        ModelRouterService,
-    )
+    from nexus.model_router.models import ChatCompletionRequest
+    from nexus.model_router.service import NEXUS_ENDPOINT, ModelRouterService
 
-# Bounds the Nexus operation (a single model call).
-_OP_TIMEOUT = timedelta(minutes=2)
+# Bounds the whole Nexus operation (a model call, run as a router workflow +
+# activity with retries) — generous, since model calls can be slow.
+_OP_TIMEOUT = timedelta(minutes=5)
 
 # Keys the OpenAI SDK sets on the create call that are client/transport-only or
 # streaming — they don't belong on the router wire.
@@ -83,17 +82,14 @@ class NexusChatClient:
     base_url = "nexus://model-router"
 
     def __init__(self) -> None:
-        self.chat = _NexusChat()
-
-
-class _NexusChat:
-    def __init__(self) -> None:
-        self.completions = NexusChatCompletions()
+        self.chat = SimpleNamespace(completions=NexusChatCompletions())
 
 
 def nexus_model_provider(model_name: str | None) -> Model:
     """Resolve a workflow-side Model whose transport is the router Nexus service."""
+    if model_name is None:
+        raise ValueError("nexus_model_provider requires a model name")
     return OpenAIChatCompletionsModel(
-        model=model_name or "gpt-4.1-mini",
+        model=model_name,
         openai_client=NexusChatClient(),  # type: ignore[arg-type]
     )

--- a/examples/openai_nexus/nexus_transport.py
+++ b/examples/openai_nexus/nexus_transport.py
@@ -32,9 +32,10 @@ with workflow.unsafe.imports_passed_through():
     from nexus.model_router.models import ChatCompletionRequest
     from nexus.model_router.service import NEXUS_ENDPOINT, ModelRouterService
 
-# Bounds the whole Nexus operation (a model call, run as a router workflow +
-# activity with retries) — generous, since model calls can be slow.
-_OP_TIMEOUT = timedelta(minutes=5)
+# Bounds the whole Nexus operation. Set above the router's own total budget
+# (its activity schedule_to_close is 5m, incl. retries) so the operation doesn't
+# time out mid-retry — the router's timeouts are the real cap.
+_OP_TIMEOUT = timedelta(minutes=6)
 
 # Keys the OpenAI SDK sets on the create call that are client/transport-only or
 # streaming — they don't belong on the router wire.

--- a/examples/openai_nexus/nexus_transport.py
+++ b/examples/openai_nexus/nexus_transport.py
@@ -1,0 +1,99 @@
+"""Bridge: run the agent's model over the model-router Nexus service.
+
+This is the whole "transport swap". The OpenAI Agents SDK's
+``OpenAIChatCompletionsModel`` already turns a model call into a chat-completions
+request and turns the response back into a ``ModelResponse`` — the only thing it
+does over the network is ``client.chat.completions.create(...)``. So we hand it a
+stand-in client whose ``create`` goes over Nexus to ``ModelRouterService`` instead
+of HTTP to OpenAI.
+
+``nexus_model_provider`` is wired onto the plugin as
+``ModelActivityParameters.workflow_model_provider``. The stub calls it in workflow
+context, so the ``create_nexus_client`` call inside ``NexusChatCompletions.create``
+is valid. No serialization, no tool reconstruction, no bespoke translation: the
+SDK produces/consumes the (LiteLLM/OpenRouter-shaped) chat-completions payload,
+and the router owns the wire types.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from openai import NotGiven, Omit
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from agents import Model, OpenAIChatCompletionsModel
+    from openai.types.chat import ChatCompletion
+
+    from nexus.model_router import (
+        NEXUS_ENDPOINT,
+        ChatCompletionRequest,
+        ModelRouterService,
+    )
+
+# Bounds the Nexus operation (a single model call).
+_OP_TIMEOUT = timedelta(minutes=2)
+
+# Keys the OpenAI SDK sets on the create call that are client/transport-only or
+# streaming — they don't belong on the router wire.
+_DROP_KEYS = frozenset(
+    {"extra_headers", "extra_query", "extra_body", "stream", "stream_options"}
+)
+
+
+def _is_unset(value: Any) -> bool:
+    # The OpenAI SDK fills unspecified params with `omit` / NOT_GIVEN sentinels.
+    return value is None or isinstance(value, (Omit, NotGiven))
+
+
+class NexusChatCompletions:
+    """``client.chat.completions`` stand-in: one async ``create`` over Nexus."""
+
+    async def create(self, **kwargs: Any) -> ChatCompletion:
+        clean = {
+            k: v
+            for k, v in kwargs.items()
+            if k not in _DROP_KEYS and not _is_unset(v)
+        }
+        model = clean.pop("model")
+        messages = clean.pop("messages")
+        request = ChatCompletionRequest(model=model, messages=messages, params=clean)
+
+        nexus_client = workflow.create_nexus_client(
+            service=ModelRouterService, endpoint=NEXUS_ENDPOINT
+        )
+        return await nexus_client.execute_operation(
+            ModelRouterService.chat_completion,
+            request,
+            schedule_to_close_timeout=_OP_TIMEOUT,
+        )
+
+
+class NexusChatClient:
+    """Minimal ``AsyncOpenAI`` stand-in for ``OpenAIChatCompletionsModel``.
+
+    The SDK only calls ``.chat.completions.create(...)`` and reads ``.base_url``
+    (to detect the official OpenAI endpoint — a ``nexus://`` URL reads as "not
+    official", which is what we want). Nothing else is touched.
+    """
+
+    base_url = "nexus://model-router"
+
+    def __init__(self) -> None:
+        self.chat = _NexusChat()
+
+
+class _NexusChat:
+    def __init__(self) -> None:
+        self.completions = NexusChatCompletions()
+
+
+def nexus_model_provider(model_name: str | None) -> Model:
+    """Resolve a workflow-side Model whose transport is the router Nexus service."""
+    return OpenAIChatCompletionsModel(
+        model=model_name or "gpt-4.1-mini",
+        openai_client=NexusChatClient(),  # type: ignore[arg-type]
+    )

--- a/examples/openai_nexus/worker.py
+++ b/examples/openai_nexus/worker.py
@@ -4,20 +4,16 @@ Run from the repo root with:
     uv run --group examples python -m examples.openai_nexus.worker
 
 The sibling of ``examples/openai_hello``'s worker, with one change: model calls
-are routed over Nexus to the standalone model router
-(``nexus/model_router``) instead of running as the ``invoke_model_activity``
-activity. That routing is wired here via the plugin's workflow-side seam:
+are routed over Nexus to the standalone model router (``nexus/model_router``)
+instead of running as the ``invoke_model_activity`` activity. That routing is
+wired here via the plugin's workflow-side seam:
 
     ModelActivityParameters(workflow_model_provider=nexus_model_provider)
 
-``nexus_model_provider`` (see ``nexus_transport.py``) hands the SDK an
-``OpenAIChatCompletionsModel`` whose transport is a Nexus call. The router worker
-must be running too (``uv run --group examples python -m nexus.model_router.worker``,
-or ``just router`` in ``nexus/model_router``); it owns and creates the endpoint.
-
-Unlike ``openai_hello``, there is NO streaming seam (no ``stream_to_provider`` /
-``observer_factory``): the router path is non-streaming, so the agent uses
-``Runner.run``. The UI still shows the final reply and tool lifecycle events.
+See ``nexus_transport.py`` for how that provider swaps the transport. The router
+worker must be running too (``just router`` in ``nexus/model_router``); it owns
+and creates the endpoint. There is no streaming seam — the router path is
+non-streaming, so the agent uses ``Runner.run``.
 
 Env vars (set in .env.local — see .env.example):
     TEMPORAL_CONFIG_FILE / TEMPORAL_PROFILE   Temporal connection profile

--- a/examples/openai_nexus/worker.py
+++ b/examples/openai_nexus/worker.py
@@ -61,7 +61,13 @@ async def main() -> None:
     )
 
     # The plugin supplies its own (OpenAI-aware, pydantic-compatible) data converter.
+    # Use the configured Temporal profile if any, else default to a local dev
+    # server (matching the router worker) so `just worker` runs with zero config.
     connect_config = ClientConfig.load_client_connect_config()
+    if not connect_config.get("target_host"):
+        connect_config["target_host"] = os.environ.get("TEMPORAL_ADDRESS", "localhost:7233")
+    if not connect_config.get("namespace"):
+        connect_config["namespace"] = os.environ.get("TEMPORAL_NAMESPACE", "default")
     client = await Client.connect(**connect_config, plugins=[plugin])
 
     worker = Worker(

--- a/examples/openai_nexus/worker.py
+++ b/examples/openai_nexus/worker.py
@@ -1,0 +1,91 @@
+"""Worker for the OpenAI-agent-over-Nexus example.
+
+Run from the repo root with:
+    uv run --group examples python -m examples.openai_nexus.worker
+
+The sibling of ``examples/openai_hello``'s worker, with one change: model calls
+are routed over Nexus to the standalone model router
+(``nexus/model_router``) instead of running as the ``invoke_model_activity``
+activity. That routing is wired here via the plugin's workflow-side seam:
+
+    ModelActivityParameters(workflow_model_provider=nexus_model_provider)
+
+``nexus_model_provider`` (see ``nexus_transport.py``) hands the SDK an
+``OpenAIChatCompletionsModel`` whose transport is a Nexus call. The router worker
+must be running too (``uv run --group examples python -m nexus.model_router.worker``,
+or ``just router`` in ``nexus/model_router``); it owns and creates the endpoint.
+
+Unlike ``openai_hello``, there is NO streaming seam (no ``stream_to_provider`` /
+``observer_factory``): the router path is non-streaming, so the agent uses
+``Runner.run``. The UI still shows the final reply and tool lifecycle events.
+
+Env vars (set in .env.local — see .env.example):
+    TEMPORAL_CONFIG_FILE / TEMPORAL_PROFILE   Temporal connection profile
+    OPENAI_NEXUS_TASK_QUEUE                   agent task queue to poll (default: openai-nexus)
+
+Note: OPENAI_API_KEY is needed by the ROUTER worker (which calls OpenAI), not by
+this agent worker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from temporalio.client import Client
+from temporalio.envconfig import ClientConfig
+from temporalio.worker import Worker
+
+from temporal_agent_harness.ai_sdks.openai_agents import (
+    ModelActivityParameters,
+    OpenAIAgentsPlugin,
+)
+
+from .nexus_transport import nexus_model_provider
+from .workflow import TASK_QUEUE, OpenAINexusAgentWorkflow
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        force=True,
+    )
+
+    task_queue = os.environ.get("OPENAI_NEXUS_TASK_QUEUE", TASK_QUEUE)
+
+    plugin = OpenAIAgentsPlugin(
+        model_params=ModelActivityParameters(
+            # THE seam: resolve the model in workflow context and call it directly.
+            # nexus_model_provider gives it a Nexus transport (→ the model router),
+            # so no invoke_model_activity is used on this path.
+            workflow_model_provider=nexus_model_provider,
+        ),
+    )
+
+    # The plugin supplies its own (OpenAI-aware, pydantic-compatible) data converter.
+    connect_config = ClientConfig.load_client_connect_config()
+    client = await Client.connect(**connect_config, plugins=[plugin])
+
+    worker = Worker(
+        client,
+        task_queue=task_queue,
+        workflows=[OpenAINexusAgentWorkflow],
+        # No tool activities: get_weather is an inline workflow tool. No model
+        # activities are used either — model calls go over Nexus to the router.
+        activities=[],
+    )
+    print(
+        f"OpenAI-over-Nexus agent worker ready: "
+        f"profile={os.environ.get('TEMPORAL_PROFILE', 'default')!r} "
+        f"address={connect_config.get('target_host')} "
+        f"namespace={connect_config.get('namespace')} "
+        f"taskQueue={task_queue}",
+        flush=True,
+    )
+    await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/openai_nexus/workflow.py
+++ b/examples/openai_nexus/workflow.py
@@ -3,9 +3,8 @@
 This is the sibling of ``examples/openai_hello`` — same harness shape (one ``ask``
 handler, one ``get_weather`` tool) so it plugs into the shared web UI the same
 way — but with one difference that is the whole point: the LLM call does not go
-to the provider from a Temporal activity. It goes over a Nexus **sync
-operation** to a standalone model router (``nexus/model_router``), which is what
-calls OpenAI.
+to the provider from a Temporal activity. It goes over a Nexus operation to a
+standalone model router (``nexus/model_router``), which is what calls OpenAI.
 
 Why this needs the plugin's workflow-side seam rather than a plain custom model
 provider: in the Temporal integration the model call runs inside an activity,

--- a/examples/openai_nexus/workflow.py
+++ b/examples/openai_nexus/workflow.py
@@ -1,0 +1,112 @@
+"""A hello-world OpenAI Agents SDK agent whose model calls travel over Nexus.
+
+This is the sibling of ``examples/openai_hello`` — same harness shape (one ``ask``
+handler, one ``get_weather`` tool) so it plugs into the shared web UI the same
+way — but with one difference that is the whole point: the LLM call does not go
+to the provider from a Temporal activity. It goes over a Nexus **sync
+operation** to a standalone model router (``nexus/model_router``), which is what
+calls OpenAI.
+
+Why this needs the plugin's workflow-side seam rather than a plain custom model
+provider: in the Temporal integration the model call runs inside an activity,
+but ``workflow.create_nexus_client`` only works in workflow context. So the model
+is resolved and called from the model stub (which does run in the workflow) via
+``ModelActivityParameters.workflow_model_provider`` — wired in ``worker.py`` to a
+model whose transport is the router Nexus service (see ``nexus_transport.py``).
+
+Streaming is intentionally out of scope, so this uses ``Runner.run`` (blocking),
+not ``Runner.run_streamed``. That means there is no live token/model-interaction
+stream (the streaming observer only runs on the activity streaming path); the
+harness still delivers the final reply and — because ``get_weather`` is adapted
+with ``as_openai_agent_tool`` — the ``tool_start`` / ``tool_end`` lifecycle to the
+UI. Drive it with the shared example stack; it is registered in ``agents.toml``.
+"""
+
+from __future__ import annotations
+
+from temporalio import workflow
+from temporalio.contrib.workflow_streams import WorkflowStream
+
+with workflow.unsafe.imports_passed_through():
+    from agents import Agent as OpenAIAgent
+    from agents import Runner, TResponseInputItem
+
+    from temporal_agent_harness.ai_sdks.openai_agents_harness import as_openai_agent_tool
+    from temporal_agent_harness.harness import agent
+    from temporal_agent_harness.harness.agent_protocol import (
+        AgentConfig,
+        TextMessage,
+        TextReply,
+        ToolApprovalPolicy,
+    )
+    from temporal_agent_harness.harness.agent_workflow import AgentWorkflowRunner
+
+
+# The agent workflow's own task queue. The model transport (Nexus → the model
+# router) is wired on the worker, so this workflow stays transport-agnostic.
+TASK_QUEUE = "openai-nexus"
+DEFAULT_MODEL = "gpt-4.1-mini"
+
+SYSTEM_INSTRUCTION = """\
+You are a friendly assistant. Answer the user in brief, natural prose.
+
+You have one tool, `get_weather`, which returns the current weather for a city. When the user
+asks about the weather somewhere, call it (don't guess), then tell them the answer in a sentence
+or two. For anything else, just reply directly."""
+
+
+@agent.tool_defn(inherently_safe=True)
+async def get_weather(city: str) -> str:
+    """Return the current weather for a city. `city` is a plain city name, e.g. "Paris"."""
+    # Canned lookup — this is a hello-world, no real weather service — but a genuine harness
+    # tool call: adapted onto the SDK with as_openai_agent_tool, it flows through run_tool and
+    # shows up on the turn stream as tool_start -> tool_end.
+    return f"It's 72°F and sunny in {city}."
+
+
+@workflow.defn(name="OpenAINexusAgent")
+@agent.defn
+class OpenAINexusAgentWorkflow:
+    """A one-tool conversational agent whose model calls are made over Nexus."""
+
+    @workflow.init
+    def __init__(self, config: AgentConfig) -> None:
+        self._runner = AgentWorkflowRunner(
+            config,
+            stream=WorkflowStream(),
+            # Hello-world stance: don't gate tool calls. `get_weather` is a read-only lookup;
+            # a caller can still tighten this per session via AgentConfig.approval_policy.
+            approval_policy_default=ToolApprovalPolicy.dangerously_skip_all(),
+        )
+        # OpenAI conversation state, threaded across turns as the SDK's input-item list.
+        self._conversation: list[TResponseInputItem] = []
+
+    @workflow.run
+    async def run(self, _config: AgentConfig) -> None:
+        await self._runner.run(self)
+
+    @agent.accepts
+    async def ask(self, message: TextMessage) -> TextReply:
+        """Chat with the assistant. Ask it anything; ask about the weather in a city and it
+        calls its `get_weather` tool and tells you what it found — with every model call routed
+        over Nexus to the LLM service."""
+        sdk_agent = OpenAIAgent(
+            name="NexusHello",
+            instructions=SYSTEM_INSTRUCTION,
+            model=DEFAULT_MODEL,
+            tools=[as_openai_agent_tool(self._runner, get_weather)],
+        )
+        input_items: list[TResponseInputItem] = [
+            *self._conversation,
+            {"role": "user", "content": message.text},
+        ]
+
+        # Runner.run (NOT run_streamed): the Nexus model path is non-streaming. Each
+        # model.get_response the SDK makes is dispatched from the model stub over Nexus to
+        # the model router's chat_completion op (see worker.py / nexus_transport.py) instead
+        # of running as an activity. A weather question is typically two such calls: the model
+        # asks for the tool, the tool runs in the workflow, then a second Nexus call answers.
+        result = await Runner.run(sdk_agent, input=input_items)
+
+        self._conversation = result.to_input_list()
+        return TextReply(text=str(result.final_output))

--- a/nexus/model_router/README.md
+++ b/nexus/model_router/README.md
@@ -30,8 +30,10 @@ class ModelRouterService:
 |---|---|
 | `models.py` | `ChatCompletionRequest` — the router's own request model. |
 | `service.py` | `ModelRouterService` contract + `NEXUS_ENDPOINT` / `TASK_QUEUE`. Light, import-safe in workflow context. |
-| `handler.py` | `ModelRouterServiceHandler` — forwards to OpenAI. The seam for LiteLLM / multi-provider routing. |
-| `worker.py` | Standalone worker; creates the Nexus endpoint and serves the handler. |
+| `handler.py` | `ModelRouterServiceHandler` — the async, workflow-backed operation; starts `ModelRouterWorkflow` per call. |
+| `workflow.py` | `ModelRouterWorkflow` — backs the operation so it isn't time-capped; runs the model call as an activity. |
+| `activities.py` | `ModelRouterActivities.invoke_chat_completion` — the actual provider call. The seam for LiteLLM / multi-provider routing. |
+| `worker.py` | Standalone worker; serves the handler + workflow + activity and creates the Nexus endpoint. |
 
 ## Run
 
@@ -60,7 +62,10 @@ to build its Nexus client.
 
 ## Limitations (prototype)
 
-- Non-streaming only (`chat_completion` is a sync operation).
+- `chat_completion` is an asynchronous, **workflow-backed** operation (a Nexus
+  *sync* operation caps at ~10s, which model calls exceed): each call starts a
+  `ModelRouterWorkflow` that runs the provider call as a retryable activity. Still
+  non-streaming (one request → one response).
 - Always routes to OpenAI; `handler.py` is where provider selection / LiteLLM
   would go.
 - Uses `temporalio.contrib.pydantic.pydantic_data_converter`, compatible with the

--- a/nexus/model_router/README.md
+++ b/nexus/model_router/README.md
@@ -1,0 +1,67 @@
+# Model router (LLM API over Nexus)
+
+A **prototype** model router exposed as a Temporal Nexus service. Callers send a
+chat-completion request over Nexus; the router calls a model provider and returns
+the response. Today it forwards every request to OpenAI; the design point is that
+this is the single place a real router would select a backend from the requested
+model and fan out to many providers (e.g. via LiteLLM).
+
+Standalone: nothing here depends on the OpenAI Agents plugin. Its wire format is
+the OpenAI **Chat Completions** shape — the de-facto standard LiteLLM and
+OpenRouter also use — so any chat-completions-shaped caller can use it.
+
+## Contract
+
+```python
+@nexusrpc.service
+class ModelRouterService:
+    chat_completion: nexusrpc.Operation[ChatCompletionRequest, ChatCompletion]
+```
+
+- `ChatCompletionRequest` (`models.py`) — the router's own request: `model`,
+  `messages`, and a `params` dict carrying the rest (`tools`, `tool_choice`,
+  `temperature`, …) in OpenAI/LiteLLM shape.
+- `ChatCompletion` — reused verbatim from the OpenAI SDK (that's exactly what a
+  chat-completions call returns, so there's nothing to translate).
+
+## Files
+
+| File | Role |
+|---|---|
+| `models.py` | `ChatCompletionRequest` — the router's own request model. |
+| `service.py` | `ModelRouterService` contract + `NEXUS_ENDPOINT` / `TASK_QUEUE`. Light, import-safe in workflow context. |
+| `handler.py` | `ModelRouterServiceHandler` — forwards to OpenAI. The seam for LiteLLM / multi-provider routing. |
+| `worker.py` | Standalone worker; creates the Nexus endpoint and serves the handler. |
+
+## Run
+
+```sh
+# from the repo root (needs a Temporal server + OPENAI_API_KEY):
+uv run --group examples python -m nexus.model_router.worker
+# or, from this dir:
+just router
+```
+
+It creates the endpoint on startup (idempotent). Equivalent CLI:
+
+```sh
+temporal operator nexus endpoint create \
+  --name model-router-endpoint \
+  --target-namespace default \
+  --target-task-queue model-router
+```
+
+## Who calls it
+
+[`examples/openai_nexus`](../../examples/openai_nexus) — an OpenAI Agents SDK
+agent whose model calls are routed here over Nexus. That example imports only the
+light contract (`ModelRouterService` / `ChatCompletionRequest` / `NEXUS_ENDPOINT`)
+to build its Nexus client.
+
+## Limitations (prototype)
+
+- Non-streaming only (`chat_completion` is a sync operation).
+- Always routes to OpenAI; `handler.py` is where provider selection / LiteLLM
+  would go.
+- Uses `temporalio.contrib.pydantic.pydantic_data_converter`, compatible with the
+  OpenAI Agents plugin's converter on the caller side.

--- a/nexus/model_router/__init__.py
+++ b/nexus/model_router/__init__.py
@@ -1,16 +1,7 @@
-"""A model router exposed over Temporal Nexus.
+"""A model router exposed over Temporal Nexus (Chat Completions / LiteLLM shape).
 
-Speaks the OpenAI Chat Completions / LiteLLM / OpenRouter shape; today forwards
-to OpenAI, later routes to any provider. Standalone: nothing here depends on the
-OpenAI Agents plugin.
-
-Import from the submodules, not this package, on purpose: ``service`` (and thus
-``handler``) pulls in the OpenAI SDK for the ``ChatCompletion`` wire type, and this
-package's ``workflow`` module is loaded inside a Temporal workflow sandbox. Keeping
-``__init__`` import-light means loading the workflow doesn't drag ``openai`` through
-the sandbox unguarded. So:
-
-* callers of the contract:  ``from nexus.model_router.service import ModelRouterService, NEXUS_ENDPOINT``
-                            ``from nexus.model_router.models import ChatCompletionRequest``
-* the worker:               ``from nexus.model_router.worker`` (registers everything)
+Standalone — nothing here depends on the OpenAI Agents plugin. Import from the
+submodules, not this package: ``service`` pulls in the OpenAI SDK, and keeping
+``__init__`` empty means loading the ``workflow`` submodule inside a Temporal
+workflow sandbox doesn't drag ``openai`` in unguarded.
 """

--- a/nexus/model_router/__init__.py
+++ b/nexus/model_router/__init__.py
@@ -4,21 +4,13 @@ Speaks the OpenAI Chat Completions / LiteLLM / OpenRouter shape; today forwards
 to OpenAI, later routes to any provider. Standalone: nothing here depends on the
 OpenAI Agents plugin.
 
-Import the light contract (``ModelRouterService`` / ``ChatCompletionRequest`` /
-``NEXUS_ENDPOINT``) from callers — including in workflow context — to build a
-Nexus client. The handler (``ModelRouterServiceHandler``) and worker are
-server-side only; import them from their submodules to avoid pulling an OpenAI
-client into a workflow sandbox.
+Import from the submodules, not this package, on purpose: ``service`` (and thus
+``handler``) pulls in the OpenAI SDK for the ``ChatCompletion`` wire type, and this
+package's ``workflow`` module is loaded inside a Temporal workflow sandbox. Keeping
+``__init__`` import-light means loading the workflow doesn't drag ``openai`` through
+the sandbox unguarded. So:
+
+* callers of the contract:  ``from nexus.model_router.service import ModelRouterService, NEXUS_ENDPOINT``
+                            ``from nexus.model_router.models import ChatCompletionRequest``
+* the worker:               ``from nexus.model_router.worker`` (registers everything)
 """
-
-from __future__ import annotations
-
-from .models import ChatCompletionRequest
-from .service import NEXUS_ENDPOINT, TASK_QUEUE, ModelRouterService
-
-__all__ = [
-    "ChatCompletionRequest",
-    "ModelRouterService",
-    "NEXUS_ENDPOINT",
-    "TASK_QUEUE",
-]

--- a/nexus/model_router/__init__.py
+++ b/nexus/model_router/__init__.py
@@ -1,0 +1,24 @@
+"""A model router exposed over Temporal Nexus.
+
+Speaks the OpenAI Chat Completions / LiteLLM / OpenRouter shape; today forwards
+to OpenAI, later routes to any provider. Standalone: nothing here depends on the
+OpenAI Agents plugin.
+
+Import the light contract (``ModelRouterService`` / ``ChatCompletionRequest`` /
+``NEXUS_ENDPOINT``) from callers — including in workflow context — to build a
+Nexus client. The handler (``ModelRouterServiceHandler``) and worker are
+server-side only; import them from their submodules to avoid pulling an OpenAI
+client into a workflow sandbox.
+"""
+
+from __future__ import annotations
+
+from .models import ChatCompletionRequest
+from .service import NEXUS_ENDPOINT, TASK_QUEUE, ModelRouterService
+
+__all__ = [
+    "ChatCompletionRequest",
+    "ModelRouterService",
+    "NEXUS_ENDPOINT",
+    "TASK_QUEUE",
+]

--- a/nexus/model_router/activities.py
+++ b/nexus/model_router/activities.py
@@ -12,12 +12,52 @@ operation is workflow-backed rather than synchronous.
 
 from __future__ import annotations
 
-from openai import AsyncOpenAI
+from datetime import timedelta
+from typing import NoReturn
+
+from openai import APIStatusError, AsyncOpenAI
 from openai.types.chat import ChatCompletion
 
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from .models import ChatCompletionRequest
+
+
+def _raise_for_openai_status(e: APIStatusError) -> NoReturn:
+    """Translate an OpenAI APIStatusError into the right Temporal retry posture.
+
+    The client runs with ``max_retries=0`` (below), so retries are governed by
+    the activity's retry policy — which retries every exception by default. That
+    is wrong for permanent errors (400 bad request, 401 auth, most 4xx): they
+    would be retried identically to no effect. Mark those non-retryable, honoring
+    OpenAI's ``x-should-retry`` and ``retry-after`` hints. (Same classification
+    the OpenAI Agents plugin applies on its activity path.)
+    """
+    retry_after: timedelta | None = None
+    retry_after_ms = e.response.headers.get("retry-after-ms")
+    if retry_after_ms is not None:
+        retry_after = timedelta(milliseconds=float(retry_after_ms))
+    elif (retry_after_s := e.response.headers.get("retry-after")) is not None:
+        retry_after = timedelta(seconds=float(retry_after_s))
+
+    should_retry = e.response.headers.get("x-should-retry")
+    if should_retry == "true":
+        raise e  # retryable per OpenAI; let the activity retry policy handle it
+    if should_retry == "false":
+        raise ApplicationError(
+            "Non retryable OpenAI error", non_retryable=True, next_retry_delay=retry_after
+        ) from e
+
+    # Retry 408 (timeout), 409 (conflict), 429 (rate limit), and any 5xx; every
+    # other 4xx is a caller error that won't recover on retry.
+    retryable = e.response.status_code in (408, 409, 429) or e.response.status_code >= 500
+    raise ApplicationError(
+        f"{'Retryable' if retryable else 'Non retryable'} OpenAI status "
+        f"{e.response.status_code}",
+        non_retryable=not retryable,
+        next_retry_delay=retry_after,
+    ) from e
 
 
 class ModelRouterActivities:
@@ -32,8 +72,11 @@ class ModelRouterActivities:
         self, request: ChatCompletionRequest
     ) -> ChatCompletion:
         # TODO(router): pick a backend from request.model instead of always OpenAI.
-        return await self._client.chat.completions.create(
-            model=request.model,
-            messages=request.messages,
-            **request.params,
-        )
+        try:
+            return await self._client.chat.completions.create(
+                model=request.model,
+                messages=request.messages,
+                **request.params,
+            )
+        except APIStatusError as e:
+            _raise_for_openai_status(e)

--- a/nexus/model_router/activities.py
+++ b/nexus/model_router/activities.py
@@ -1,0 +1,39 @@
+"""The activity that actually calls a model provider.
+
+Runs on the router worker (normal activity context — real I/O is fine). This is
+where provider selection would live: today it always calls OpenAI's
+chat-completions endpoint; a multi-provider router would pick a backend from
+``request.model`` (e.g. via ``litellm.acompletion(...)``) here.
+
+It lives in an activity (not inline in the Nexus operation) because model calls
+are slow and unbounded — see ``workflow.py`` / ``handler.py`` for why the router
+operation is workflow-backed rather than synchronous.
+"""
+
+from __future__ import annotations
+
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
+
+from temporalio import activity
+
+from .models import ChatCompletionRequest
+
+
+class ModelRouterActivities:
+    """Holds the reusable model client. Defaults to OpenAI with retries disabled
+    (so Temporal activity retries govern retry behavior)."""
+
+    def __init__(self, client: AsyncOpenAI | None = None) -> None:
+        self._client = client or AsyncOpenAI(max_retries=0)
+
+    @activity.defn
+    async def invoke_chat_completion(
+        self, request: ChatCompletionRequest
+    ) -> ChatCompletion:
+        # TODO(router): pick a backend from request.model instead of always OpenAI.
+        return await self._client.chat.completions.create(
+            model=request.model,
+            messages=request.messages,
+            **request.params,
+        )

--- a/nexus/model_router/handler.py
+++ b/nexus/model_router/handler.py
@@ -1,12 +1,9 @@
 """The model router Nexus handler.
 
-``chat_completion`` is an **asynchronous, workflow-backed** Nexus operation, not a
-sync one: it starts a :class:`ModelRouterWorkflow` and returns its handle, so the
-operation completes when that workflow completes. This is required because model
-calls routinely take longer than the ~10s a Nexus sync operation allows (a sync
-operation resolves inline in the StartOperation RPC). The workflow runs the actual
-provider call as an activity (see ``activities.py``), making the whole thing
-durable and retryable.
+``chat_completion`` is an **asynchronous, workflow-backed** operation: it starts a
+:class:`ModelRouterWorkflow` and returns its handle, so the operation completes
+when that workflow does. See ``workflow.py`` for why it's workflow-backed rather
+than a (time-capped) sync operation.
 """
 
 from __future__ import annotations

--- a/nexus/model_router/handler.py
+++ b/nexus/model_router/handler.py
@@ -1,47 +1,42 @@
 """The model router Nexus handler.
 
-Runs in a normal worker (no workflow sandbox), so it can do real I/O freely. It
-receives a chat-completions request and returns the model's response.
-
-Today it routes every request straight to OpenAI's chat-completions endpoint.
-This is exactly the seam where a real router would select a backend from
-``request.model`` and fan out to many providers — e.g. by calling
-``litellm.acompletion(...)`` here instead of the OpenAI client. Because this runs
-server-side (not in a workflow), a heavy multi-provider library like LiteLLM
-belongs here, not on the caller.
+``chat_completion`` is an **asynchronous, workflow-backed** Nexus operation, not a
+sync one: it starts a :class:`ModelRouterWorkflow` and returns its handle, so the
+operation completes when that workflow completes. This is required because model
+calls routinely take longer than the ~10s a Nexus sync operation allows (a sync
+operation resolves inline in the StartOperation RPC). The workflow runs the actual
+provider call as an activity (see ``activities.py``), making the whole thing
+durable and retryable.
 """
 
 from __future__ import annotations
 
+import uuid
+
 import nexusrpc.handler
-from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion
+
+from temporalio import nexus
 
 from .models import ChatCompletionRequest
 from .service import ModelRouterService
+from .workflow import ModelRouterWorkflow
 
 
 @nexusrpc.handler.service_handler(service=ModelRouterService)
 class ModelRouterServiceHandler:
-    """Routes chat-completion requests to a provider. Today: always OpenAI.
+    """Serves ``chat_completion`` by starting a router workflow per call."""
 
-    Defaults to an ``AsyncOpenAI`` client with retries disabled (so Temporal /
-    Nexus retries govern retry behavior); pass a client to point elsewhere.
-    """
-
-    def __init__(self, client: AsyncOpenAI | None = None) -> None:
-        self._client = client or AsyncOpenAI(max_retries=0)
-
-    @nexusrpc.handler.sync_operation
+    @nexus.workflow_run_operation
     async def chat_completion(
         self,
-        ctx: nexusrpc.handler.StartOperationContext,  # noqa: ARG002
+        ctx: nexus.WorkflowRunOperationContext,
         request: ChatCompletionRequest,
-    ) -> ChatCompletion:
-        # TODO(router): pick a backend from request.model instead of always OpenAI.
-        # A multi-provider router would call litellm.acompletion(...) here.
-        return await self._client.chat.completions.create(
-            model=request.model,
-            messages=request.messages,
-            **request.params,
+    ) -> nexus.WorkflowHandle[ChatCompletion]:
+        # The workflow runs on this handler worker's task queue by default — the
+        # same worker that registers ModelRouterWorkflow (see worker.py).
+        return await ctx.start_workflow(
+            ModelRouterWorkflow.run,
+            request,
+            id=f"model-router-{uuid.uuid4()}",
         )

--- a/nexus/model_router/handler.py
+++ b/nexus/model_router/handler.py
@@ -1,0 +1,47 @@
+"""The model router Nexus handler.
+
+Runs in a normal worker (no workflow sandbox), so it can do real I/O freely. It
+receives a chat-completions request and returns the model's response.
+
+Today it routes every request straight to OpenAI's chat-completions endpoint.
+This is exactly the seam where a real router would select a backend from
+``request.model`` and fan out to many providers — e.g. by calling
+``litellm.acompletion(...)`` here instead of the OpenAI client. Because this runs
+server-side (not in a workflow), a heavy multi-provider library like LiteLLM
+belongs here, not on the caller.
+"""
+
+from __future__ import annotations
+
+import nexusrpc.handler
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
+
+from .models import ChatCompletionRequest
+from .service import ModelRouterService
+
+
+@nexusrpc.handler.service_handler(service=ModelRouterService)
+class ModelRouterServiceHandler:
+    """Routes chat-completion requests to a provider. Today: always OpenAI.
+
+    Defaults to an ``AsyncOpenAI`` client with retries disabled (so Temporal /
+    Nexus retries govern retry behavior); pass a client to point elsewhere.
+    """
+
+    def __init__(self, client: AsyncOpenAI | None = None) -> None:
+        self._client = client or AsyncOpenAI(max_retries=0)
+
+    @nexusrpc.handler.sync_operation
+    async def chat_completion(
+        self,
+        ctx: nexusrpc.handler.StartOperationContext,  # noqa: ARG002
+        request: ChatCompletionRequest,
+    ) -> ChatCompletion:
+        # TODO(router): pick a backend from request.model instead of always OpenAI.
+        # A multi-provider router would call litellm.acompletion(...) here.
+        return await self._client.chat.completions.create(
+            model=request.model,
+            messages=request.messages,
+            **request.params,
+        )

--- a/nexus/model_router/justfile
+++ b/nexus/model_router/justfile
@@ -1,0 +1,21 @@
+# Scoped justfile for the model router Nexus service (nexus/model_router).
+# Run from this directory: `just <recipe>`.
+#
+#   just router   # run the router worker (creates the Nexus endpoint on startup)
+#
+# Needs a Temporal server reachable via the repo-root .env.local profile (or
+# localhost:7233) and OPENAI_API_KEY. The router is the "LLM API over Nexus" that
+# the examples/openai_nexus agent calls.
+
+set dotenv-path := "../../.env.local"
+set dotenv-load := true
+
+root := justfile_directory() / ".." / ".."
+
+# List available recipes (bare `just`).
+default:
+    @just --list
+
+# Run the model router worker (registers the handler + creates the Nexus endpoint).
+router:
+    cd "{{root}}" && uv run --group examples python -m nexus.model_router.worker

--- a/nexus/model_router/models.py
+++ b/nexus/model_router/models.py
@@ -1,14 +1,7 @@
-"""The model router's own wire models.
+"""The router's own request model (Chat Completions / LiteLLM / OpenRouter shape).
 
-The router speaks the OpenAI **Chat Completions** shape — the de-facto standard
-that LiteLLM and OpenRouter also use — so any client that can produce a
-chat-completions request can call it, and it can fan out to any provider that
-speaks the same shape.
-
-The request is the router's own dataclass (below). The *response* is reused
-verbatim from the OpenAI SDK's ``ChatCompletion`` (that is exactly what a
-chat-completions call returns, so there is nothing to translate) — see
-``service.py``.
+The response type is reused verbatim from the OpenAI SDK's ``ChatCompletion`` —
+see ``service.py``.
 """
 
 from __future__ import annotations
@@ -19,15 +12,9 @@ from typing import Any
 
 @dataclass
 class ChatCompletionRequest:
-    """A model-invocation request in Chat Completions / LiteLLM / OpenRouter form.
-
-    ``model`` selects the target (a future router keys its backend choice off
-    this). ``messages`` and ``params`` are the standard chat-completions fields:
-    ``params`` carries everything else the caller set — ``tools``,
-    ``tool_choice``, ``temperature``, ``response_format``, ``max_tokens``,
-    ``parallel_tool_calls``, … — already in OpenAI/LiteLLM shape, so the handler
-    forwards them as ``create(**params)``.
-    """
+    """A chat-completions request. ``model`` selects the target (a future router
+    keys its backend off this); ``params`` carries the remaining OpenAI/LiteLLM
+    ``create(**params)`` kwargs (``tools``, ``tool_choice``, ``temperature``, …)."""
 
     model: str
     messages: list[dict[str, Any]]

--- a/nexus/model_router/models.py
+++ b/nexus/model_router/models.py
@@ -1,0 +1,34 @@
+"""The model router's own wire models.
+
+The router speaks the OpenAI **Chat Completions** shape — the de-facto standard
+that LiteLLM and OpenRouter also use — so any client that can produce a
+chat-completions request can call it, and it can fan out to any provider that
+speaks the same shape.
+
+The request is the router's own dataclass (below). The *response* is reused
+verbatim from the OpenAI SDK's ``ChatCompletion`` (that is exactly what a
+chat-completions call returns, so there is nothing to translate) — see
+``service.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ChatCompletionRequest:
+    """A model-invocation request in Chat Completions / LiteLLM / OpenRouter form.
+
+    ``model`` selects the target (a future router keys its backend choice off
+    this). ``messages`` and ``params`` are the standard chat-completions fields:
+    ``params`` carries everything else the caller set — ``tools``,
+    ``tool_choice``, ``temperature``, ``response_format``, ``max_tokens``,
+    ``parallel_tool_calls``, … — already in OpenAI/LiteLLM shape, so the handler
+    forwards them as ``create(**params)``.
+    """
+
+    model: str
+    messages: list[dict[str, Any]]
+    params: dict[str, Any] = field(default_factory=dict)

--- a/nexus/model_router/service.py
+++ b/nexus/model_router/service.py
@@ -1,8 +1,10 @@
 """The model router Nexus service contract.
 
-One sync operation, ``chat_completion``, takes a :class:`ChatCompletionRequest`
-and returns an OpenAI-SDK :class:`~openai.types.chat.ChatCompletion`. This is the
-LLM API, exposed over Nexus rather than HTTP.
+One operation, ``chat_completion``, takes a :class:`ChatCompletionRequest` and
+returns an OpenAI-SDK :class:`~openai.types.chat.ChatCompletion`. This is the LLM
+API, exposed over Nexus rather than HTTP. The handler implements it as an
+asynchronous, workflow-backed operation (model calls exceed the ~10s a Nexus sync
+operation allows) — but that is a handler concern; the contract is just in→out.
 
 Light and side-effect-free to import (no OpenAI client, no worker) so callers can
 import it in workflow context to build a Nexus client. The handler lives in

--- a/nexus/model_router/service.py
+++ b/nexus/model_router/service.py
@@ -1,0 +1,30 @@
+"""The model router Nexus service contract.
+
+One sync operation, ``chat_completion``, takes a :class:`ChatCompletionRequest`
+and returns an OpenAI-SDK :class:`~openai.types.chat.ChatCompletion`. This is the
+LLM API, exposed over Nexus rather than HTTP.
+
+Light and side-effect-free to import (no OpenAI client, no worker) so callers can
+import it in workflow context to build a Nexus client. The handler lives in
+``handler.py``; the worker in ``worker.py``.
+"""
+
+from __future__ import annotations
+
+import nexusrpc
+from openai.types.chat import ChatCompletion
+
+from .models import ChatCompletionRequest
+
+# The Nexus endpoint name + the task queue the router worker polls. Shared with
+# callers so they can address the endpoint and with the worker so it registers
+# (and creates) the matching endpoint.
+NEXUS_ENDPOINT = "model-router-endpoint"
+TASK_QUEUE = "model-router"
+
+
+@nexusrpc.service
+class ModelRouterService:
+    """A model router exposed as a Nexus service: request in, model response out."""
+
+    chat_completion: nexusrpc.Operation[ChatCompletionRequest, ChatCompletion]

--- a/nexus/model_router/service.py
+++ b/nexus/model_router/service.py
@@ -2,13 +2,14 @@
 
 One operation, ``chat_completion``, takes a :class:`ChatCompletionRequest` and
 returns an OpenAI-SDK :class:`~openai.types.chat.ChatCompletion`. This is the LLM
-API, exposed over Nexus rather than HTTP. The handler implements it as an
-asynchronous, workflow-backed operation (model calls exceed the ~10s a Nexus sync
-operation allows) — but that is a handler concern; the contract is just in→out.
+API, exposed over Nexus rather than HTTP. Sync-vs-async is a handler concern
+(see ``handler.py`` / ``workflow.py``); the contract is just in→out.
 
-Light and side-effect-free to import (no OpenAI client, no worker) so callers can
-import it in workflow context to build a Nexus client. The handler lives in
-``handler.py``; the worker in ``worker.py``.
+Constructs nothing, but importing it does pull in the OpenAI SDK (for the
+``ChatCompletion`` type), so workflow-context callers import it under
+``workflow.unsafe.imports_passed_through()`` (see the example's
+``nexus_transport.py``). The handler lives in ``handler.py``; the worker in
+``worker.py``.
 """
 
 from __future__ import annotations

--- a/nexus/model_router/worker.py
+++ b/nexus/model_router/worker.py
@@ -1,0 +1,111 @@
+"""Standalone worker hosting the model router Nexus service.
+
+Run from the repo root with:
+    uv run --group examples python -m nexus.model_router.worker
+
+Registers ``ModelRouterServiceHandler`` on the ``model-router`` task queue and
+creates the Nexus endpoint (idempotent) that maps ``NEXUS_ENDPOINT`` -> this
+worker. Any workflow (in this namespace) can then call the router over Nexus.
+
+Uses the pydantic data converter so the router's dataclass request and the
+OpenAI ``ChatCompletion`` response serialize cleanly — and compatibly with the
+OpenAI Agents plugin's (also pydantic-based) converter on the caller side.
+
+Env:
+    OPENAI_API_KEY                             required — the router calls OpenAI.
+    TEMPORAL_CONFIG_FILE / TEMPORAL_PROFILE    connection profile (else localhost:7233).
+    TEMPORAL_ADDRESS / TEMPORAL_NAMESPACE      fallback connection when no profile.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from typing import Any
+
+import temporalio.api.nexus.v1 as nexus_pb
+import temporalio.api.operatorservice.v1 as operator_pb
+from temporalio.client import Client
+from temporalio.contrib.pydantic import pydantic_data_converter
+from temporalio.envconfig import ClientConfig
+from temporalio.service import RPCError, RPCStatusCode
+from temporalio.worker import Worker
+
+from .handler import ModelRouterServiceHandler
+from .service import NEXUS_ENDPOINT, TASK_QUEUE
+
+
+def _connect_config() -> dict[str, Any]:
+    try:
+        cfg = ClientConfig.load_client_connect_config()
+        if cfg.get("target_host"):
+            return cfg
+    except Exception:
+        pass
+    return {
+        "target_host": os.environ.get("TEMPORAL_ADDRESS", "localhost:7233"),
+        "namespace": os.environ.get("TEMPORAL_NAMESPACE", "default"),
+    }
+
+
+async def ensure_endpoint(client: Client, namespace: str) -> None:
+    """Create the Nexus endpoint (idempotent) mapping NEXUS_ENDPOINT -> TASK_QUEUE.
+
+    Equivalent CLI:
+        temporal operator nexus endpoint create --name model-router-endpoint \\
+            --target-namespace <ns> --target-task-queue model-router
+    """
+    spec = nexus_pb.EndpointSpec(
+        name=NEXUS_ENDPOINT,
+        target=nexus_pb.EndpointTarget(
+            worker=nexus_pb.EndpointTarget.Worker(
+                namespace=namespace,
+                task_queue=TASK_QUEUE,
+            )
+        ),
+    )
+    try:
+        await client.operator_service.create_nexus_endpoint(
+            operator_pb.CreateNexusEndpointRequest(spec=spec)
+        )
+        print(f"created nexus endpoint {NEXUS_ENDPOINT!r} -> {namespace}/{TASK_QUEUE}")
+    except RPCError as e:
+        if e.status == RPCStatusCode.ALREADY_EXISTS:
+            print(f"nexus endpoint {NEXUS_ENDPOINT!r} already exists")
+        else:
+            raise
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        force=True,
+    )
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        sys.exit("error: OPENAI_API_KEY env var not set")
+
+    cfg = _connect_config()
+    client = await Client.connect(**cfg, data_converter=pydantic_data_converter)
+
+    namespace = cfg.get("namespace") or client.namespace
+    await ensure_endpoint(client, namespace)
+
+    worker = Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        nexus_service_handlers=[ModelRouterServiceHandler()],
+    )
+    print(
+        f"model-router worker ready: address={cfg.get('target_host')} "
+        f"namespace={namespace} taskQueue={TASK_QUEUE} nexusEndpoint={NEXUS_ENDPOINT}",
+        flush=True,
+    )
+    await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/nexus/model_router/worker.py
+++ b/nexus/model_router/worker.py
@@ -3,9 +3,11 @@
 Run from the repo root with:
     uv run --group examples python -m nexus.model_router.worker
 
-Registers ``ModelRouterServiceHandler`` on the ``model-router`` task queue and
-creates the Nexus endpoint (idempotent) that maps ``NEXUS_ENDPOINT`` -> this
-worker. Any workflow (in this namespace) can then call the router over Nexus.
+Registers the ``ModelRouterServiceHandler`` Nexus service, the
+``ModelRouterWorkflow`` that backs its (asynchronous) operation, and the activity
+that calls the model — all on the ``model-router`` task queue — and creates the
+Nexus endpoint (idempotent) mapping ``NEXUS_ENDPOINT`` -> this worker. Any
+workflow (in this namespace) can then call the router over Nexus.
 
 Uses the pydantic data converter so the router's dataclass request and the
 OpenAI ``ChatCompletion`` response serialize cleanly — and compatibly with the
@@ -33,8 +35,10 @@ from temporalio.envconfig import ClientConfig
 from temporalio.service import RPCError, RPCStatusCode
 from temporalio.worker import Worker
 
+from .activities import ModelRouterActivities
 from .handler import ModelRouterServiceHandler
 from .service import NEXUS_ENDPOINT, TASK_QUEUE
+from .workflow import ModelRouterWorkflow
 
 
 def _connect_config() -> dict[str, Any]:
@@ -94,9 +98,12 @@ async def main() -> None:
     namespace = cfg.get("namespace") or client.namespace
     await ensure_endpoint(client, namespace)
 
+    activities = ModelRouterActivities()
     worker = Worker(
         client,
         task_queue=TASK_QUEUE,
+        workflows=[ModelRouterWorkflow],
+        activities=[activities.invoke_chat_completion],
         nexus_service_handlers=[ModelRouterServiceHandler()],
     )
     print(

--- a/nexus/model_router/worker.py
+++ b/nexus/model_router/worker.py
@@ -42,16 +42,15 @@ from .workflow import ModelRouterWorkflow
 
 
 def _connect_config() -> dict[str, Any]:
-    try:
-        cfg = ClientConfig.load_client_connect_config()
-        if cfg.get("target_host"):
-            return cfg
-    except Exception:
-        pass
-    return {
-        "target_host": os.environ.get("TEMPORAL_ADDRESS", "localhost:7233"),
-        "namespace": os.environ.get("TEMPORAL_NAMESPACE", "default"),
-    }
+    # Use the configured Temporal profile if there is one, else default to a local
+    # dev server so `just router` works with zero config. (Not swallowing errors:
+    # load_client_connect_config returns None fields rather than raising when unset.)
+    cfg = ClientConfig.load_client_connect_config()
+    if not cfg.get("target_host"):
+        cfg["target_host"] = os.environ.get("TEMPORAL_ADDRESS", "localhost:7233")
+    if not cfg.get("namespace"):
+        cfg["namespace"] = os.environ.get("TEMPORAL_NAMESPACE", "default")
+    return cfg
 
 
 async def ensure_endpoint(client: Client, namespace: str) -> None:

--- a/nexus/model_router/workflow.py
+++ b/nexus/model_router/workflow.py
@@ -30,6 +30,11 @@ class ModelRouterWorkflow:
         return await workflow.execute_activity_method(
             ModelRouterActivities.invoke_chat_completion,
             request,
-            start_to_close_timeout=timedelta(minutes=5),
+            # Per-attempt cap; schedule_to_close bounds the whole activity
+            # INCLUDING retries, so the total stays below the caller's Nexus
+            # operation timeout (nexus_transport._OP_TIMEOUT) — otherwise retries
+            # would be cut off mid-flight when the operation times out.
+            start_to_close_timeout=timedelta(minutes=2),
+            schedule_to_close_timeout=timedelta(minutes=5),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )

--- a/nexus/model_router/workflow.py
+++ b/nexus/model_router/workflow.py
@@ -1,0 +1,35 @@
+"""The workflow that backs the router's Nexus operation.
+
+Each ``chat_completion`` Nexus call starts one of these. It exists so the model
+call can be **asynchronous and unbounded**: a Nexus *sync* operation must return
+in ~10s (it resolves inline in the StartOperation RPC), which LLM calls routinely
+exceed. A workflow-backed operation instead completes whenever this workflow
+completes — durably, with the model call retried as an activity.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from openai.types.chat import ChatCompletion
+
+    from .activities import ModelRouterActivities
+    from .models import ChatCompletionRequest
+
+
+@workflow.defn
+class ModelRouterWorkflow:
+    """Runs one model call as an activity and returns its response."""
+
+    @workflow.run
+    async def run(self, request: ChatCompletionRequest) -> ChatCompletion:
+        return await workflow.execute_activity_method(
+            ModelRouterActivities.invoke_chat_completion,
+            request,
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )

--- a/temporal_agent_harness/ai_sdks/openai_agents/_model_parameters.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_model_parameters.py
@@ -80,9 +80,9 @@ class ModelActivityParameters:
     callable (given the requested model name) and awaits its ``get_response``
     directly, INSTEAD of scheduling the ``invoke_model_activity`` activity. The
     resolved model runs in workflow context, so — unlike the activity path's
-    worker-side ``model_provider`` — it may do workflow-only things, most usefully
-    make its transport a Nexus call (``workflow.create_nexus_client(...)``), which
-    is impossible from an activity.
+    worker-side ``model_provider`` — it may do workflow-only things, e.g. make its
+    transport a Nexus call (``workflow.create_nexus_client(...)``), which is
+    impossible from an activity.
 
     It is the workflow-side analog of the activity path's ``model_provider``: the
     plugin stays agnostic about the model's transport. Because the stub hands the

--- a/temporal_agent_harness/ai_sdks/openai_agents/_model_parameters.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_model_parameters.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
-from agents import Agent, TResponseInputItem
+from agents import Agent, Model, TResponseInputItem
 
 from temporalio.common import Priority, RetryPolicy
 from temporalio.workflow import ActivityCancellationType, VersioningIntent
@@ -72,6 +72,26 @@ class ModelActivityParameters:
 
     use_local_activity: bool = False
     """Whether to use a local activity. If changed during a workflow execution, that would break determinism."""
+
+    workflow_model_provider: Callable[[str | None], Model] | None = None
+    """Optional workflow-side model provider for non-streaming model calls.
+
+    When set, ``_TemporalModelStub.get_response`` resolves a ``Model`` from this
+    callable (given the requested model name) and awaits its ``get_response``
+    directly, INSTEAD of scheduling the ``invoke_model_activity`` activity. The
+    resolved model runs in workflow context, so — unlike the activity path's
+    worker-side ``model_provider`` — it may do workflow-only things, most usefully
+    make its transport a Nexus call (``workflow.create_nexus_client(...)``), which
+    is impossible from an activity.
+
+    It is the workflow-side analog of the activity path's ``model_provider``: the
+    plugin stays agnostic about the model's transport. Because the stub hands the
+    resolved model its already-live ``tools`` / ``handoffs`` / ``model_settings``,
+    there is no serialization or tool reconstruction on this path. Streaming
+    (``Runner.run_streamed``) ignores it.
+
+    .. warning::
+        Experimental; behavior may change."""
 
     streaming_topic: str | None = None
     """Stream topic to publish raw model stream events to when the workflow

--- a/temporal_agent_harness/ai_sdks/openai_agents/_openai_runner.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_openai_runner.py
@@ -283,6 +283,12 @@ class TemporalOpenAIRunner(AgentRunner):
                 "use_local_activity (local activities do not support "
                 "heartbeats or the workflow stream signal channel)."
             )
+        if self.model_params.workflow_model_provider is not None:
+            raise AgentsWorkflowError(
+                "Runner.run_streamed is incompatible with "
+                "ModelActivityParameters.workflow_model_provider (a "
+                "non-streaming seam). Use Runner.run instead."
+            )
 
         converted_agent = self._prepare_workflow_run(starting_agent, kwargs)
 

--- a/temporal_agent_harness/ai_sdks/openai_agents/_temporal_model_stub.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_temporal_model_stub.py
@@ -187,6 +187,27 @@ class _TemporalModelStub(Model):  # type:ignore[reportUnusedClass]
         conversation_id: str | None,
         prompt: ResponsePromptParam | None,
     ) -> ModelResponse:
+        # Workflow-side model provider: resolve a Model here (in workflow context)
+        # and call it directly with the already-live args — no serialization, no
+        # tool reconstruction, no activity. The resolved model's transport may be
+        # a Nexus call, which only works because we are in workflow context (the
+        # activity path could never reach Nexus). See
+        # ``ModelActivityParameters.workflow_model_provider``.
+        if self.model_params.workflow_model_provider is not None:
+            model = self.model_params.workflow_model_provider(self.model_name)
+            return await model.get_response(
+                system_instructions=system_instructions,
+                input=input,
+                model_settings=model_settings,
+                tools=tools,
+                output_schema=output_schema,
+                handoffs=handoffs,
+                tracing=tracing,
+                previous_response_id=previous_response_id,
+                conversation_id=conversation_id,
+                prompt=prompt,
+            )
+
         activity_input, summary = self._build_activity_input(
             system_instructions=system_instructions,
             input=input,

--- a/temporal_agent_harness/ai_sdks/openai_agents/_temporal_model_stub.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_temporal_model_stub.py
@@ -274,6 +274,17 @@ class _TemporalModelStub(Model):  # type:ignore[reportUnusedClass]
                 "workflow stream signal channel)."
             )
 
+        # workflow_model_provider is a non-streaming seam: get_response resolves
+        # and calls the model in workflow context, but the streaming path runs in
+        # an activity. Fail loudly rather than silently ignoring the configured
+        # provider and streaming via the (possibly unconfigured) activity path.
+        if self.model_params.workflow_model_provider is not None:
+            raise ValueError(
+                "workflow_model_provider is not supported with "
+                "Runner.run_streamed (it is a non-streaming seam). Use "
+                "Runner.run, or drive streaming through the activity path."
+            )
+
         # Resolve the opaque per-call routing token: prefer the configured
         # provider (called here, in workflow context), falling back to the
         # static streaming_topic. The activity hands whatever this is to its


### PR DESCRIPTION
This PR:
- Adds a Nexus service which acts as a model router
  + Currently only actually calls out to OpenAI, but can add routing decisions in follow-up
- Modifies OAI plugin to allow to Nexus calls for LLM calls
- Adds an openai_nexus example that does LLM calls via the Nexus service

To run the demo, first make sure you have `OPENAI_API_KEY` set in your environment. Then from `examples/openai_nexus/`, run these:
1. `just temporal          # 1. local Temporal dev server (skip if you have one)`
2. `just router            # 2. the model router — the "LLM API over Nexus"; creates the endpoint. NEEDS OPENAI_API_KEY`
3. `just session-manager   # 3. packaged session-manager worker`
4. `just server            # 4. FastAPI API + Svelte UI on http://localhost:8000  (builds the UI via pnpm first)`
5. `just worker            # 5. the OpenAI-over-Nexus agent worker`

Then go to http://localhost:8000, type in "what is the weather in Boston". Then go over to the standard Temporal UI, check the timeline and you should see Nexus operations.

<img width="1624" height="604" alt="Screenshot 2026-07-14 at 7 31 06 PM" src="https://github.com/user-attachments/assets/47e7c312-cc8a-40bf-a318-28a9a2c92ba3" />
<img width="1401" height="490" alt="Screenshot 2026-07-14 at 7 30 13 PM" src="https://github.com/user-attachments/assets/561720df-e620-4078-ac41-f0d30992b13e" />
<img width="1427" height="677" alt="Screenshot 2026-07-14 at 7 30 55 PM" src="https://github.com/user-attachments/assets/18e79afa-34d3-42ec-b2fd-11630a825238" />
