### PR TITLE
Add Pydantic AI Temporal plugin integration

### DIFF
--- a/examples/pydantic_ai_hello/README.md
+++ b/examples/pydantic_ai_hello/README.md
@@ -1,0 +1,75 @@
+# Hello-world Pydantic AI agent
+
+The smallest interesting agent you can build on the harness with **Pydantic AI**: it chats in plain
+text and can call one tool (`get_weather`). It's here to show the harness **streaming** path for the
+Pydantic AI integration end to end — from the model call, through Pydantic AI's model activity, to
+the live turn stream the web UI consumes.
+
+Unlike the OpenAI and Gemini integrations (whose plugins are vendored into the harness so a streaming
+seam could be added), Pydantic AI's Temporal plugin is used **unmodified** from
+`pydantic_ai.durable_exec.temporal`: it already ships a first-class `event_stream_handler` hook that
+runs inside the model-request activity on the live event stream, which is exactly the seam the
+harness needs. The harness only supplies a thin glue module.
+
+## What it demonstrates
+
+- **Streaming via `event_stream_handler`.** The agent is built with
+  `event_stream_handler=harness_event_stream_handler`. When you call `agent.run(...)`, Pydantic AI
+  streams the model request into its `…__model_request_stream` activity and invokes the handler
+  there on the live `AgentStreamEvent`s. The handler translates them into harness vocabulary —
+  `model_interaction_started` → `reply_delta` / `thought_summary` … `tool_requested` …
+  `model_interaction_ended` (with token usage).
+- **Explicit per-run threading (no `self._runner` assumption).** The `TemporalAgent` is built once
+  at module load (its activities are registered on the worker). Each turn threads the runner through
+  `deps` — that's all you pass:
+  ```python
+  await agent.run(message.text, deps=HarnessDeps(runner=self._runner), message_history=self._history)
+  ```
+  `HarnessDeps` snapshots `harness_stream_context` from the runner for you. Both handles are needed
+  but consumed in different places: the runner stays a live in-workflow reference the adapted tools
+  read off `deps` (excluded from serialization), while the snapshotted stream context rides across
+  into the model activity — where the handler runs and the runner can't follow.
+- **Harness-owned tools.** `get_weather` is a normal `@agent.tool_defn`, adapted onto the SDK with
+  `build_harness_toolset([...])`, which also returns the `tool_activity_config` that disables
+  Pydantic AI's per-tool activity wrapper so the tool runs **in-workflow** — where the harness
+  approval gate and `tool_start`/`tool_end` events live.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `workflow.py` | `PydanticAIHelloAgent` — the harness agent; one `ask` handler, one `get_weather` tool, driven by `TemporalAgent.run` + the harness event-stream handler. |
+| `worker.py` | Worker hosting the workflow; `PydanticAIPlugin` on the client, `AgentPlugin(agent)` on the worker. |
+| `agents.toml` | Registry entry that makes this agent selectable in the shared web UI. |
+
+There is **no per-example client**: like the other examples, this agent is driven by the shared
+example stack — the packaged `SessionManagerWorkflow` worker plus the FastAPI app and web UI
+(`examples/app.py`). Registering the agent in `agents.toml` is all it takes to make it driveable.
+
+## Run it
+
+Prereq: from the repo root, `cp .env.example .env.local` and set `OPENAI_API_KEY` (and your Temporal
+connection profile). Then, each in its own terminal:
+
+```sh
+just temporal          # 1. local Temporal dev server (or bring your own)
+just session-manager   # 2. packaged session-manager worker
+just server            # 3. builds the Svelte UI, then serves API + UI on http://localhost:8000
+just worker            # 4. the agent worker
+```
+
+`just server` builds the web UI first, so it needs `pnpm` on your PATH. (If the build reports missing
+modules, run `just app-install` once. For UI hot-reloading, `just ui-dev` runs it on Vite with
+`/api` proxied to the server on :8000.)
+
+Open http://localhost:8000, pick **Pydantic AI Hello**, and chat — e.g. *"What's the weather in
+Paris?"*. The reply streams in token by token and the `get_weather` tool call appears live, each
+event produced by the handler translating a raw Pydantic AI event in the model activity.
+
+Without `just`, the equivalent commands (from the repo root):
+
+```sh
+uv run --group examples python -m examples.session_manager_worker
+uv run --group examples python -m examples.app examples/pydantic_ai_hello/agents.toml --host 0.0.0.0 --port 8000
+uv run --group examples python -m examples.pydantic_ai_hello.worker
+```

--- a/examples/pydantic_ai_hello/agents.toml
+++ b/examples/pydantic_ai_hello/agents.toml
@@ -1,0 +1,20 @@
+# Registry of agents the Pydantic AI hello-world example UI can launch.
+#
+# The shared FastAPI server (examples/app.py) reads this file and passes the parsed
+# registry into the packaged SessionManagerWorkflow as its workflow init arg. The
+# manager then serves it back over the `available_agents` query, so the app server
+# can expose it at /api/agents without hardcoding the agent list.
+#
+# To expose a new agent: register its @workflow.defn on a worker, then add a
+# [[agents]] entry here.
+
+[[agents]]
+key = "pydantic-ai-hello"
+workflow_type = "PydanticAIHelloAgent"
+task_queue = "pydantic-ai-hello"
+label = "Pydantic AI Hello"
+description = """
+A hello-world Pydantic AI agent. Chat in plain text; it replies in prose and can call one
+tool (get_weather) for a city's weather. Exists to show the harness streaming path for the
+Pydantic AI integration end to end — model call → event_stream_handler in the model activity →
+live turn stream (reply_delta / tool_requested / tool_start / tool_end / model_interaction_*)."""

--- a/examples/pydantic_ai_hello/justfile
+++ b/examples/pydantic_ai_hello/justfile
@@ -1,0 +1,63 @@
+# Scoped justfile for the hello-world Pydantic AI example (examples/pydantic_ai_hello).
+# Run from this directory: `just <recipe>`.
+#
+# Self-contained local stack (each in its own terminal):
+#   just temporal          # 1. local Temporal dev server (or bring your own)
+#   just session-manager   # 2. packaged session-manager worker
+#   just server            # 3. FastAPI API + UI on :8000
+#   just worker            # 4. this example's agent worker
+#
+# Then open http://localhost:8000, pick "Pydantic AI Hello", and chat (e.g. "What's the weather in
+# Paris?"). The reply streams token by token and the get_weather tool call shows up live.
+# `just server` builds the Svelte UI first (needs `pnpm`); `just ui-dev` runs it on Vite instead.
+#
+# uv installs the project's `examples` dependency group (incl. Pydantic AI) on demand, so there's no
+# separate install step. First-time setup: `cp .env.example .env.local` from the repo root and fill
+# it in (Temporal connection + OPENAI_API_KEY). See README.md.
+
+# Read the single shared env file at the repo root (resolved relative to this justfile).
+set dotenv-path := "../../.env.local"
+set dotenv-load := true
+
+root := justfile_directory() / ".." / ".."
+ui := root / "ui"
+
+# List available recipes (bare `just`).
+default:
+    @just --list
+
+# Show the Temporal connection these recipes will use (read from the repo-root .env.local).
+config:
+    @echo "TEMPORAL_CONFIG_FILE = ${TEMPORAL_CONFIG_FILE:-<unset — set it in the repo-root .env.local>}"
+    @echo "TEMPORAL_PROFILE     = ${TEMPORAL_PROFILE:-default}"
+
+# Start a local Temporal dev server (Web UI: http://localhost:8233; needs the `temporal` CLI).
+temporal:
+    temporal server start-dev
+
+# Run the shared session-manager worker (examples/session_manager_worker.py).
+session-manager:
+    cd "{{root}}" && uv run --group examples python -m examples.session_manager_worker
+
+# Serve the packaged FastAPI API + UI on http://localhost:8000, pointed at this example's registry
+# via the shared examples app entrypoint. Builds the Svelte UI first (app-build).
+server: app-build
+    cd "{{root}}" && uv run --group examples python -m examples.app "{{justfile_directory()}}/agents.toml" --host 0.0.0.0 --port 8000
+
+# Build the shared Svelte UI into temporal_agent_harness/ui/dist for the server to serve.
+# Runs FROM the ui dir (not `pnpm --dir`) so corepack reads ui/package.json's pinned pnpm
+# version instead of the repo root's (which has none) — avoids a corepack version mismatch.
+app-build:
+    cd "{{ui}}" && pnpm run build
+
+# Install the shared Svelte UI dependencies (run once if the build complains about missing modules).
+app-install:
+    cd "{{ui}}" && pnpm install
+
+# Run the shared Svelte UI on Vite for hot reloading. /api is proxied to the FastAPI server on :8000.
+ui-dev:
+    cd "{{ui}}" && pnpm run dev
+
+# Run the PydanticAIHelloAgent worker.
+worker:
+    cd "{{root}}" && uv run --group examples python -m examples.pydantic_ai_hello.worker

