### PR TITLE
Thread the harness runner into OpenAI streaming via run_streamed context

### DIFF
--- a/examples/openai_hello/workflow.py
+++ b/examples/openai_hello/workflow.py
@@ -86,7 +86,9 @@ class OpenAIHelloAgentWorkflow:
         ]
 
         # run_streamed returns immediately; iterate its events to drive the turn to completion.
-        result = Runner.run_streamed(sdk_agent, input=input_items)
+        # context=self._runner threads the harness runner to the streaming activity so the
+        # plugin can route live events to this turn's stream.
+        result = Runner.run_streamed(sdk_agent, input=input_items, context=self._runner)
         async for _event in result.stream_events():
             pass
 

--- a/temporal_agent_harness/ai_sdks/openai_agents/_model_parameters.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_model_parameters.py
@@ -96,19 +96,24 @@ class ModelActivityParameters:
         Streaming support is experimental and may change in future
         versions."""
 
-    stream_to_provider: Callable[[str | None], Any] | None = None
+    stream_to_provider: Callable[[str | None, Any], Any] | None = None
     """Optional per-call provider of an opaque routing token for streamed
     requests. Called once (in workflow context) at the start of each
-    ``Runner.run_streamed`` model call, with the requested model id; its return
-    value is handed, opaquely, to the streaming activity's observer factory to
-    resolve where live stream events go (and to carry any per-call metadata the
-    observer needs, such as the model). Returning ``None`` falls back to
-    :attr:`streaming_topic`.
+    ``Runner.run_streamed`` model call, with ``(requested_model_id, run_context)``
+    where ``run_context`` is exactly the object the caller passed as
+    ``Runner.run_streamed(..., context=...)``. Its return value is handed,
+    opaquely, to the streaming activity's observer factory to resolve where live
+    stream events go (and to carry per-call metadata the observer needs, such as
+    the model). Returning ``None`` falls back to :attr:`streaming_topic`.
 
-    This is the seam that lets an embedding runtime (e.g. the agent harness)
-    target a per-turn stream instead of a static worker-level topic, without
-    the plugin knowing anything about the token's concrete type. When left
-    ``None``, streaming uses :attr:`streaming_topic` exactly as before.
+    The ``run_context`` parameter exists because this is the point where an
+    embedding runtime turns a handle it threaded through the SDK into a
+    serializable routing token — the plugin can't interpret that handle itself,
+    so the runtime is handed it here. It lets the runtime (e.g. the agent
+    harness, passing its per-workflow runner) target a per-turn stream instead of
+    a static worker-level topic without the plugin knowing anything about the
+    handle's or token's concrete type. When left ``None``, streaming uses
+    :attr:`streaming_topic` exactly as before.
 
     .. warning::
         Streaming support is experimental and may change in future

--- a/temporal_agent_harness/ai_sdks/openai_agents/_openai_runner.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_openai_runner.py
@@ -33,6 +33,7 @@ def _convert_agent(
     model_params: ModelActivityParameters,
     agent: Agent[Any],
     seen: dict[int, Agent] | None,
+    run_context: Any = None,
 ) -> Agent[Any]:
     if seen is None:
         seen = dict()
@@ -54,7 +55,7 @@ def _convert_agent(
     new_handoffs: list[Agent | Handoff] = []
     for handoff in agent.handoffs:
         if isinstance(handoff, Agent):
-            new_handoffs.append(_convert_agent(model_params, handoff, seen))
+            new_handoffs.append(_convert_agent(model_params, handoff, seen, run_context))
         elif isinstance(handoff, Handoff):
             original_invoke = handoff.on_invoke_handoff
 
@@ -65,9 +66,10 @@ def _convert_agent(
                 invoke_func: Callable[
                     [RunContextWrapper[Any], str], Awaitable[Any]
                 ] = original_invoke,
+                run_context: Any = run_context,
             ) -> Agent:
                 handoff_agent = await invoke_func(context, args)
-                return _convert_agent(model_params, handoff_agent, seen)
+                return _convert_agent(model_params, handoff_agent, seen, run_context)
 
             new_handoffs.append(
                 dataclasses.replace(handoff, on_invoke_handoff=on_invoke)
@@ -79,6 +81,7 @@ def _convert_agent(
         model_name=name,
         model_params=model_params,
         agent=agent,
+        run_context=run_context,
     )
     new_agent.handoffs = new_handoffs
     return new_agent
@@ -147,6 +150,12 @@ class TemporalOpenAIRunner(AgentRunner):
         if isinstance(kwargs.get("session"), SQLiteSession):
             raise ValueError("Temporal workflows don't support SQLite sessions.")
 
+        # The object the caller threaded via ``Runner.run_streamed(..., context=...)``.
+        # Captured here (synchronously, before the framework starts its run task) and
+        # handed to each model stub, which forwards it to ``stream_to_provider`` to
+        # resolve the live stream routing token.
+        run_context = kwargs.get("context")
+
         run_config = kwargs.get("run_config")
         if run_config is None:
             run_config = RunConfig()
@@ -159,7 +168,10 @@ class TemporalOpenAIRunner(AgentRunner):
             run_config = dataclasses.replace(
                 run_config,
                 model=_TemporalModelStub(
-                    run_config.model, model_params=self.model_params, agent=None
+                    run_config.model,
+                    model_params=self.model_params,
+                    agent=None,
+                    run_context=run_context,
                 ),
             )
 
@@ -187,7 +199,7 @@ class TemporalOpenAIRunner(AgentRunner):
                 )
 
         kwargs["run_config"] = run_config
-        return _convert_agent(self.model_params, starting_agent, None)
+        return _convert_agent(self.model_params, starting_agent, None, run_context)
 
     async def run(
         self,

--- a/temporal_agent_harness/ai_sdks/openai_agents/_temporal_model_stub.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_temporal_model_stub.py
@@ -58,10 +58,17 @@ class _TemporalModelStub(Model):  # type:ignore[reportUnusedClass]
         *,
         model_params: ModelActivityParameters,
         agent: Agent[Any] | None,
+        run_context: Any = None,
     ) -> None:
         self.model_name = model_name
         self.model_params = model_params
         self.agent = agent
+        # The object the caller passed as ``Runner.run_streamed(..., context=...)``,
+        # threaded in workflow-side by the runner. Opaque here; handed to
+        # ``stream_to_provider`` so an embedding runtime can turn its own handle
+        # (e.g. a per-workflow runner) into a routing token. Unused by non-streaming
+        # calls.
+        self._run_context = run_context
 
     def _build_activity_input(
         self,
@@ -259,9 +266,12 @@ class _TemporalModelStub(Model):  # type:ignore[reportUnusedClass]
         # observer factory; it never inspects the token itself.
         stream_to: Any = None
         if self.model_params.stream_to_provider is not None:
-            # Pass the requested model id so the provider can build a token that lets the
-            # observer name the model when it brackets the call at dispatch.
-            stream_to = self.model_params.stream_to_provider(self.model_name)
+            # Pass the requested model id and the caller's run context, so the
+            # provider can turn its threaded handle into a routing token (and let
+            # the observer name the model when it brackets the call at dispatch).
+            stream_to = self.model_params.stream_to_provider(
+                self.model_name, self._run_context
+            )
         if stream_to is None:
             stream_to = self.model_params.streaming_topic
         if stream_to is None:

--- a/temporal_agent_harness/ai_sdks/openai_agents_harness.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents_harness.py
@@ -71,7 +71,6 @@ from temporal_agent_harness.harness.agent_protocol import (
 from temporal_agent_harness.harness.agent_workflow import (
     AgentWorkflowRunner,
     TurnEventPublisher,
-    current_stream_context,
 )
 from temporal_agent_harness.harness.stream_context import TurnStreamContext
 
@@ -288,16 +287,18 @@ class _HarnessStreamToken(BaseModel):
     model: str | None = None
 
 
-def stream_to_provider(model: str | None) -> _HarnessStreamToken | None:
+def stream_to_provider(model: str | None, run_context: Any) -> _HarnessStreamToken | None:
     """Per-call routing-token provider (wired as ``model_params.stream_to_provider``).
 
-    Called once per streamed request, in workflow context, with the requested model id.
-    Resolves the in-flight turn's stream context ambiently off the running workflow
-    instance (no explicit runner threading) and bundles it with the model. Returns
-    ``None`` outside a harness turn, so the vendored stub falls back to
-    ``streaming_topic``.
+    Called once per streamed request, in workflow context, with the requested model id
+    and the object the agent passed as ``Runner.run_streamed(..., context=self._runner)``.
+    Reads the in-flight turn's stream context off that runner and bundles it with the
+    model. Returns ``None`` when the run context is not a harness runner or there is no
+    active turn, so the vendored stub falls back to ``streaming_topic``.
     """
-    context = current_stream_context()
+    if not isinstance(run_context, AgentWorkflowRunner):
+        return None
+    context = run_context.current_stream_context
     if context is None:
         return None
     return _HarnessStreamToken(context=context, model=model)

--- a/temporal_agent_harness/harness/agent_workflow.py
+++ b/temporal_agent_harness/harness/agent_workflow.py
@@ -431,29 +431,6 @@ def _enclosing_workflow_class() -> type | None:
     return None
 
 
-def current_stream_context() -> TurnStreamContext | None:
-    """Resolve the in-flight turn's stream context for the running harness agent.
-
-    Ambient lookup, no threading required: gets the currently-executing workflow
-    instance (:func:`temporalio.workflow.instance`) and reads the
-    :class:`AgentWorkflowRunner` it holds — harness agents store it as ``self._runner``.
-    Returns the runner's :attr:`~AgentWorkflowRunner.current_stream_context` (which is
-    ``None`` between turns), or ``None`` when we're not in a workflow at all, or the
-    running workflow is not a harness agent (no ``_runner``).
-
-    This lets an AI-SDK client/model-stub obtain the routing context for its streamed
-    activity without being handed the runner explicitly. It is concurrency- and
-    replay-safe: ``workflow.instance()`` resolves per running workflow execution, so it
-    always returns the right agent's context even with many workflows on one worker.
-    """
-    if not workflow.in_workflow():
-        return None
-    runner = getattr(workflow.instance(), "_runner", None)
-    if not isinstance(runner, AgentWorkflowRunner):
-        return None
-    return runner.current_stream_context
-
-
 def _assert_standardized_agent_signature() -> None:
     """Enforce the uniform agent-input contract for the workflow building this runner.
 


### PR DESCRIPTION
## What

Replaces the ambient runner resolution for the OpenAI Agents streaming integration with **explicit threading** through the SDK's per-run `context`.

The agent now passes its runner into the run:

```python
result = Runner.run_streamed(sdk_agent, input=input_items, context=self._runner)
```

The vendored `TemporalOpenAIRunner` captures `context=` workflow-side in `_prepare_workflow_run` and threads it through `_convert_agent` into each model stub; `stream_to_provider(model, run_context)` then turns the runner into the per-turn routing token that the streaming activity's observer uses.

## Why

The previous mechanism resolved the runner ambiently via `workflow.instance()._runner`. That depended on the **unenforced convention** that every harness agent stores its runner at `self._runner`, and it degraded *silently* (no live streaming) if an agent named it anything else. Threading the runner explicitly removes that dependence and makes the data flow visible at the call site.

## Changes

- **`_model_parameters`** — `stream_to_provider` gains a `run_context` arg (the object passed as `context=`). This is the seam where the embedding runtime converts its threaded handle into a serializable token, so the handle has to be passed in.
- **`_openai_runner` / `_temporal_model_stub`** — capture `context=` and thread it to each stub; the stub forwards it to `stream_to_provider`.
- **`openai_agents_harness`** — `stream_to_provider(model, run_context)` reads the turn context off the passed-in runner instead of resolving it ambiently.
- **`agent_workflow`** — removes the module-level `current_stream_context()` free function (the `AgentWorkflowRunner.current_stream_context` **property** stays; that's what the provider reads).
- **`examples/openai_hello`** — passes `context=self._runner`.

## Testing

- `tests/ai_sdks` + `tests/harness` green (181 passed).
- Downstream of the token (the observer translation, model bracket, usage) is covered by the observer unit tests. The `context → stub → provider` hop has no hermetic e2e (would need a streaming fake model), so it's worth a live smoke: run the `openai_hello` worker and send a simple + a tool-call turn, confirming the turn stream still lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)