--- a/examples/pydantic_ai_hello/worker.py
+++ b/examples/pydantic_ai_hello/worker.py
@@ -1,0 +1,79 @@
+"""Worker for the hello-world Pydantic AI agent.
+
+Run from the repo root with:
+    uv run --group examples python -m examples.pydantic_ai_hello.worker
+
+Hosts only the PydanticAIHelloAgent workflow. Its one tool (`get_weather`) is an inline workflow
+tool with no worker-side body, so there are no harness tool activities to register — the Pydantic AI
+`AgentPlugin` registers the agent's activities (model request/stream, event_stream_handler, and the
+toolset's call_tool) itself.
+
+Two plugins, mirroring the upstream Pydantic AI Temporal setup:
+  * ``PydanticAIPlugin`` on the CLIENT — installs the Pydantic-compatible data converter and the
+    workflow-sandbox passthroughs the SDK needs.
+  * ``AgentPlugin(temporal_agent)`` on the WORKER — registers the durable agent's activities.
+
+The harness streaming path is wired on the agent itself (in workflow.py): its
+``event_stream_handler=harness_event_stream_handler`` runs inside the model activity and translates
+raw Pydantic AI events onto the harness turn stream. Drop that handler and the model still runs
+durably, just without live streaming.
+
+Env vars (set in .env.local — see .env.example):
+    TEMPORAL_CONFIG_FILE / TEMPORAL_PROFILE   Temporal connection profile
+    OPENAI_API_KEY                            required — the agent calls the OpenAI API
+    PYDANTIC_AI_HELLO_TASK_QUEUE              task queue to poll (default: pydantic-ai-hello)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+from pydantic_ai.durable_exec.temporal import AgentPlugin, PydanticAIPlugin
+from temporalio.client import Client
+from temporalio.envconfig import ClientConfig
+from temporalio.worker import Worker
+
+from .workflow import TASK_QUEUE, PydanticAIHelloAgentWorkflow, _TEMPORAL_AGENT
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        force=True,
+    )
+
+    task_queue = os.environ.get("PYDANTIC_AI_HELLO_TASK_QUEUE", TASK_QUEUE)
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        sys.exit("error: OPENAI_API_KEY env var not set")
+
+    # PydanticAIPlugin supplies the Pydantic-compatible data converter + sandbox passthroughs.
+    connect_config = ClientConfig.load_client_connect_config()
+    client = await Client.connect(**connect_config, plugins=[PydanticAIPlugin()])
+
+    worker = Worker(
+        client,
+        task_queue=task_queue,
+        workflows=[PydanticAIHelloAgentWorkflow],
+        # No harness tool activities: get_weather is an inline workflow tool. The durable agent's
+        # activities are registered by AgentPlugin.
+        activities=[],
+        plugins=[AgentPlugin(_TEMPORAL_AGENT)],
+    )
+    print(
+        f"Pydantic AI hello agent worker ready: "
+        f"profile={os.environ.get('TEMPORAL_PROFILE', 'default')!r} "
+        f"address={connect_config.get('target_host')} "
+        f"namespace={connect_config.get('namespace')} "
+        f"taskQueue={task_queue}",
+        flush=True,
+    )
+    await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/pydantic_ai_hello/workflow.py
+++ b/examples/pydantic_ai_hello/workflow.py
@@ -1,0 +1,121 @@
+"""A hello-world Pydantic AI agent on the harness, with one tool call.
+
+A conversational agent that answers in plain text and can call a single tool (``get_weather``).
+The turn runs the model with ``TemporalAgent.run(...)`` and a harness ``event_stream_handler``, so
+each streamed model call routes through Pydantic AI's model activity where the handler translates
+raw ``AgentStreamEvent``s into the turn-stream events an attached client sees. The tool is a normal
+harness tool adapted onto the SDK with ``build_harness_toolset``, so the harness still owns approval
+and its ``tool_start`` / ``tool_end`` / ``tool_error`` events.
+
+The ``TemporalAgent`` is built ONCE at module load — its activities are registered on the worker via
+``AgentPlugin`` (see worker.py). It carries no runner: the per-turn runner is threaded EXPLICITLY
+through ``deps`` at each ``run(...)`` call (``HarnessDeps(runner=...)``, which snapshots the turn's
+stream context from it), so one shared agent serves every concurrent workflow correctly — no
+``self._runner`` assumption.
+
+Run it with the shared example stack (session-manager worker + FastAPI/UI); this agent is registered
+in ``agents.toml`` and driven by the packaged web app. See ``README.md``.
+"""
+
+from __future__ import annotations
+
+from temporalio import workflow
+from temporalio.contrib.workflow_streams import WorkflowStream
+
+with workflow.unsafe.imports_passed_through():
+    from pydantic_ai import Agent
+    from pydantic_ai.durable_exec.temporal import TemporalAgent
+    from pydantic_ai.messages import ModelMessage
+
+    from temporal_agent_harness.ai_sdks.pydantic_ai_harness import (
+        HarnessDeps,
+        build_harness_toolset,
+        harness_event_stream_handler,
+    )
+    from temporal_agent_harness.harness import agent
+    from temporal_agent_harness.harness.agent_protocol import (
+        AgentConfig,
+        TextMessage,
+        TextReply,
+        ToolApprovalPolicy,
+    )
+    from temporal_agent_harness.harness.agent_workflow import AgentWorkflowRunner
+
+
+TASK_QUEUE = "pydantic-ai-hello"
+AGENT_NAME = "pydantic-ai-hello"
+DEFAULT_MODEL = "openai:gpt-5.1"
+TOOLSET_ID = "hello-tools"
+
+SYSTEM_INSTRUCTION = """\
+You are a friendly assistant. Answer the user in brief, natural prose.
+
+You have one tool, `get_weather`, which returns the current weather for a city. When the user
+asks about the weather somewhere, call it (don't guess), then tell them the answer in a sentence
+or two. For anything else, just reply directly."""
+
+
+@agent.tool_defn(inherently_safe=True)
+async def get_weather(city: str) -> str:
+    """Return the current weather for a city. `city` is a plain city name, e.g. "Paris"."""
+    # Canned lookup — a hello-world, not a real weather service.
+    return f"It's 72°F and sunny in {city}."
+
+
+# Built once at module load: harness tools adapted into a Pydantic AI FunctionToolset, plus the
+# tool_activity_config that disables Temporal's per-tool activity wrapper so each call runs
+# in-workflow (where the harness approval gate + tool events live, and the runner is on deps).
+_TOOLSET, _TOOL_CONFIG = build_harness_toolset([get_weather], id=TOOLSET_ID)
+
+# The durable agent. Its activities (model_request(_stream), event_stream_handler, and the toolset's
+# call_tool) are registered on the worker via AgentPlugin(_TEMPORAL_AGENT). deps_type=HarnessDeps
+# lets Temporal (de)serialize the per-turn stream context that rides on deps into the model activity.
+_TEMPORAL_AGENT = TemporalAgent(
+    Agent(
+        DEFAULT_MODEL,
+        instructions=SYSTEM_INSTRUCTION,
+        deps_type=HarnessDeps,
+        toolsets=[_TOOLSET],
+    ),
+    name=AGENT_NAME,
+    event_stream_handler=harness_event_stream_handler,
+    tool_activity_config=_TOOL_CONFIG,
+)
+
+
+@workflow.defn(name="PydanticAIHelloAgent")
+@agent.defn
+class PydanticAIHelloAgentWorkflow:
+    """A one-tool conversational agent driven by Pydantic AI."""
+
+    @workflow.init
+    def __init__(self, config: AgentConfig) -> None:
+        self._runner = AgentWorkflowRunner(
+            config,
+            stream=WorkflowStream(),
+            # Hello-world stance: don't gate tool calls. A caller can tighten this per session via
+            # AgentConfig.approval_policy.
+            approval_policy_default=ToolApprovalPolicy.dangerously_skip_all(),
+        )
+        # Pydantic AI conversation state, threaded across turns as its message history.
+        self._history: list[ModelMessage] = []
+
+    @workflow.run
+    async def run(self, _config: AgentConfig) -> None:
+        await self._runner.run(self)
+
+    @agent.accepts
+    async def ask(self, message: TextMessage) -> TextReply:
+        """Chat with the assistant. Ask it anything; ask about the weather in a city and it calls
+        its `get_weather` tool and tells you what it found."""
+        # Thread the runner EXPLICITLY through deps (not assumed off the workflow instance). Passing
+        # just the runner is enough: HarnessDeps snapshots the in-flight turn's stream context from
+        # it — the live runner is read in-workflow by the adapted tools, and the snapshotted context
+        # rides into the model activity where the streaming handler publishes.
+        result = await _TEMPORAL_AGENT.run(
+            message.text,
+            deps=HarnessDeps(runner=self._runner),
+            message_history=self._history,
+        )
+        self._history = result.all_messages()
+        return TextReply(text=str(result.output))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,13 @@ openai-agents = [
     "mcp>=1.9.4,<2",
     "temporalio[opentelemetry]>=1.30.0",
 ]
+# The Pydantic AI integration: temporal_agent_harness.ai_sdks.pydantic_ai_harness. Unlike the
+# openai-agents/genai integrations, the upstream plugin (pydantic_ai.durable_exec.temporal, shipped
+# in pydantic-ai-slim[temporal]) is used UNMODIFIED — its first-class `event_stream_handler` hook is
+# the streaming seam the harness needs, so there is nothing to vendor and only a thin glue module.
+pydantic-ai = [
+    "pydantic-ai-slim[temporal]>=2.13",
+]
 # Packaged FastAPI server and browser UI assets.
 ui = [
     "fastapi[standard]>=0.136.3",
@@ -54,6 +61,7 @@ examples = [
     "pydantic-monty>=0.0.18",  # the Monty sandbox the monty example runs scripts in
     "fastapi[standard]>=0.136.3",  # packaged web app used by the examples; pulls in uvicorn
     "openai-agents>=0.17.5",  # the OpenAI Agents SDK example (examples/openai_hello)
+    "pydantic-ai-slim[temporal]>=2.13",  # the Pydantic AI example (examples/pydantic_ai_hello)
 ]
 # Test + lint tooling. The full tests/ suite imports both the Gemini SDK (the ai_sdks plugin
 # tests) and pydantic-monty (the monty example tests), which live in the `examples` group —
@@ -70,6 +78,8 @@ dev = [
     "openai-agents>=0.17.5",
     "mcp>=1.9.4,<2",
     "temporalio[opentelemetry]>=1.30.0",
+    # Pydantic AI integration (the ai_sdks glue + its tests) — mirrors the `pydantic-ai` extra.
+    "pydantic-ai-slim[temporal]>=2.13",
     { include-group = "examples" },
 ]
 

--- a/temporal_agent_harness/ai_sdks/__init__.py
+++ b/temporal_agent_harness/ai_sdks/__init__.py
@@ -5,4 +5,7 @@ can use the SDK it already knows while inheriting Temporal's durability, retries
 observability. One subpackage per SDK; more are expected over time.
 
   * :mod:`temporal_agent_harness.ai_sdks.google_genai_plugin` — the Google Gemini SDK.
+  * :mod:`temporal_agent_harness.ai_sdks.openai_agents` — the OpenAI Agents SDK.
+  * :mod:`temporal_agent_harness.ai_sdks.pydantic_ai_harness` — Pydantic AI (glue for the
+    unmodified upstream ``pydantic_ai.durable_exec.temporal`` plugin).
 """

--- a/temporal_agent_harness/ai_sdks/pydantic_ai_harness.py
+++ b/temporal_agent_harness/ai_sdks/pydantic_ai_harness.py
@@ -1,0 +1,512 @@
+# ABOUTME: Harness-owned glue for the (unmodified, upstream) Pydantic AI Temporal plugin
+# (`pydantic_ai.durable_exec.temporal`). Unlike the vendored OpenAI/Gemini trees — which the
+# harness had to modify to add a streaming seam — Pydantic AI already ships a first-class
+# `event_stream_handler` hook that runs INSIDE the model-request activity on the live
+# `AgentStreamEvent` stream, which is exactly the seam the harness needs. So there is nothing to
+# vendor: this module only translates that hook's raw events into the harness turn-stream
+# vocabulary (`PydanticAIStreamObserver` / `harness_event_stream_handler`) and adapts harness tools
+# onto the SDK (`as_pydantic_ai_tool(s)` / `build_harness_toolset`). Mirrors the structure of
+# `openai_agents_harness.py`.
+
+"""Harness integration for the Pydantic AI Temporal plugin.
+
+Wire it onto a worker with the upstream plugin, unmodified:
+
+>>> from pydantic_ai import Agent
+>>> from pydantic_ai.durable_exec.temporal import AgentPlugin, PydanticAIPlugin, TemporalAgent
+>>> from temporal_agent_harness.ai_sdks.pydantic_ai_harness import (
+...     build_harness_toolset,
+...     harness_event_stream_handler,
+... )
+>>> toolset, tool_config = build_harness_toolset([my_tool], id="my-tools")
+>>> agent = Agent("openai:gpt-5.1", toolsets=[toolset])
+>>> temporal_agent = TemporalAgent(
+...     agent,
+...     name="my-agent",
+...     event_stream_handler=harness_event_stream_handler,
+...     tool_activity_config=tool_config,  # run harness tools in-workflow, not in an activity
+... )
+>>> # worker: Worker(..., plugins=[AgentPlugin(temporal_agent)]); client: plugins=[PydanticAIPlugin()]
+
+Then, inside the agent workflow, call ``await temporal_agent.run(text, deps=deps)`` where
+``deps`` carries the in-flight turn's stream context (see :class:`HarnessDeps`); the streamed
+model call publishes ``reply_delta`` / ``thought_summary`` / ``tool_requested`` and
+``model_interaction_started`` / ``…_ended`` onto the harness turn stream live — the same vocabulary
+the Gemini and OpenAI integrations produce.
+
+.. warning::
+    Streaming support is experimental and may change in future versions.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterable, Awaitable, Callable, Mapping, Sequence
+from contextlib import AsyncExitStack
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic_core import to_jsonable_python
+
+_INSTALL_MESSAGE = (
+    "Pydantic AI support requires the optional `pydantic-ai` extra. "
+    "Install it with `uv sync --extra pydantic-ai` or "
+    "`pip install 'temporal-agent-harness[pydantic-ai]'`."
+)
+
+try:
+    from pydantic_ai import FunctionToolset, Tool
+    from pydantic_ai.messages import (
+        BaseToolCallPart,
+        PartDeltaEvent,
+        PartEndEvent,
+        PartStartEvent,
+        TextPart,
+        TextPartDelta,
+        ThinkingPart,
+        ThinkingPartDelta,
+    )
+    from pydantic_ai.models import StreamedResponse
+    from pydantic_ai.tools import RunContext
+except ImportError as exc:  # pragma: no cover - exercised only without the extra
+    raise RuntimeError(_INSTALL_MESSAGE) from exc
+
+from temporal_agent_harness.harness.agent_protocol import (
+    ModelInteractionEnded,
+    ModelInteractionStarted,
+    ReplyDelta,
+    ThoughtSummaryDelta,
+    TokenUsage,
+    ToolRequested,
+)
+from temporal_agent_harness.harness.agent_workflow import (
+    AgentWorkflowRunner,
+    TurnEventPublisher,
+)
+from temporal_agent_harness.harness.stream_context import TurnStreamContext
+
+if TYPE_CHECKING:
+    from pydantic_ai.messages import AgentStreamEvent
+
+__all__ = [
+    "HarnessDeps",
+    "PydanticAIStreamObserver",
+    "harness_event_stream_handler",
+    "as_pydantic_ai_tool",
+    "as_pydantic_ai_tools",
+    "build_harness_toolset",
+]
+
+_HARNESS_TOOL_ATTRS = ("__agent_tool__", "__agent_activity_tool__")
+
+
+# ---------------------------------------------------------------------------
+# Live streaming: raw Pydantic AI stream events -> harness turn vocabulary
+# ---------------------------------------------------------------------------
+#
+# Pydantic AI's Temporal plugin runs the agent's `event_stream_handler` INSIDE the model-request
+# activity, handing it the live `StreamedResponse` (an async iterable of `ModelResponseStreamEvent`s:
+# PartStart / PartDelta / PartEnd / FinalResult). That is where this observer translates, so — like
+# the Gemini `_StreamEventPublisher` — it works in part/delta terms rather than the flat event
+# vocabulary the OpenAI Responses stream uses:
+#
+#   * reply text arrives as a `TextPart`'s initial `content` on its PartStart, then as
+#     `TextPartDelta.content_delta` on each PartDelta — publish both straight through as
+#     `reply_delta` (they are disjoint fragments, so there is no double count).
+#   * `ThinkingPart` / `ThinkingPartDelta` -> `thought_summary` (capability-gated, dumped raw so a
+#     consumer can position it).
+#   * a custom tool call streams as a `ToolCallPart`: name + id + JSON args accumulate across
+#     PartStart/PartDelta, and Pydantic AI synthesizes a PartEnd carrying the COMPLETE part. We emit
+#     ONE consolidated `tool_requested` at that PartEnd, keyed by the SDK `tool_call_id` — the same
+#     id `as_pydantic_ai_tool` hands to `run_tool`, so `tool_requested` and the eventual
+#     `tool_start` / `tool_end` share a `tool_id`.
+#
+# As with Gemini/OpenAI, `run_tool` OWNS `tool_start` / `tool_end` / `tool_error`; this translator
+# only emits `tool_requested`. Hosted/native tool spans are deferred (as in the OpenAI integration).
+
+
+class PydanticAIStreamObserver:
+    """Translate one streamed Pydantic AI model call into harness turn events, live.
+
+    A :class:`StreamObserver` — one instance per streamed call, so its per-call state (pending
+    tool-call parts, captured usage) never bleeds across the concurrent calls a shared worker runs.
+    Constructed with the call's :class:`TurnStreamContext` and the requested ``model`` id; opens a
+    :class:`TurnEventPublisher` on ``__aenter__`` and publishes ``model_interaction_started`` THERE —
+    at model-call dispatch, before the first event — so the started→ended span measures the true
+    model-call latency (time-to-first-token included). ``on_event`` folds each raw event into harness
+    vocabulary; ``__aexit__`` closes the bracket with ``…_ended`` carrying usage recorded via
+    :meth:`set_usage`.
+    """
+
+    def __init__(self, context: TurnStreamContext, *, model: str | None = None) -> None:
+        self._context = context
+        # The requested model id, known at dispatch, so BOTH brackets name it. Never read from the
+        # stream: doing so would delay `started` past the first event and corrupt the latency.
+        self._model = model
+        self._stack: AsyncExitStack | None = None
+        self._publisher: TurnEventPublisher | None = None
+        # Part index -> the tool-call part seen at PartStart, flushed on the matching PartEnd (or,
+        # defensively, on close if the stream ended without one).
+        self._pending_tool_calls: dict[int, BaseToolCallPart] = {}
+        # Token usage, recorded off the drained StreamedResponse for the ended bracket.
+        self._usage: TokenUsage | None = None
+
+    async def __aenter__(self) -> PydanticAIStreamObserver:
+        self._stack = AsyncExitStack()
+        self._publisher = await self._stack.enter_async_context(
+            AgentWorkflowRunner.publisher_from_activity(self._context)
+        )
+        # Open the model-interaction span at dispatch, before awaiting any event.
+        self._publisher.publish(ModelInteractionStarted(model=self._model))
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool | None:
+        try:
+            if self._publisher is not None:
+                # Flush any tool call whose PartEnd never arrived (defensive — Pydantic AI
+                # synthesizes PartEnd for tool-call parts), then always close the started bracket
+                # (usage stays None if the stream errored). Published while the publisher is open.
+                for part in self._pending_tool_calls.values():
+                    self._emit_tool_requested(self._publisher, part)
+                self._pending_tool_calls.clear()
+                self._publisher.publish(
+                    ModelInteractionEnded(model=self._model, usage=self._usage)
+                )
+        finally:
+            if self._stack is not None:
+                await self._stack.aclose()
+                self._stack = None
+            self._publisher = None
+        # Never swallow a stream error: the batched-collect path owns failures.
+        return False
+
+    def set_usage(self, usage: Any) -> None:
+        """Record the call's usage (a Pydantic AI ``RequestUsage``/``RunUsage``) for the ended
+        bracket. Called after the stream is drained, before ``__aexit__``."""
+        self._usage = _to_token_usage(usage)
+
+    async def on_event(self, event: AgentStreamEvent) -> None:
+        """Fold one raw model-stream event into harness vocabulary."""
+        pub = self._publisher
+        if pub is None:
+            return
+
+        if isinstance(event, PartStartEvent):
+            part = event.part
+            if isinstance(part, TextPart):
+                if part.content:
+                    pub.publish(ReplyDelta(text=part.content))
+            elif isinstance(part, ThinkingPart):
+                if part.content:
+                    pub.publish(ThoughtSummaryDelta(delta=_dump(part)))
+            elif isinstance(part, BaseToolCallPart):
+                # A tool call is opening; its args may still stream. Hold it and publish one
+                # consolidated tool_requested on the part's PartEnd.
+                self._pending_tool_calls[event.index] = part
+        elif isinstance(event, PartDeltaEvent):
+            delta = event.delta
+            if isinstance(delta, TextPartDelta):
+                if delta.content_delta:
+                    pub.publish(ReplyDelta(text=delta.content_delta))
+            elif isinstance(delta, ThinkingPartDelta):
+                if delta.content_delta or delta.signature_delta:
+                    pub.publish(ThoughtSummaryDelta(delta=_dump(delta)))
+            # A ToolCallPartDelta streams arg fragments; the COMPLETE part arrives on PartEnd, so
+            # there is nothing to consolidate here.
+        elif isinstance(event, PartEndEvent):
+            if isinstance(event.part, BaseToolCallPart):
+                self._pending_tool_calls.pop(event.index, None)
+                self._emit_tool_requested(pub, event.part)
+
+    def _emit_tool_requested(
+        self, pub: TurnEventPublisher, part: BaseToolCallPart
+    ) -> None:
+        """Publish the consolidated ``tool_requested`` for one custom tool call.
+
+        ``tool_id`` is the SDK ``tool_call_id`` (shared with the execution lifecycle in
+        ``run_tool`` via ``RunContext.tool_call_id``). ``args_as_dict`` is best-effort for
+        display/approval; the workflow-side reducer does the authoritative parse on its own copy."""
+        pub.publish(
+            ToolRequested(
+                tool_id=part.tool_call_id,
+                tool_name=part.tool_name,
+                tool_input=_args_as_dict(part),
+            )
+        )
+
+
+def _dump(obj: Any) -> dict[str, Any]:
+    """Dump a Pydantic AI message part/delta (a dataclass) to a JSON-safe dict."""
+    dumped = to_jsonable_python(obj)
+    return dumped if isinstance(dumped, dict) else {"value": dumped}
+
+
+def _args_as_dict(part: BaseToolCallPart) -> dict[str, Any]:
+    """Best-effort dict of a tool call's arguments for display/approval (never raises)."""
+    try:
+        args = part.args_as_dict()
+    except Exception:  # noqa: BLE001 - display-only; a malformed payload must not break streaming
+        return {}
+    return args if isinstance(args, dict) else {}
+
+
+def _to_token_usage(usage: Any) -> TokenUsage | None:
+    """Map Pydantic AI's ``RequestUsage``/``RunUsage`` onto the harness's provider-agnostic
+    :class:`TokenUsage`. ``None`` in → ``None`` out. Reasoning tokens are not a first-class field
+    upstream — they ride in ``details['reasoning_tokens']`` — and there is no separate tool-use
+    count, so that stays ``None``."""
+    if usage is None:
+        return None
+    details = getattr(usage, "details", None) or {}
+    total = getattr(usage, "total_tokens", None)
+    return TokenUsage(
+        input_tokens=getattr(usage, "input_tokens", None),
+        output_tokens=getattr(usage, "output_tokens", None),
+        thought_tokens=details.get("reasoning_tokens"),
+        cached_tokens=getattr(usage, "cache_read_tokens", None) or None,
+        tool_use_tokens=None,
+        total_tokens=total,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The event_stream_handler wired onto the TemporalAgent
+# ---------------------------------------------------------------------------
+
+
+class HarnessDeps(BaseModel):
+    """A ready ``deps`` type (or base to subclass) carrying the harness per-run handles.
+
+    Build it per turn from just the runner and pass it to ``agent.run(...)``::
+
+        await temporal_agent.run(message.text, deps=HarnessDeps(runner=self._runner))
+
+    You pass only ``runner``; the initializer snapshots ``harness_stream_context`` from
+    ``runner.current_stream_context`` for you. Both are needed because they are consumed in different
+    places: the ``runner`` stays a live in-workflow reference the harness tools read off ``ctx.deps``,
+    while ``harness_stream_context`` must be resolved workflow-side and carried across into the model
+    activity — that is where the streaming handler runs, and the (non-serializable) runner cannot
+    follow it there. So the snapshot has to happen here, on the workflow side.
+
+    ``runner`` is ``Field(exclude=True)``: it is dropped when ``deps`` is serialized into the model
+    activity, so a non-serializable runtime object never crosses the activity boundary (the handler
+    there only needs the already-snapshotted context). Subclass to add your own dependencies; the
+    harness only reads these two attributes. Pass ``harness_stream_context`` explicitly to override
+    the snapshot (e.g. in tests).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    runner: AgentWorkflowRunner | None = Field(default=None, exclude=True, repr=False)
+    harness_stream_context: TurnStreamContext | None = None
+
+    @model_validator(mode="after")
+    def _snapshot_stream_context(self) -> HarnessDeps:
+        # Convenience: given just a runner, capture the in-flight turn's stream context here, on the
+        # workflow side, where the runner is live. Skipped when the caller already supplied a context
+        # (explicit override), and a no-op on deserialization inside the activity (runner is dropped
+        # by exclude=True, so it is None there while harness_stream_context is already populated).
+        if self.runner is not None and self.harness_stream_context is None:
+            self.harness_stream_context = self.runner.current_stream_context
+        return self
+
+
+def _resolve_stream_context(ctx: RunContext[Any]) -> TurnStreamContext | None:
+    """Read the turn stream context off ``ctx.deps`` (``None`` when absent / not a harness turn).
+
+    Robust to the deps arriving either fully typed (a real :class:`TurnStreamContext`, when the
+    agent's ``deps_type`` declares it) or as a plain dict (an untyped payload)."""
+    deps = getattr(ctx, "deps", None)
+    raw = getattr(deps, "harness_stream_context", None) if deps is not None else None
+    if raw is None:
+        return None
+    if isinstance(raw, TurnStreamContext):
+        return raw
+    return TurnStreamContext.model_validate(raw)
+
+
+async def harness_event_stream_handler(
+    ctx: RunContext[Any], stream: AsyncIterable[AgentStreamEvent]
+) -> None:
+    """Pydantic AI ``event_stream_handler`` that streams model events onto the harness turn.
+
+    Pass as ``TemporalAgent(event_stream_handler=harness_event_stream_handler)``. Pydantic AI
+    invokes it in two places, both of which this handler must fully drain:
+
+    * inside the ``…__model_request_stream`` activity, on the live :class:`StreamedResponse` — the
+      model-delta path this integration cares about. We drive a :class:`PydanticAIStreamObserver`
+      over it and record final usage for the ended bracket.
+    * once per ``…__event_stream_handler`` activity for each in-workflow ``HandleResponseEvent``
+      (tool call/result). The harness owns tool lifecycle via ``run_tool``, so this handler no-ops
+      those — one lightweight activity per response event, inherent to setting a handler.
+
+    With no harness turn context on ``deps`` (e.g. outside a harness-driven run), it drains the
+    stream and publishes nothing.
+    """
+    context = _resolve_stream_context(ctx)
+    if context is None or not isinstance(stream, StreamedResponse):
+        # No turn to publish against, or the per-response-event path — drain and ignore.
+        async for _ in stream:
+            pass
+        return
+
+    model = getattr(stream, "model_name", None)
+    async with PydanticAIStreamObserver(context, model=model) as obs:
+        async for event in stream:
+            await obs.on_event(event)
+        # Final usage is known only once the stream is exhausted.
+        try:
+            obs.set_usage(stream.usage())
+        except Exception:  # noqa: BLE001 - usage is best-effort; never fail the model activity
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Tool adapter: harness tools -> Pydantic AI Tools (executed in-workflow via run_tool)
+# ---------------------------------------------------------------------------
+
+
+def as_pydantic_ai_tool(
+    tool_callable: Callable[..., Awaitable[Any]],
+    *,
+    injections: Mapping[str, Any] | None = None,
+) -> "Tool[Any]":
+    """Adapt a harness tool into a Pydantic AI :class:`~pydantic_ai.Tool`.
+
+    ``tool_callable`` must be produced by :func:`harness.agent.tool_defn`,
+    :func:`harness.agent.activity_tool_defn`, or :func:`harness.agent.subagent_toolset`. The
+    returned tool invokes ``runner.run_tool(...)`` for every model tool call, so the harness remains
+    responsible for approval-policy evaluation, ``tool_start`` / ``tool_end`` / ``tool_error``
+    events, ``Injected[...]`` parameters, and activity-backed execution.
+
+    The runner is resolved per call from ``ctx.deps`` (a :class:`HarnessDeps`) — threaded
+    EXPLICITLY by the author at the ``agent.run(deps=...)`` call site, not assumed off the workflow
+    instance. This is what lets one module-level ``TemporalAgent`` serve every concurrent workflow
+    correctly: each run supplies its own runner via its own ``deps``.
+
+    The tool MUST run in-workflow (the harness approval gate and event publishing are workflow-side),
+    so register it with the Temporal activity wrapper DISABLED — use :func:`build_harness_toolset`,
+    which returns the matching ``tool_activity_config`` for ``TemporalAgent``. (When wrongly run
+    inside an activity, ``ctx.deps`` has no live ``runner`` and the call raises with guidance.)
+    """
+    _require_harness_tool(tool_callable)
+    name, description, json_schema = _tool_schema(tool_callable)
+
+    async def on_invoke_tool(ctx: RunContext[Any], **kwargs: Any) -> Any:
+        runner = _runner_from_ctx(ctx, tool_name=name)
+        try:
+            return await runner.run_tool(
+                ctx.tool_call_id,
+                tool_callable,
+                injections=injections,
+                **kwargs,
+            )
+        except Exception as exc:  # noqa: BLE001 - surface as a model-visible tool failure
+            # Mirror the OpenAI adapter: a denied/failed tool becomes a result the model sees and
+            # moves past, rather than crashing the turn.
+            return f"Tool {name!r} failed: {exc}"
+
+    return Tool.from_schema(
+        on_invoke_tool,
+        name=name,
+        description=description,
+        json_schema=json_schema,
+        takes_ctx=True,
+    )
+
+
+def as_pydantic_ai_tools(
+    tool_callables: (
+        Mapping[str, Callable[..., Awaitable[Any]]]
+        | Sequence[Callable[..., Awaitable[Any]]]
+    ),
+    *,
+    injections: Mapping[str, Any] | None = None,
+) -> list["Tool[Any]"]:
+    """Adapt several harness tools into Pydantic AI tools."""
+    tools = (
+        list(tool_callables.values())
+        if isinstance(tool_callables, Mapping)
+        else list(tool_callables)
+    )
+    return [as_pydantic_ai_tool(tool, injections=injections) for tool in tools]
+
+
+def build_harness_toolset(
+    tool_callables: (
+        Mapping[str, Callable[..., Awaitable[Any]]]
+        | Sequence[Callable[..., Awaitable[Any]]]
+    ),
+    *,
+    id: str = "harness_tools",
+    injections: Mapping[str, Any] | None = None,
+) -> tuple["FunctionToolset[Any]", dict[str, dict[str, Literal[False]]]]:
+    """Build a Pydantic AI ``FunctionToolset`` of harness tools plus the ``tool_activity_config``
+    that disables the Temporal activity wrapper for them.
+
+    Returns ``(toolset, tool_activity_config)``. Build it once (module level is fine — no runner is
+    captured here; each run supplies its runner via ``deps``) and wire both onto the agent::
+
+        toolset, tool_config = build_harness_toolset([get_weather], id="hello-tools")
+        agent = Agent("openai:gpt-5.1", toolsets=[toolset])
+        temporal_agent = TemporalAgent(agent, name="hello", tool_activity_config=tool_config, ...)
+
+    The config maps ``{id: {tool_name: False}}`` so each (async) harness tool runs in-workflow —
+    required for the harness approval gate (``workflow.wait_condition``), its in-process tool
+    lifecycle events, and reading the live runner off ``deps``. Without it, Pydantic AI would offload
+    each call into its own activity, where none of that works.
+    """
+    tools = as_pydantic_ai_tools(tool_callables, injections=injections)
+    toolset = FunctionToolset(tools, id=id)
+    tool_config: dict[str, dict[str, Literal[False]]] = {
+        id: {tool.name: False for tool in tools}
+    }
+    return toolset, tool_config
+
+
+def _tool_schema(
+    tool_callable: Callable[..., Any],
+) -> tuple[str, str, dict[str, Any]]:
+    """Derive ``(name, description, params_json_schema)`` for a harness tool.
+
+    The harness tool decorators stamp the returned object with a MODEL-FACING ``__signature__`` /
+    ``__annotations__`` (``self`` and ``Injected[...]`` parameters already stripped), so letting
+    Pydantic AI introspect it directly yields exactly the schema the model should see — the same
+    approach the Gemini ``function_param`` helper uses with Gemini's own introspector. We build a
+    throwaway ``Tool`` (never executed) purely to reuse Pydantic AI's schema generation, then hand
+    the schema to :meth:`Tool.from_schema` alongside our own run_tool-backed callable."""
+    probe = Tool(tool_callable, takes_ctx=False)
+    schema = probe.function_schema
+    name = getattr(tool_callable, "__name__", probe.name)
+    description = schema.description or (tool_callable.__doc__ or "").strip()
+    return name, description, schema.json_schema
+
+
+def _require_harness_tool(tool_callable: Callable[..., Any]) -> None:
+    if any(getattr(tool_callable, attr, False) for attr in _HARNESS_TOOL_ATTRS):
+        return
+    name = getattr(tool_callable, "__name__", repr(tool_callable))
+    raise TypeError(
+        f"{name} is not a harness tool; decorate it with @agent.tool_defn, "
+        "@agent.activity_tool_defn, or use agent.subagent_toolset(...)."
+    )
+
+
+def _runner_from_ctx(ctx: RunContext[Any], *, tool_name: str) -> AgentWorkflowRunner:
+    """Read the live :class:`AgentWorkflowRunner` the author threaded onto ``ctx.deps``.
+
+    This is the explicit-threading contract (see :class:`HarnessDeps`): the runner is NOT assumed off
+    ``workflow.instance()`` — it is whatever the author passed as ``agent.run(deps=HarnessDeps(
+    runner=...))``. A harness tool runs in-workflow, where ``deps`` is still that live object, so the
+    runner is available here. If it is missing, the tool was most likely run inside a Temporal
+    activity (its ``tool_activity_config`` wrapper was not disabled) or ``deps`` did not carry the
+    runner; raise with guidance."""
+    runner = getattr(getattr(ctx, "deps", None), "runner", None)
+    if not isinstance(runner, AgentWorkflowRunner):
+        raise RuntimeError(
+            f"harness Pydantic AI tool {tool_name!r} has no live AgentWorkflowRunner on its "
+            "RunContext.deps. Pass deps=HarnessDeps(runner=<your runner>) to agent.run(...), and "
+            "make sure the tool runs in-workflow (use build_harness_toolset(...) so its Temporal "
+            "activity wrapper is disabled)."
+        )
+    return runner

--- a/tests/ai_sdks/pydantic_ai/test_pydantic_stream_observer.py
+++ b/tests/ai_sdks/pydantic_ai/test_pydantic_stream_observer.py
@@ -1,0 +1,342 @@
+# ABOUTME: Unit-tests the Pydantic AI live translator (PydanticAIStreamObserver) and tool adapter in
+# isolation — replays a synthetic sequence of raw Pydantic AI model-stream events (PartStart /
+# PartDelta / PartEnd) through the observer with a fake in-memory publisher (no Temporal server, no
+# API key) and asserts the emitted harness turn-stream vocabulary: the model-interaction bracket,
+# reply/thought deltas, a single consolidated tool_requested keyed by the SDK tool_call_id, and
+# mapped token usage. Also checks that as_pydantic_ai_tool / build_harness_toolset derive the right
+# schema + activity-skip config from a harness tool.
+#
+# Run with: uv run pytest tests/ai_sdks/pydantic_ai/test_stream_observer.py -v
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+
+from pydantic_ai.messages import (
+    PartDeltaEvent,
+    PartEndEvent,
+    PartStartEvent,
+    TextPart,
+    TextPartDelta,
+    ThinkingPart,
+    ThinkingPartDelta,
+    ToolCallPart,
+    ToolCallPartDelta,
+)
+from pydantic_ai.usage import RequestUsage
+
+from temporal_agent_harness.ai_sdks import pydantic_ai_harness as h
+from temporal_agent_harness.harness import agent
+from temporal_agent_harness.harness.agent_protocol import (
+    AgentEventType,
+    ModelInteractionEnded,
+    ModelInteractionStarted,
+    ReplyDelta,
+    ThoughtSummaryDelta,
+    ToolRequested,
+)
+from temporal_agent_harness.harness.agent_workflow import AgentWorkflowRunner
+from temporal_agent_harness.harness.stream_context import TurnStreamContext
+
+
+class _FakePublisher:
+    """Stands in for TurnEventPublisher: records every published payload."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def publish(self, event: Any) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture
+def fake_publisher(monkeypatch: pytest.MonkeyPatch) -> _FakePublisher:
+    """Replace publisher_from_activity so the observer's real __aenter__/__aexit__
+    (and thus the model-interaction bracket) run against an in-memory sink."""
+    pub = _FakePublisher()
+
+    @asynccontextmanager
+    async def _fake_publisher_from_activity(context: Any, **_kw: Any):
+        yield pub
+
+    monkeypatch.setattr(
+        AgentWorkflowRunner,
+        "publisher_from_activity",
+        staticmethod(_fake_publisher_from_activity),
+    )
+    return pub
+
+
+def _text_start(index: int, content: str) -> PartStartEvent:
+    return PartStartEvent(index=index, part=TextPart(content=content))
+
+
+def _text_delta(index: int, content: str) -> PartDeltaEvent:
+    return PartDeltaEvent(index=index, delta=TextPartDelta(content_delta=content))
+
+
+def _thinking_start(index: int, content: str) -> PartStartEvent:
+    return PartStartEvent(index=index, part=ThinkingPart(content=content))
+
+
+def _thinking_delta(index: int, content: str) -> PartDeltaEvent:
+    return PartDeltaEvent(index=index, delta=ThinkingPartDelta(content_delta=content))
+
+
+def _tool_start(index: int, call_id: str, name: str) -> PartStartEvent:
+    return PartStartEvent(
+        index=index, part=ToolCallPart(tool_name=name, args="", tool_call_id=call_id)
+    )
+
+
+def _tool_args_delta(index: int, call_id: str, fragment: str) -> PartDeltaEvent:
+    return PartDeltaEvent(
+        index=index,
+        delta=ToolCallPartDelta(args_delta=fragment, tool_call_id=call_id),
+    )
+
+
+def _tool_end(index: int, call_id: str, name: str, args: str) -> PartEndEvent:
+    return PartEndEvent(
+        index=index, part=ToolCallPart(tool_name=name, args=args, tool_call_id=call_id)
+    )
+
+
+def _usage() -> RequestUsage:
+    return RequestUsage(
+        input_tokens=11,
+        output_tokens=22,
+        cache_read_tokens=5,
+        details={"reasoning_tokens": 7},
+    )
+
+
+async def _drive(
+    events: list[Any],
+    context: TurnStreamContext,
+    *,
+    model: str | None = "openai:gpt-5.1",
+    usage: RequestUsage | None = None,
+) -> None:
+    async with h.PydanticAIStreamObserver(context, model=model) as obs:
+        for event in events:
+            await obs.on_event(event)
+        if usage is not None:
+            obs.set_usage(usage)
+
+
+@pytest.mark.asyncio
+async def test_full_turn_translates_to_harness_vocabulary(fake_publisher: _FakePublisher):
+    ctx = TurnStreamContext(turn_id="t-1", turn_number=1, agent_id="agent-abc")
+    events = [
+        _text_start(0, "Hel"),
+        _text_delta(0, "lo"),
+        _thinking_start(1, "thinking..."),
+        _thinking_delta(1, " more"),
+        _tool_start(2, "call_XYZ", "lookup"),
+        _tool_args_delta(2, "call_XYZ", '{"q":'),
+        _tool_args_delta(2, "call_XYZ", ' "cats"}'),
+        _tool_end(2, "call_XYZ", "lookup", '{"q": "cats"}'),
+    ]
+
+    await _drive(events, ctx, usage=_usage())
+
+    published = fake_publisher.events
+    # Bracket: exactly one started first (naming the requested model, emitted at dispatch), one last.
+    assert isinstance(published[0], ModelInteractionStarted)
+    assert published[0].model == "openai:gpt-5.1"
+    assert isinstance(published[-1], ModelInteractionEnded)
+
+    starts = [e for e in published if isinstance(e, ModelInteractionStarted)]
+    ends = [e for e in published if isinstance(e, ModelInteractionEnded)]
+    assert len(starts) == 1 and len(ends) == 1
+
+    # Reply text streamed through verbatim, in order: the TextPart's initial content on its
+    # PartStart, then each TextPartDelta fragment.
+    replies = [e for e in published if isinstance(e, ReplyDelta)]
+    assert [r.text for r in replies] == ["Hel", "lo"]
+
+    # Thinking surfaced from both the ThinkingPart start and its delta, payload preserved.
+    thoughts = [e for e in published if isinstance(e, ThoughtSummaryDelta)]
+    assert len(thoughts) == 2
+    assert thoughts[0].delta.get("content") == "thinking..."
+    assert thoughts[1].delta.get("content_delta") == " more"
+
+    # Exactly one consolidated tool_requested at PartEnd, keyed by the SDK tool_call_id, with the
+    # complete args from the finished part.
+    requested = [e for e in published if isinstance(e, ToolRequested)]
+    assert len(requested) == 1
+    assert requested[0].tool_id == "call_XYZ"
+    assert requested[0].tool_name == "lookup"
+    assert requested[0].tool_input == {"q": "cats"}
+
+    # Ended carries the model + mapped usage.
+    ended = ends[0]
+    assert ended.model == "openai:gpt-5.1"
+    assert ended.usage is not None
+    assert ended.usage.input_tokens == 11
+    assert ended.usage.output_tokens == 22
+    assert ended.usage.total_tokens == 33  # UsageBase.total_tokens == input + output
+    assert ended.usage.cached_tokens == 5
+    assert ended.usage.thought_tokens == 7
+    assert ended.usage.tool_use_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_tool_requested_flushed_on_close_without_part_end(fake_publisher: _FakePublisher):
+    # Defensive path: a tool-call part that opened (and streamed args) but whose PartEnd never
+    # arrived is still flushed as one tool_requested when the observer closes.
+    ctx = TurnStreamContext(turn_id="t-2", turn_number=1, agent_id="agent-abc")
+    events = [
+        _tool_start(0, "call_BUF", "search"),
+        _tool_args_delta(0, "call_BUF", '{"n": 42}'),
+    ]
+    await _drive(events, ctx)
+
+    requested = [e for e in fake_publisher.events if isinstance(e, ToolRequested)]
+    assert len(requested) == 1
+    assert requested[0].tool_id == "call_BUF"
+    assert requested[0].tool_name == "search"
+
+
+@pytest.mark.asyncio
+async def test_started_emitted_at_dispatch_before_any_event(fake_publisher: _FakePublisher):
+    # The started bracket must be published at __aenter__ — before any event is fed — so the
+    # started→ended span measures true model-call latency (time-to-first-token included).
+    ctx = TurnStreamContext(turn_id="t-4", turn_number=1, agent_id="agent-abc")
+    async with h.PydanticAIStreamObserver(ctx, model="openai:gpt-5.1") as obs:
+        assert len(fake_publisher.events) == 1
+        started = fake_publisher.events[0]
+        assert isinstance(started, ModelInteractionStarted)
+        assert started.model == "openai:gpt-5.1"
+        await obs.on_event(_text_start(0, "hi"))
+    assert isinstance(fake_publisher.events[-1], ModelInteractionEnded)
+
+
+@pytest.mark.asyncio
+async def test_bracket_closes_even_with_no_content(fake_publisher: _FakePublisher):
+    ctx = TurnStreamContext(turn_id="t-3", turn_number=1, agent_id="agent-abc")
+    # model=None here to exercise the degraded path (requested model unknown), no usage recorded.
+    await _drive([], ctx, model=None)
+    kinds = [e.type for e in fake_publisher.events]
+    assert kinds == [
+        AgentEventType.MODEL_INTERACTION_STARTED,
+        AgentEventType.MODEL_INTERACTION_ENDED,
+    ]
+    ended = fake_publisher.events[-1]
+    # No usage recorded -> stays None (e.g. stream errored before completing).
+    assert ended.usage is None and ended.model is None
+
+
+# ---------------------------------------------------------------------------
+# Tool adapter
+# ---------------------------------------------------------------------------
+
+
+@agent.tool_defn(inherently_safe=True)
+async def get_weather(city: str) -> str:
+    """Return the current weather for a city. `city` is a plain city name, e.g. "Paris"."""
+    return f"It's 72°F and sunny in {city}."
+
+
+def test_as_pydantic_ai_tool_derives_schema_from_harness_tool():
+    tool = h.as_pydantic_ai_tool(get_weather)
+    assert tool.name == "get_weather"
+    assert "weather" in (tool.description or "").lower()
+    schema = tool.function_schema.json_schema
+    assert "city" in schema.get("properties", {})
+    # Executes with a RunContext (harness owns the run via run_tool).
+    assert tool.takes_ctx is True
+
+
+def test_build_harness_toolset_returns_toolset_and_skip_config():
+    toolset, tool_config = h.build_harness_toolset([get_weather], id="hello-tools")
+    assert toolset.id == "hello-tools"
+    # The activity wrapper is disabled for every adapted tool so it runs in-workflow.
+    assert tool_config == {"hello-tools": {"get_weather": False}}
+
+
+def test_as_pydantic_ai_tool_rejects_non_harness_tool():
+    async def plain(x: int) -> int:
+        return x
+
+    with pytest.raises(TypeError):
+        h.as_pydantic_ai_tool(plain)
+
+
+class _FakeRunner(AgentWorkflowRunner):
+    """A test double for AgentWorkflowRunner: a real subclass (so it passes the adapter's
+    isinstance check and HarnessDeps' field validation) with a no-op __init__ that skips the heavy
+    workflow-bound construction, recording how the adapted tool invokes run_tool."""
+
+    def __init__(self, stream_context: TurnStreamContext | None = None) -> None:
+        self.calls: list[Any] = []
+        self._stream_context = stream_context
+
+    @property
+    def current_stream_context(self) -> TurnStreamContext | None:
+        return self._stream_context
+
+    async def run_tool(self, call_id: str, tool_callable: Any, /, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append((call_id, tool_callable, args, kwargs))
+        return "runner-result"
+
+
+class _FakeCtx:
+    """Minimal RunContext stand-in: only the fields the adapter reads."""
+
+    def __init__(self, deps: Any, tool_call_id: str) -> None:
+        self.deps = deps
+        self.tool_call_id = tool_call_id
+
+
+@pytest.mark.asyncio
+async def test_tool_reads_runner_off_deps_not_workflow_instance():
+    # The whole point of the fix: the runner is threaded EXPLICITLY via deps at the run(...) call
+    # site — never assumed off workflow.instance()._runner. Prove the adapter invokes run_tool on
+    # the runner it finds on ctx.deps, with the SDK tool_call_id as the correlation id.
+    runner = _FakeRunner()
+    tool = h.as_pydantic_ai_tool(get_weather)
+    ctx = _FakeCtx(deps=h.HarnessDeps(runner=runner), tool_call_id="call_ABC")
+
+    result = await tool.function(ctx, city="Paris")
+
+    assert result == "runner-result"
+    assert len(runner.calls) == 1
+    call_id, tool_callable, _args, kwargs = runner.calls[0]
+    assert call_id == "call_ABC"
+    assert tool_callable is get_weather
+    assert kwargs["city"] == "Paris"
+    assert kwargs["injections"] is None
+
+
+@pytest.mark.asyncio
+async def test_tool_raises_loudly_when_no_runner_on_deps():
+    # No runner on deps (e.g. wrongly run inside an activity, or deps didn't carry the runner) is a
+    # developer misconfiguration, so it fails loudly with guidance rather than being papered over.
+    tool = h.as_pydantic_ai_tool(get_weather)
+    ctx = _FakeCtx(deps=h.HarnessDeps(), tool_call_id="call_NONE")
+    with pytest.raises(RuntimeError, match="no live AgentWorkflowRunner"):
+        await tool.function(ctx, city="Paris")
+
+
+def test_harness_deps_snapshots_stream_context_from_runner():
+    # Ergonomics: pass just the runner; HarnessDeps captures the in-flight turn's stream context
+    # from it (resolved workflow-side, since the model-activity handler that consumes it can't reach
+    # the runner). The runner stays a live attribute but is excluded from serialization.
+    ctx = TurnStreamContext(turn_id="t-9", turn_number=3, agent_id="agent-abc")
+    runner = _FakeRunner(stream_context=ctx)
+
+    deps = h.HarnessDeps(runner=runner)
+    assert deps.harness_stream_context == ctx
+    assert deps.runner is runner
+    # Serialized form drops the runner and keeps the snapshotted context.
+    assert "runner" not in deps.model_dump()
+    assert deps.model_dump()["harness_stream_context"]["turn_id"] == "t-9"
+
+    # An explicit context overrides the snapshot rather than being clobbered.
+    other = TurnStreamContext(turn_id="t-override", turn_number=1, agent_id="agent-abc")
+    assert h.HarnessDeps(runner=runner, harness_stream_context=other).harness_stream_context == other

--- a/uv.lock
+++ b/uv.lock
@@ -950,6 +950,19 @@ wheels = [
 ]
 
 [[package]]
+name = "genai-prices"
+version = "0.0.71"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e4/5072862613fba039da2b7c981a8649c6c6bbcb2863bd8bc81617c09ce5ee/genai_prices-0.0.71.tar.gz", hash = "sha256:de4db34ec38404f9ef383cb1ab29e204d16ccf27071af0b16d5747ee7affe36b", size = 82105, upload-time = "2026-07-10T00:38:30.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/98/c06c1318f6834a26268a2d4280e4183f60c5ea92152aea841feff29826ff/genai_prices-0.0.71-py3-none-any.whl", hash = "sha256:1d13111563af2b1ce43ccfacf77b7ac3216ad704c644408a56e11b181fe0d128", size = 84586, upload-time = "2026-07-10T00:38:29.252Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.55.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1029,6 +1042,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/fe/6a3f9f1a8bb8733326140737446aaf72fddb8b54b8f202302f5c84960613/httpcore2-2.7.0.tar.gz", hash = "sha256:6dc0fedf329a52a990930a5579edfebaea81118ea700ea0dd7de2b5e5be49efc", size = 65593, upload-time = "2026-07-14T20:40:01.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/6c/62e2e279e63fc4f7a5ee841ef13175a8bbc613f258e9dcc186e9de803a42/httpcore2-2.7.0-py3-none-any.whl", hash = "sha256:1452f589fe23f55b44546cd884294c41a29330af902bc0b71a761fd52d18f92b", size = 81506, upload-time = "2026-07-14T20:39:58.053Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1093,6 +1119,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4a/129b2e21b90ac2985d3928d96792bccc39bc6dfe796c5eee2d8ec06d4105/httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07", size = 94487, upload-time = "2026-07-14T20:40:02.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/b8/c341bba6411bdfda786020343c47a75ef472f6085caf82391b142b1a3ad9/httpx2-2.7.0-py3-none-any.whl", hash = "sha256:ed2a2719c696789e09493bd8e2bec3d8bd925cc6e26b68389ec25ade132f7bf4", size = 90234, upload-time = "2026-07-14T20:39:59.531Z" },
 ]
 
 [[package]]
@@ -1350,6 +1392,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
     { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
     { url = "https://files.pythonhosted.org/packages/41/a0/b91504515c1f9a299fc157967ffbd2f0321bce0516a3d5b89f6f4cad0355/lazy_object_proxy-1.12.0-pp39.pp310.pp311.graalpy311-none-any.whl", hash = "sha256:c3b2e0af1f7f77c4263759c4824316ce458fabe0fceadcd24ef8ca08b2d1e402", size = 15072, upload-time = "2025-08-22T13:50:05.498Z" },
+]
+
+[[package]]
+name = "logfire-api"
+version = "4.38.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/1a/17af258260cf8378fabd10bacef0c585e19697eab1deea25f8e4f4fb6462/logfire_api-4.38.0.tar.gz", hash = "sha256:e773cd4a26edb48ef4ec6f88661d1c670bb68c303a71c7043a236d64a9699cd2", size = 90364, upload-time = "2026-07-20T12:15:34.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/22/598f988f293ce391e88baddeeaa1acaea625822653193935301e7149b5c6/logfire_api-4.38.0-py3-none-any.whl", hash = "sha256:6c0612d9200727b64b42eba6068d0d6afd45308f4b844ffd6290c2d33aa6a6f6", size = 140109, upload-time = "2026-07-20T12:15:31.973Z" },
 ]
 
 [[package]]
@@ -1978,6 +2029,29 @@ email = [
 ]
 
 [[package]]
+name = "pydantic-ai-slim"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "genai-prices" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pydantic-graph" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/0e/33989e7bcd2abaefdc2534129055dce0943bbcdcc5212d2296f79fd604b7/pydantic_ai_slim-2.14.1.tar.gz", hash = "sha256:3ce0afde81cd50fcd434ccdd46774f4386bee8cc0ed3e75d7dc8784fdca303ff", size = 866335, upload-time = "2026-07-21T05:40:59.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/51/8682b564598571d7056971d62221fafda2ce513481cc241f3ac621e6460e/pydantic_ai_slim-2.14.1-py3-none-any.whl", hash = "sha256:64687be32deb8075eb99edba837a61d22daf1801cd3b1e6925e8519c13838934", size = 1050646, upload-time = "2026-07-21T05:40:52.205Z" },
+]
+
+[package.optional-dependencies]
+temporal = [
+    { name = "temporalio" },
+]
+
+[[package]]
 name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2090,6 +2164,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
+]
+
+[[package]]
+name = "pydantic-graph"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "logfire-api" },
+    { name = "pydantic" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/e7/db61f8c7a323feb55884ca701f138ae18911126628595375ff9d0d47397a/pydantic_graph-2.14.1.tar.gz", hash = "sha256:8f3a577a3ae278012d168c0db07a9bdf1b0021d21e48831c0b05518f2230730e", size = 43934, upload-time = "2026-07-21T05:41:02.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/03/ff2ee9174ea0083638c1e31b5f5c92ffd3e795024db23caa0ea297458cd5/pydantic_graph-2.14.1-py3-none-any.whl", hash = "sha256:4e4b2afb0751b5495fce9f253a5b4ccac9a0f86989fa7479ee8d517f76bd449f", size = 51658, upload-time = "2026-07-21T05:40:55.711Z" },
 ]
 
 [[package]]
@@ -2872,6 +2961,9 @@ openai-agents = [
     { name = "openai-agents" },
     { name = "temporalio", extra = ["opentelemetry"] },
 ]
+pydantic-ai = [
+    { name = "pydantic-ai-slim", extra = ["temporal"] },
+]
 s3 = [
     { name = "temporalio", extra = ["aioboto3"] },
 ]
@@ -2887,6 +2979,7 @@ dev = [
     { name = "mcp" },
     { name = "moto", extra = ["server"] },
     { name = "openai-agents" },
+    { name = "pydantic-ai-slim", extra = ["temporal"] },
     { name = "pydantic-monty" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2898,6 +2991,7 @@ examples = [
     { name = "google-auth" },
     { name = "google-genai" },
     { name = "openai-agents" },
+    { name = "pydantic-ai-slim", extra = ["temporal"] },
     { name = "pydantic-monty" },
 ]
 
@@ -2909,12 +3003,13 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'openai-agents'", specifier = ">=1.9.4,<2" },
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.17.5" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic-ai-slim", extras = ["temporal"], marker = "extra == 'pydantic-ai'", specifier = ">=2.13" },
     { name = "pydantic-monty", marker = "extra == 'code-mode'", specifier = ">=0.0.18" },
     { name = "temporalio", specifier = ">=1.30.0" },
     { name = "temporalio", extras = ["aioboto3"], marker = "extra == 's3'", specifier = ">=1.30.0" },
     { name = "temporalio", extras = ["opentelemetry"], marker = "extra == 'openai-agents'", specifier = ">=1.30.0" },
 ]
-provides-extras = ["genai", "s3", "openai-agents", "ui", "code-mode"]
+provides-extras = ["genai", "s3", "openai-agents", "pydantic-ai", "ui", "code-mode"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2924,6 +3019,7 @@ dev = [
     { name = "mcp", specifier = ">=1.9.4,<2" },
     { name = "moto", extras = ["server"], specifier = ">=5.2.1" },
     { name = "openai-agents", specifier = ">=0.17.5" },
+    { name = "pydantic-ai-slim", extras = ["temporal"], specifier = ">=2.13" },
     { name = "pydantic-monty", specifier = ">=0.0.18" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
@@ -2936,6 +3032,7 @@ examples = [
     { name = "google-auth", specifier = ">=2.53.0" },
     { name = "google-genai", specifier = ">=2.0.0" },
     { name = "openai-agents", specifier = ">=0.17.5" },
+    { name = "pydantic-ai-slim", extras = ["temporal"], specifier = ">=2.13" },
     { name = "pydantic-monty", specifier = ">=0.0.18" },
 ]
 
@@ -2987,6 +3084,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds the harness's third native AI-SDK integration, alongside Gemini and the OpenAI Agents SDK: **Pydantic AI** (`pydantic_ai.durable_exec.temporal`).

Key difference from the other two: OAI/Gemini were *vendored* because upstream had no streaming seam, so the harness had to add one. Pydantic AI's Temporal plugin already ships a **first-class `event_stream_handler` hook** that runs inside the model-request activity on the live `AgentStreamEvent` stream - exactly the seam the harness needs. So we depend on the upstream plugin **unmodified** and add only a thin glue module.

## Changes

- **`temporal_agent_harness/ai_sdks/pydantic_ai_harness.py`** (new glue):
  - `PydanticAIStreamObserver` - folds `PartStart/PartDelta/PartEnd` events into the harness turn vocabulary (`reply_delta` / `thought_summary` / one consolidated `tool_requested` keyed by `tool_call_id`), bracketed by `model_interaction_started/…_ended` with mapped `TokenUsage`. Same `StreamObserver` shape as `OpenAIStreamObserver`.
  - `harness_event_stream_handler` - the handler to wire onto a `TemporalAgent`; drives the observer over the model stream and no-ops the per-response-event path (the harness owns tool lifecycle via `run_tool`).
  - `as_pydantic_ai_tool(s)` / `build_harness_toolset` - adapt harness tools onto the SDK (routing every call through `runner.run_tool`), plus the `tool_activity_config` that runs them **in-workflow**.
  - `HarnessDeps` -  the per-run channel for the runner + stream context.
- **`examples/pydantic_ai_hello/`** - mirrors `openai_hello` (workflow/worker/agents.toml/justfile/README).
- **`pyproject.toml`** - `pydantic-ai` optional extra (`pydantic-ai-slim[temporal]>=2.13`) + examples/dev groups.
- **`tests/ai_sdks/pydantic_ai/`** - translator unit tests + tests asserting the deps-threaded tool adapter and the `HarnessDeps` snapshot.

## Testing

Confirmed that the example runs, and both streaming and tool calling streams out correct events.