### PR TITLE
Added a sandboxed portable coding agent, a model-activity input fix, and a payload sweep.

### DIFF
--- a/examples/portable_coding_agent/README.md
+++ b/examples/portable_coding_agent/README.md
@@ -5,8 +5,9 @@ model-driven commands cannot touch the host beyond the sandbox. It runs two ways
 from one codebase:
 
 - **Durable**, as a Temporal workflow. Sessions survive worker loss and
-  redeploys, every sandbox operation is an activity, and the sandbox is reached
-  through the harness's `temporal_sandbox_client`.
+  redeploys, every sandbox operation is an activity, the sandbox is reached
+  through the harness's `temporal_sandbox_client`, and one sandbox is reused for
+  the whole session so files persist from one message to the next.
 - **Local**, in one process with no Temporal and no server, for the end-user's
   machine.
 
@@ -28,19 +29,25 @@ tells it to:
   harness tool rather than a sandbox tool.
 - **Search by meaning** with `codebase_search`: an embedding index over the
   project, keyed by content hash so re-indexing only re-embeds changed chunks
-  (the merkle-tree idea). It complements plain text search. It runs as an
-  activity and reads the project on the worker's filesystem
-  (`CODING_AGENT_WORKSPACE`); see the note below on keeping that consistent with
+  (the merkle-tree idea) and evicts vectors for files that go away. Results carry
+  the matched code, not just line ranges. It runs as an activity and reads the
+  project on the worker's filesystem (`CODING_AGENT_WORKSPACE`); it complements
+  the shell's own `grep`/`find`. See the note below on keeping it consistent with
   the sandbox.
 - **Ask the user** with `ask_user`: when the task is ambiguous the agent asks
-  rather than guesses. In the durable mode this is a callback tool (the workflow
-  pauses and an attached client answers, at no worker cost); locally it is a
-  terminal prompt.
+  rather than guesses, optionally offering a short list of `choices`. In the
+  durable mode this is a callback tool (the workflow pauses and an attached client
+  answers, at no worker cost); locally it is a terminal prompt.
 - **Delegate** with `task`: hand a self-contained sub-task to another instance of
   this agent. In the durable mode that instance is a child workflow (the harness
-  `subagent_toolset`); locally it is a nested run.
+  `subagent_toolset`); locally it is a nested run. A subagent cannot ask the user
+  (nothing answers a child's callback) and delegation depth is capped, so
+  subagents do not recurse without bound.
+- **Fetch the web** with `web_fetch`: pull a URL's text for documentation or an
+  error message the repository does not contain, as an activity-backed tool.
 - **Verify**: the prompt has it run the build or the relevant test after a change
-  and fix what it broke, rather than declaring success blind.
+  and fix what it broke, rather than declaring success blind. If an edit does not
+  apply cleanly it re-reads the region and retries rather than forcing it.
 - **Context** stays bounded: the SDK's compaction capability summarizes the
   conversation as it grows.
 
@@ -71,9 +78,17 @@ first example wiring the harness's sandbox seam (`SandboxClientProvider` +
   **no isolation**, for a machine you already trust or where Docker is not
   available.
 
-The isolation is the safety boundary, so this agent does not gate individual
-commands (unlike the callback coding agent, which prompts for approval because
-its tools run on the user's own machine).
+The default image is deliberately small and ships `grep` / `find` / `sed` /
+`awk` (enough for text search); set `CODING_AGENT_SANDBOX_IMAGE` to one that also
+has `git`, `ripgrep`, and your language toolchain for richer work.
+
+Isolation is the safety boundary. With the `docker` backend the model's commands
+cannot reach the host, so this agent does not gate individual commands. Note that
+the harness `ToolApprovalPolicy` gates the harness-side tools (plan, search, ask,
+web, delegate), not the SDK's own shell and edit tools, so on the `local` backend
+(no isolation) that boundary is gone and you are trusting the model on your host.
+Use `local` only on a machine you already trust; per-command approval of the
+sandbox's own tools would use the SDK's `needs_approval` and is not wired here.
 
 ## Durable mode
 
@@ -90,18 +105,19 @@ Then open http://localhost:8000, pick "Portable Coding Agent", and chat.
 
 ### Placement, and why it is set up this way
 
-The sandbox a message creates lives on the worker that created it, for the
-length of that message (with the `docker` backend, a container on that host; see
-Status for why it is per-message today). Its sandbox operations
-(create / exec / read / write / delete) run as activities on the workflow's own
-task queue and are dispatched eagerly, so they tend to return to that worker; the
-session worker also sets a short `sticky_queue_schedule_to_start_timeout` so a
-lost worker is re-dispatched quickly. Within a message this is already an affinity
-concern: a sandbox operation that lands on a worker without the container cannot
-serve it. Once the sandbox is reused across a session's messages it becomes a
-hard affinity requirement, so run a single session worker, or keep sandbox
-operations local to the worker holding the container, until that is guaranteed.
-The model call, by contrast, runs on its own task queue
+The session's sandbox lives on the worker that created it (with the `docker`
+backend, a container on that host) and is reused for the whole conversation. Its
+operations (create / resume / exec / read / write / delete) run as activities on
+the workflow's own task queue and are dispatched eagerly, so they tend to return
+to that worker; the session worker also sets a short
+`sticky_queue_schedule_to_start_timeout` so a lost worker is re-dispatched
+quickly. Because the sandbox persists across messages, this is a hard affinity
+requirement: an operation that lands on a worker without the container cannot
+serve it, so run a single session worker (or otherwise keep a session's sandbox
+operations on the worker that holds its container) until that affinity is
+guaranteed. On a lost worker, the workflow resumes the sandbox from its stored
+state, which the `docker` backend can do only on the host that still has the
+container. The model call, by contrast, runs on its own task queue
 (`portable-coding-agent-model`) because it is the long, provider-bound step.
 
 ## Local mode (no server)
@@ -120,20 +136,25 @@ conversation across restarts.
 
 ## Working on an existing project
 
-The sandbox starts empty and is created fresh for each message (see Status), so
-out of the box the agent builds and runs code inside the sandbox rather than
-editing a repo on your disk. To work on existing code, mount it into the sandbox:
-the Docker backend supports volume mounts, so a project directory can be mounted
-read-write and the agent edits it in place. Wiring a host mount through the run
-config is the natural next step for this example and is not done here yet.
+With the `local` backend, point the agent at a real repo and it edits it in
+place:
 
-## What a fuller build adds
+```bash
+export CODING_AGENT_SANDBOX=local
+export CODING_AGENT_WORKSPACE=/path/to/your/repo
+just local "add a docstring to the top function in main.py"
+```
 
-Semantic search, ask-user, and subagent delegation are wired (see Tools above).
-A production coding agent typically adds one more, which fits the same shape:
+The unix-local backend roots its workspace at `CODING_AGENT_WORKSPACE`, and the
+SDK never deletes or clears a caller-provided root, so edits land in your files
+and `codebase_search` indexes the same tree. It runs with **no isolation**, so
+use it only on a repo and machine you trust.
 
-- **Web search / fetch**: for docs and error messages the repository does not
-  contain, as an activity-backed tool.
+The `docker` backend keeps an isolated workspace instead: its SDK options expose
+no host bind mount, so it cannot edit a repo on your disk directly. To work on a
+project under isolation you would seed the container from a directory (the
+session supports `hydrate_workspace` / `persist_workspace`) and apply changes
+back out of band; that copy-in/copy-out flow is not wired here.
 
 ## Large-payload retention
 
@@ -151,36 +172,41 @@ namespace retention period. See
 
 ## Status
 
-Both modes were run end to end against the OpenAI API with the `docker` backend.
-Local mode: a `SandboxAgent` created a file and ran it inside a container,
-returning the program's output; `update_plan`, `codebase_search` (live
-embeddings, ranked the right file), `ask_user` (answered from the terminal), and
-`task` (delegated a sub-task and used its result) each ran. Durable mode: a turn
-completed through the harness with no errors, the history shows the sandbox
-operations on the session queue and the model call on its own queue, and the
-workers register all four tool families (sandbox, plan, search activity, ask
-callback, `task` subagent). The durable ask-callback and subagent turns run on
-the harness's own callback and `subagent_toolset` mechanisms; a full durable
-run of each is not exercised here.
+Verified end to end against the OpenAI API with the `docker` backend.
 
-Known limitations, in priority order:
+Durable mode, the sandbox-persistence path specifically: a two-message session
+was driven against a dev server. History shows the sandbox created once and
+resumed on the second message (not recreated), exactly one container served the
+whole session, and a file written on the first message was present in that
+container on the second (checked out of band with `docker exec`, not the model's
+word). The whole tool surface is registered and a turn completes with no errors.
 
-- **The sandbox is per-message, not per-session.** Each message runs one
-  `Runner.run`, which creates a sandbox and the SDK deletes it at the end of the
-  run, so a file the agent writes in one message is gone in the next (the durable
-  conversation still remembers it, which is the confusing part). Persisting it
-  means keeping the sandbox session state in workflow state and passing it back on
-  the next run (the no-delete path is a reused live session), plus deleting it when
-  the agent closes. This is the main open item.
-- **A durable `task` subagent can block on `ask_user`.** The child is another
-  instance of this workflow, so it carries `ask_user`, but nothing in this example
-  attaches a client to a child workflow to answer it. Give subagents a no-ask
-  variant (or drop `ASK_TOOLS` for children) and cap delegation depth before
-  relying on the durable delegation path.
+Local mode: the unix-local backend, rooted at a workspace, read an existing repo
+file and wrote a file that landed on the host in that repo, and `client.delete`
+left the caller's directory intact. `update_plan`, `codebase_search` (live
+embeddings, ranked the right file), `ask_user`, and `task` each ran end to end in
+an earlier check.
+
+The full test suite is green (258 passed): the search machinery, the
+subagent/ask/delegation policy, sandbox backend selection, and the retention
+sweep are unit-tested. CI here does not run the model-backed loop or spin a
+container. Two paths rest on the harness's own unit-tested mechanisms rather than
+a live run here: the durable `ask_user` callback and a full durable `task`
+subagent turn.
+
+Not wired here, by design:
+
+- **Editing a repo under `docker` isolation.** The SDK's Docker options have no
+  host bind mount, so in-place editing uses the `local` backend; a seed/apply
+  flow for docker is a next step.
+- **Per-command approval of the sandbox's own shell/edit tools.** Isolation is
+  the boundary; gating individual sandbox commands would use the SDK's
+  `needs_approval` integrated with the durable approval flow.
+- **`AGENTS.md` ingestion is local-mode only**, where the workspace is the real
+  repo; the durable sandbox starts empty.
 
 The durable path needed a harness fix (a separate commit in this PR): the model
 activity was validating its input back into the typed item union, which made
 pydantic hand the SDK lazy `ValidatorIterator`s for `Iterable`-typed fields that
 cannot be re-serialized once detached; forwarding the input as opaque JSON fixes
-it. Sandbox backend selection and the retention sweep are unit-tested (`tests/`);
-CI here does not run the model-backed loop or spin a container.
+it.

--- a/examples/portable_coding_agent/README.md
+++ b/examples/portable_coding_agent/README.md
@@ -46,11 +46,13 @@ tells it to:
 
 One consistency note for `codebase_search`: it reads the project on the worker's
 disk, while the `docker` sandbox has its own workspace, so out of the box the
-agent can search a repo the sandbox is not editing. To keep search and edits on
-the same files, run the `local` backend (tools run on the host, over the same
-directory the search reads) or hydrate the sandbox from that directory. A host
-bind mount is not a first-class option in this SDK sandbox, which is why a
-production build indexes through an indexing service instead.
+agent can search a repo the sandbox is not editing. The results carry the matched
+code (not just line ranges), so a mismatch still returns usable content rather
+than pointers the sandbox cannot open. To keep search and edits on the same
+files, run the `local` backend (tools run on the host, over the same directory
+the search reads) or hydrate the sandbox from that directory. A host bind mount
+is not a first-class option in this SDK sandbox, which is why a production build
+indexes through an indexing service instead.
 
 It is a sibling to [`callback_tools/coding_agent`](../callback_tools/coding_agent),
 which keeps its tools on the user's laptop and reasons in the cloud through
@@ -88,16 +90,18 @@ Then open http://localhost:8000, pick "Portable Coding Agent", and chat.
 
 ### Placement, and why it is set up this way
 
-A session's sandbox lives on the worker that created it (with the `docker`
-backend, a container on that host). Its sandbox operations
+The sandbox a message creates lives on the worker that created it, for the
+length of that message (with the `docker` backend, a container on that host; see
+Status for why it is per-message today). Its sandbox operations
 (create / exec / read / write / delete) run as activities on the workflow's own
 task queue and are dispatched eagerly, so they tend to return to that worker; the
 session worker also sets a short `sticky_queue_schedule_to_start_timeout` so a
-lost worker is re-dispatched quickly. In a pool of workers this is a real
-affinity requirement: a sandbox operation that lands on a worker without the
-session's container cannot serve it. Run a single session worker, or keep sandbox
-operations local to the worker holding the container, until that affinity is
-guaranteed. The model call, by contrast, runs on its own task queue
+lost worker is re-dispatched quickly. Within a message this is already an affinity
+concern: a sandbox operation that lands on a worker without the container cannot
+serve it. Once the sandbox is reused across a session's messages it becomes a
+hard affinity requirement, so run a single session worker, or keep sandbox
+operations local to the worker holding the container, until that is guaranteed.
+The model call, by contrast, runs on its own task queue
 (`portable-coding-agent-model`) because it is the long, provider-bound step.
 
 ## Local mode (no server)
@@ -116,12 +120,12 @@ conversation across restarts.
 
 ## Working on an existing project
 
-The sandbox starts empty and is created fresh per session, so out of the box the
-agent builds and runs code inside the sandbox rather than editing a repo on your
-disk. To work on existing code, mount it into the sandbox: the Docker backend
-supports volume mounts, so a project directory can be mounted read-write and the
-agent edits it in place. Wiring a host mount through the run config is the
-natural next step for this example and is not done here yet.
+The sandbox starts empty and is created fresh for each message (see Status), so
+out of the box the agent builds and runs code inside the sandbox rather than
+editing a repo on your disk. To work on existing code, mount it into the sandbox:
+the Docker backend supports volume mounts, so a project directory can be mounted
+read-write and the agent edits it in place. Wiring a host mount through the run
+config is the natural next step for this example and is not done here yet.
 
 ## What a fuller build adds
 
@@ -158,6 +162,21 @@ workers register all four tool families (sandbox, plan, search activity, ask
 callback, `task` subagent). The durable ask-callback and subagent turns run on
 the harness's own callback and `subagent_toolset` mechanisms; a full durable
 run of each is not exercised here.
+
+Known limitations, in priority order:
+
+- **The sandbox is per-message, not per-session.** Each message runs one
+  `Runner.run`, which creates a sandbox and the SDK deletes it at the end of the
+  run, so a file the agent writes in one message is gone in the next (the durable
+  conversation still remembers it, which is the confusing part). Persisting it
+  means keeping the sandbox session state in workflow state and passing it back on
+  the next run (the no-delete path is a reused live session), plus deleting it when
+  the agent closes. This is the main open item.
+- **A durable `task` subagent can block on `ask_user`.** The child is another
+  instance of this workflow, so it carries `ask_user`, but nothing in this example
+  attaches a client to a child workflow to answer it. Give subagents a no-ask
+  variant (or drop `ASK_TOOLS` for children) and cap delegation depth before
+  relying on the durable delegation path.
 
 The durable path needed a harness fix (a separate commit in this PR): the model
 activity was validating its input back into the typed item union, which made

--- a/examples/portable_coding_agent/README.md
+++ b/examples/portable_coding_agent/README.md
@@ -1,0 +1,167 @@
+# Portable coding agent
+
+A coding agent whose shell and file edits run inside a **sandbox**, so
+model-driven commands cannot touch the host beyond the sandbox. It runs two ways
+from one codebase:
+
+- **Durable**, as a Temporal workflow. Sessions survive worker loss and
+  redeploys, every sandbox operation is an activity, and the sandbox is reached
+  through the harness's `temporal_sandbox_client`.
+- **Local**, in one process with no Temporal and no server, for the end-user's
+  machine.
+
+Both modes are the same `SandboxAgent` (OpenAI Agents SDK); the only difference
+is whether the sandbox client is used directly or through Temporal activities.
+
+## Tools and method
+
+The agent works the way a production coding agent works, and its system prompt
+tells it to:
+
+- **Read / edit / shell** come from the sandbox: the model lists directories,
+  reads files, edits them, and runs commands, all inside the sandbox. It reads a
+  file before editing it, and can batch independent reads in one step (the SDK
+  runs tool calls in parallel).
+- **Plan** with `update_plan`: for multi-step work it lays out the steps, marks
+  one in progress, and ticks them off. The plan is the agent's own state (durable
+  workflow state in the durable mode), not a sandbox action, so it is an inline
+  harness tool rather than a sandbox tool.
+- **Search by meaning** with `codebase_search`: an embedding index over the
+  project, keyed by content hash so re-indexing only re-embeds changed chunks
+  (the merkle-tree idea). It complements plain text search. It runs as an
+  activity and reads the project on the worker's filesystem
+  (`CODING_AGENT_WORKSPACE`); see the note below on keeping that consistent with
+  the sandbox.
+- **Ask the user** with `ask_user`: when the task is ambiguous the agent asks
+  rather than guesses. In the durable mode this is a callback tool (the workflow
+  pauses and an attached client answers, at no worker cost); locally it is a
+  terminal prompt.
+- **Delegate** with `task`: hand a self-contained sub-task to another instance of
+  this agent. In the durable mode that instance is a child workflow (the harness
+  `subagent_toolset`); locally it is a nested run.
+- **Verify**: the prompt has it run the build or the relevant test after a change
+  and fix what it broke, rather than declaring success blind.
+- **Context** stays bounded: the SDK's compaction capability summarizes the
+  conversation as it grows.
+
+One consistency note for `codebase_search`: it reads the project on the worker's
+disk, while the `docker` sandbox has its own workspace, so out of the box the
+agent can search a repo the sandbox is not editing. To keep search and edits on
+the same files, run the `local` backend (tools run on the host, over the same
+directory the search reads) or hydrate the sandbox from that directory. A host
+bind mount is not a first-class option in this SDK sandbox, which is why a
+production build indexes through an indexing service instead.
+
+It is a sibling to [`callback_tools/coding_agent`](../callback_tools/coding_agent),
+which keeps its tools on the user's laptop and reasons in the cloud through
+callback tools. This one runs the tools in a server-side sandbox, and is the
+first example wiring the harness's sandbox seam (`SandboxClientProvider` +
+`temporal_sandbox_client`).
+
+## The sandbox
+
+`CODING_AGENT_SANDBOX` picks the backend (both are the OpenAI Agents SDK's own):
+
+- `docker` (default): a throwaway container per session. Real isolation; needs a
+  Docker daemon. The image is `CODING_AGENT_SANDBOX_IMAGE` (default
+  `python:3.12-slim`).
+- `local`: the unix-local backend. The same tools run directly on the host with
+  **no isolation**, for a machine you already trust or where Docker is not
+  available.
+
+The isolation is the safety boundary, so this agent does not gate individual
+commands (unlike the callback coding agent, which prompts for approval because
+its tools run on the user's own machine).
+
+## Durable mode
+
+```bash
+cp ../../.env.example ../../.env.local     # fill in the Temporal profile + OPENAI_API_KEY
+
+just temporal          # 1. local Temporal dev server (or bring your own)
+just session-manager   # 2. packaged session-manager worker
+just server            # 3. FastAPI API + UI on :8000
+just worker            # 4. this example's agent + model workers (hosts the sandbox)
+```
+
+Then open http://localhost:8000, pick "Portable Coding Agent", and chat.
+
+### Placement, and why it is set up this way
+
+A session's sandbox lives on the worker that created it (with the `docker`
+backend, a container on that host). Its sandbox operations
+(create / exec / read / write / delete) run as activities on the workflow's own
+task queue and are dispatched eagerly, so they tend to return to that worker; the
+session worker also sets a short `sticky_queue_schedule_to_start_timeout` so a
+lost worker is re-dispatched quickly. In a pool of workers this is a real
+affinity requirement: a sandbox operation that lands on a worker without the
+session's container cannot serve it. Run a single session worker, or keep sandbox
+operations local to the worker holding the container, until that affinity is
+guaranteed. The model call, by contrast, runs on its own task queue
+(`portable-coding-agent-model`) because it is the long, provider-bound step.
+
+## Local mode (no server)
+
+```bash
+export OPENAI_API_KEY=...
+just local "write a script that prints the first 10 fibonacci numbers and run it"
+# or directly:
+uv run --group examples python -m examples.portable_coding_agent.local_runner \
+    --session myproj "add a docstring to the top function in main.py"
+```
+
+No Temporal is used on this path; the sandbox client is called directly. A
+checkpoint file under `~/.portable-coding-agent/sessions/` keeps the
+conversation across restarts.
+
+## Working on an existing project
+
+The sandbox starts empty and is created fresh per session, so out of the box the
+agent builds and runs code inside the sandbox rather than editing a repo on your
+disk. To work on existing code, mount it into the sandbox: the Docker backend
+supports volume mounts, so a project directory can be mounted read-write and the
+agent edits it in place. Wiring a host mount through the run config is the
+natural next step for this example and is not done here yet.
+
+## What a fuller build adds
+
+Semantic search, ask-user, and subagent delegation are wired (see Tools above).
+A production coding agent typically adds one more, which fits the same shape:
+
+- **Web search / fetch**: for docs and error messages the repository does not
+  contain, as an activity-backed tool.
+
+## Large-payload retention
+
+A cloud agent that offloads large conversation snapshots (see
+`temporal_agent_harness.utils.large_payload`) accumulates blobs, because neither
+offload driver deletes. Reclaim space with the sweep:
+
+```bash
+just sweep-payloads     # deletes offloaded payloads older than 7 days
+```
+
+Run it from cron or a Temporal Schedule. Size the window longer than your
+namespace retention period. See
+`temporal_agent_harness/utils/large_payload_gc.py` for the age caveat.
+
+## Status
+
+Both modes were run end to end against the OpenAI API with the `docker` backend.
+Local mode: a `SandboxAgent` created a file and ran it inside a container,
+returning the program's output; `update_plan`, `codebase_search` (live
+embeddings, ranked the right file), `ask_user` (answered from the terminal), and
+`task` (delegated a sub-task and used its result) each ran. Durable mode: a turn
+completed through the harness with no errors, the history shows the sandbox
+operations on the session queue and the model call on its own queue, and the
+workers register all four tool families (sandbox, plan, search activity, ask
+callback, `task` subagent). The durable ask-callback and subagent turns run on
+the harness's own callback and `subagent_toolset` mechanisms; a full durable
+run of each is not exercised here.
+
+The durable path needed a harness fix (a separate commit in this PR): the model
+activity was validating its input back into the typed item union, which made
+pydantic hand the SDK lazy `ValidatorIterator`s for `Iterable`-typed fields that
+cannot be re-serialized once detached; forwarding the input as opaque JSON fixes
+it. Sandbox backend selection and the retention sweep are unit-tested (`tests/`);
+CI here does not run the model-backed loop or spin a container.

--- a/examples/portable_coding_agent/agents.toml
+++ b/examples/portable_coding_agent/agents.toml
@@ -1,0 +1,16 @@
+# Registry of agents the portable coding agent example UI can launch.
+#
+# The shared FastAPI server (examples/app.py) reads this file and serves it back
+# over the session manager's `available_agents` query. To expose a new agent:
+# register its @workflow.defn on a worker, then add a [[agents]] entry here.
+
+[[agents]]
+key = "portable-coding-agent"
+workflow_type = "PortableCodingAgent"
+task_queue = "portable-coding-agent"
+label = "Portable Coding Agent"
+description = """
+A coding agent whose shell and file edits run inside a sandbox (a Docker container by default),
+driven by the OpenAI Agents SDK's sandbox tools and made durable through the harness's
+temporal_sandbox_client. The model call runs on its own task queue. The same agent runs with no
+server through local_runner.py."""

--- a/examples/portable_coding_agent/ask.py
+++ b/examples/portable_coding_agent/ask.py
@@ -14,11 +14,12 @@ from temporal_agent_harness.harness import agent
 
 
 @agent.callback_tool_defn()
-async def ask_user(question: str) -> str:
+async def ask_user(question: str, choices: list[str] = []) -> str:
     """Ask the user a question and use their answer to continue. Use it when the task is
     ambiguous or needs a decision only the user can make: which of two files they mean, permission
-    for a destructive or slow command, or a missing detail. Prefer asking over guessing when it
-    matters; ask again if the answer is unclear. Returns the user's answer as text."""
+    for a destructive or slow command, or a missing detail. Pass `choices` to offer a short list of
+    options to pick from (leave it empty for a free-form answer). Prefer asking over guessing when
+    it matters; ask again if the answer is unclear. Returns the user's answer as text."""
     ...  # no worker body: the attached client (or the local prompt) supplies the answer
 
 

--- a/examples/portable_coding_agent/ask.py
+++ b/examples/portable_coding_agent/ask.py
@@ -1,0 +1,25 @@
+"""Ask-the-user tool: human-in-the-loop clarification.
+
+When a task is ambiguous or needs a decision only the user can make, a good
+coding agent asks rather than guesses. In the durable mode this is a callback
+tool: the workflow pauses and an attached client answers, so the wait costs no
+worker time and survives a restart. The local runner supplies the same tool as
+a terminal prompt instead (see ``local_runner``).
+
+NB: no ``from __future__ import annotations``; the annotations build the
+model-facing schema at runtime.
+"""
+
+from temporal_agent_harness.harness import agent
+
+
+@agent.callback_tool_defn()
+async def ask_user(question: str) -> str:
+    """Ask the user a question and use their answer to continue. Use it when the task is
+    ambiguous or needs a decision only the user can make: which of two files they mean, permission
+    for a destructive or slow command, or a missing detail. Prefer asking over guessing when it
+    matters; ask again if the answer is unclear. Returns the user's answer as text."""
+    ...  # no worker body: the attached client (or the local prompt) supplies the answer
+
+
+ASK_TOOLS = [ask_user]

--- a/examples/portable_coding_agent/codebase_search.py
+++ b/examples/portable_coding_agent/codebase_search.py
@@ -9,20 +9,28 @@ same idea as a merkle tree over the tree's contents).
 The embedder is injectable so the machinery is testable offline with a
 deterministic stub; production uses OpenAI embeddings.
 
-The search reads the project on the worker's filesystem (``CODING_AGENT_WORKSPACE``),
-which is the same directory mounted into the sandbox, so what the agent searches
-and what it edits are the same files.
+The search reads the project on the worker's filesystem
+(``CODING_AGENT_WORKSPACE``, default the worker's cwd). That is not the same
+place the ``docker`` sandbox edits files, so out of the box search can look at a
+different tree than the sandbox tools touch. Two things keep it useful anyway:
+the results carry the matched code (not just line ranges), and with the
+``local`` backend the tools run on the host over this same directory. See the
+README's coherence note.
 
 NB: no ``from __future__ import annotations``; the tool annotations build the
 model-facing schema at runtime.
 """
 
+import asyncio
 import hashlib
 import json
 import math
 import os
+from datetime import timedelta
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Callable, Sequence
+
+from temporalio.workflow import ActivityConfig
 
 from temporal_agent_harness.harness import agent
 
@@ -31,8 +39,12 @@ Embedder = Callable[[Sequence[str]], "list[list[float]]"]
 
 _CHUNK_LINES = 60
 _SKIP_DIRS = {".git", "node_modules", ".venv", "__pycache__", ".mypy_cache", "dist", "build"}
+_SKIP_FILES = {"package-lock.json", "poetry.lock", "uv.lock", "yarn.lock", "Cargo.lock"}
 _TEXT_MAX_BYTES = 200_000  # skip anything larger; not source
 _DEFAULT_TOP_K = 8
+# OpenAI caps inputs and tokens per embeddings request, so a first index of a real
+# repo cannot go in one call. Embed in batches and persist after each.
+_EMBED_BATCH = 128
 
 
 def _chunks(text: str) -> list[tuple[int, int, str]]:
@@ -47,10 +59,17 @@ def _chunks(text: str) -> list[tuple[int, int, str]]:
     return out
 
 
+def _skip_file(name: str) -> bool:
+    # Do not embed secrets or machine-generated lockfiles into a third-party API.
+    return name == ".env" or name.startswith(".env.") or name in _SKIP_FILES
+
+
 def _walk_text_files(root: Path):
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
         for name in filenames:
+            if _skip_file(name):
+                continue
             path = Path(dirpath) / name
             try:
                 if path.stat().st_size > _TEXT_MAX_BYTES:
@@ -81,8 +100,8 @@ class CodebaseIndex:
                 self._vectors = json.loads(cache_path.read_text())
             except (OSError, ValueError):
                 self._vectors = {}
-        # (path, start, end, hash), rebuilt each index() from the current tree.
-        self._chunks: list[tuple[str, int, int, str]] = []
+        # (path, start, end, hash, body), rebuilt each index() from the current tree.
+        self._chunks: list[tuple[str, int, int, str, str]] = []
 
     def index(self) -> int:
         """Scan the tree, embedding any chunk whose content hash is not cached.
@@ -93,16 +112,21 @@ class CodebaseIndex:
             rel = str(path.relative_to(self._root))
             for start, end, body in _chunks(text):
                 h = hashlib.sha256(body.encode()).hexdigest()
-                self._chunks.append((rel, start, end, h))
+                self._chunks.append((rel, start, end, h, body))
                 if h not in self._vectors and h not in to_embed:
                     to_embed[h] = body
-        if to_embed:
-            hashes = list(to_embed)
-            vectors = self._embedder([to_embed[h] for h in hashes])
-            for h, vec in zip(hashes, vectors):
+        if not to_embed:
+            return 0
+        hashes = list(to_embed)
+        # Batch so a large first index stays under the API's per-request limit, and persist
+        # after each batch so a crash mid-index resumes from what was already embedded.
+        for i in range(0, len(hashes), _EMBED_BATCH):
+            batch = hashes[i : i + _EMBED_BATCH]
+            vectors = self._embedder([to_embed[h] for h in batch])
+            for h, vec in zip(batch, vectors):
                 self._vectors[h] = list(vec)
             self._persist()
-        return len(to_embed)
+        return len(hashes)
 
     def _persist(self) -> None:
         if not self._cache_path:
@@ -112,25 +136,25 @@ class CodebaseIndex:
         tmp.write_text(json.dumps(self._vectors))
         tmp.replace(self._cache_path)
 
-    def search(self, query: str, k: int = _DEFAULT_TOP_K) -> list[tuple[str, int, int, float]]:
-        """Return the top-k (path, start_line, end_line, score) for a query."""
+    def search(self, query: str, k: int = _DEFAULT_TOP_K) -> list[tuple[str, int, int, float, str]]:
+        """Return the top-k (path, start_line, end_line, score, body) for a query."""
         [qvec] = self._embedder([query])
         scored = [
-            (path, start, end, _cosine(qvec, self._vectors[h]))
-            for path, start, end, h in self._chunks
+            (path, start, end, _cosine(qvec, self._vectors[h]), body)
+            for path, start, end, h, body in self._chunks
             if h in self._vectors
         ]
         scored.sort(key=lambda t: t[3], reverse=True)
         return scored[:k]
 
 
-def format_hits(root: Path, hits: list[tuple[str, int, int, float]]) -> str:
+def format_hits(root: Path, hits: list[tuple[str, int, int, float, str]]) -> str:
     if not hits:
         return "no matches"
-    lines = []
-    for rel, start, end, score in hits:
-        lines.append(f"{rel}:{start}-{end}  (score {score:.2f})")
-    return "\n".join(lines)
+    blocks = []
+    for rel, start, end, score, body in hits:
+        blocks.append(f"{rel}:{start}-{end}  (score {score:.2f})\n{body}")
+    return "\n\n".join(blocks)
 
 
 def _workspace_root() -> Path:
@@ -156,16 +180,27 @@ def _openai_embedder() -> Embedder:
     return embed
 
 
-@agent.activity_tool_defn(inherently_safe=True)
+@agent.activity_tool_defn(
+    inherently_safe=True,
+    # First-time indexing walks and embeds the whole tree; the 30s default would time out on a
+    # real repo. (A production index would heartbeat and run in a background service.)
+    activity_config=ActivityConfig(start_to_close_timeout=timedelta(minutes=10)),
+)
 async def codebase_search(query: str) -> str:
     """Search the repository by MEANING for code relevant to a query, e.g. "where are retries
-    configured" or "the function that validates the token". Returns the most relevant file regions
-    as `path:start-end`; read those regions to see the code. Use it to find where something lives
-    before reading or editing; it complements plain text search."""
+    configured" or "the function that validates the token". Returns the most relevant file
+    regions as `path:start-end` followed by the code itself, best match first. Use it to find
+    where something lives before reading or editing; it complements plain text search."""
     root = _workspace_root()
-    index = CodebaseIndex(root, _openai_embedder(), cache_path=_cache_path(root))
-    index.index()
-    return format_hits(root, index.search(query))
+
+    def _run() -> str:
+        index = CodebaseIndex(root, _openai_embedder(), cache_path=_cache_path(root))
+        index.index()
+        return format_hits(root, index.search(query))
+
+    # Indexing and embedding are blocking (file walk + the sync OpenAI client); keep them off the
+    # worker's event loop so co-located sandbox activities and heartbeats are not stalled.
+    return await asyncio.to_thread(_run)
 
 
 SEARCH_TOOLS = [codebase_search]

--- a/examples/portable_coding_agent/codebase_search.py
+++ b/examples/portable_coding_agent/codebase_search.py
@@ -1,0 +1,171 @@
+"""Semantic codebase search.
+
+The agent queries the repository by meaning, not just by text. Files are split
+into chunks, each chunk is embedded once and cached by a hash of its content, and
+a query is answered by cosine-nearest chunks. Caching by content hash makes
+re-indexing incremental: only chunks whose text changed are re-embedded (the
+same idea as a merkle tree over the tree's contents).
+
+The embedder is injectable so the machinery is testable offline with a
+deterministic stub; production uses OpenAI embeddings.
+
+The search reads the project on the worker's filesystem (``CODING_AGENT_WORKSPACE``),
+which is the same directory mounted into the sandbox, so what the agent searches
+and what it edits are the same files.
+
+NB: no ``from __future__ import annotations``; the tool annotations build the
+model-facing schema at runtime.
+"""
+
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from temporal_agent_harness.harness import agent
+
+# Injectable so tests pass a stub. An embedder maps texts to vectors.
+Embedder = Callable[[Sequence[str]], "list[list[float]]"]
+
+_CHUNK_LINES = 60
+_SKIP_DIRS = {".git", "node_modules", ".venv", "__pycache__", ".mypy_cache", "dist", "build"}
+_TEXT_MAX_BYTES = 200_000  # skip anything larger; not source
+_DEFAULT_TOP_K = 8
+
+
+def _chunks(text: str) -> list[tuple[int, int, str]]:
+    """Split into (start_line, end_line, text) windows of ~_CHUNK_LINES lines."""
+    lines = text.split("\n")
+    out: list[tuple[int, int, str]] = []
+    for start in range(0, len(lines), _CHUNK_LINES):
+        window = lines[start : start + _CHUNK_LINES]
+        body = "\n".join(window).strip()
+        if body:
+            out.append((start + 1, start + len(window), "\n".join(window)))
+    return out
+
+
+def _walk_text_files(root: Path):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for name in filenames:
+            path = Path(dirpath) / name
+            try:
+                if path.stat().st_size > _TEXT_MAX_BYTES:
+                    continue
+                yield path, path.read_text()
+            except (OSError, UnicodeDecodeError):
+                continue  # binary or unreadable
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+class CodebaseIndex:
+    """A content-hash-cached embedding index over a directory."""
+
+    def __init__(self, root: Path, embedder: Embedder, cache_path: Path | None = None) -> None:
+        self._root = root.resolve()
+        self._embedder = embedder
+        self._cache_path = cache_path
+        # hash -> vector, persisted so re-indexing only embeds changed chunks.
+        self._vectors: dict[str, list[float]] = {}
+        if cache_path and cache_path.exists():
+            try:
+                self._vectors = json.loads(cache_path.read_text())
+            except (OSError, ValueError):
+                self._vectors = {}
+        # (path, start, end, hash), rebuilt each index() from the current tree.
+        self._chunks: list[tuple[str, int, int, str]] = []
+
+    def index(self) -> int:
+        """Scan the tree, embedding any chunk whose content hash is not cached.
+        Returns the number of newly embedded chunks."""
+        self._chunks = []
+        to_embed: dict[str, str] = {}
+        for path, text in _walk_text_files(self._root):
+            rel = str(path.relative_to(self._root))
+            for start, end, body in _chunks(text):
+                h = hashlib.sha256(body.encode()).hexdigest()
+                self._chunks.append((rel, start, end, h))
+                if h not in self._vectors and h not in to_embed:
+                    to_embed[h] = body
+        if to_embed:
+            hashes = list(to_embed)
+            vectors = self._embedder([to_embed[h] for h in hashes])
+            for h, vec in zip(hashes, vectors):
+                self._vectors[h] = list(vec)
+            self._persist()
+        return len(to_embed)
+
+    def _persist(self) -> None:
+        if not self._cache_path:
+            return
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._cache_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._vectors))
+        tmp.replace(self._cache_path)
+
+    def search(self, query: str, k: int = _DEFAULT_TOP_K) -> list[tuple[str, int, int, float]]:
+        """Return the top-k (path, start_line, end_line, score) for a query."""
+        [qvec] = self._embedder([query])
+        scored = [
+            (path, start, end, _cosine(qvec, self._vectors[h]))
+            for path, start, end, h in self._chunks
+            if h in self._vectors
+        ]
+        scored.sort(key=lambda t: t[3], reverse=True)
+        return scored[:k]
+
+
+def format_hits(root: Path, hits: list[tuple[str, int, int, float]]) -> str:
+    if not hits:
+        return "no matches"
+    lines = []
+    for rel, start, end, score in hits:
+        lines.append(f"{rel}:{start}-{end}  (score {score:.2f})")
+    return "\n".join(lines)
+
+
+def _workspace_root() -> Path:
+    return Path(os.environ.get("CODING_AGENT_WORKSPACE", ".")).resolve()
+
+
+def _cache_path(root: Path) -> Path:
+    home = Path(os.environ.get("AGENT_HOME", Path.home() / ".portable-coding-agent"))
+    key = hashlib.sha256(str(root).encode()).hexdigest()[:16]
+    return home / "index" / f"{key}.json"
+
+
+def _openai_embedder() -> Embedder:
+    from openai import OpenAI
+
+    client = OpenAI()
+    model = os.environ.get("CODING_AGENT_EMBED_MODEL", "text-embedding-3-small")
+
+    def embed(texts: Sequence[str]) -> list[list[float]]:
+        resp = client.embeddings.create(model=model, input=list(texts))
+        return [d.embedding for d in resp.data]
+
+    return embed
+
+
+@agent.activity_tool_defn(inherently_safe=True)
+async def codebase_search(query: str) -> str:
+    """Search the repository by MEANING for code relevant to a query, e.g. "where are retries
+    configured" or "the function that validates the token". Returns the most relevant file regions
+    as `path:start-end`; read those regions to see the code. Use it to find where something lives
+    before reading or editing; it complements plain text search."""
+    root = _workspace_root()
+    index = CodebaseIndex(root, _openai_embedder(), cache_path=_cache_path(root))
+    index.index()
+    return format_hits(root, index.search(query))
+
+
+SEARCH_TOOLS = [codebase_search]

--- a/examples/portable_coding_agent/codebase_search.py
+++ b/examples/portable_coding_agent/codebase_search.py
@@ -108,14 +108,23 @@ class CodebaseIndex:
         Returns the number of newly embedded chunks."""
         self._chunks = []
         to_embed: dict[str, str] = {}
+        live: set[str] = set()
         for path, text in _walk_text_files(self._root):
             rel = str(path.relative_to(self._root))
             for start, end, body in _chunks(text):
                 h = hashlib.sha256(body.encode()).hexdigest()
                 self._chunks.append((rel, start, end, h, body))
+                live.add(h)
                 if h not in self._vectors and h not in to_embed:
                     to_embed[h] = body
+        # Evict vectors for chunks that no longer exist (edited or deleted files), so the cache
+        # tracks the tree instead of growing forever.
+        stale = [h for h in self._vectors if h not in live]
+        for h in stale:
+            del self._vectors[h]
         if not to_embed:
+            if stale:
+                self._persist()
             return 0
         hashes = list(to_embed)
         # Batch so a large first index stays under the API's per-request limit, and persist

--- a/examples/portable_coding_agent/justfile
+++ b/examples/portable_coding_agent/justfile
@@ -1,0 +1,56 @@
+# Scoped justfile for the portable coding agent example.
+# Run from this directory: `just <recipe>`.
+#
+# Durable stack (each in its own terminal):
+#   just temporal          # 1. local Temporal dev server (or bring your own)
+#   just session-manager   # 2. packaged session-manager worker
+#   just server            # 3. FastAPI API + UI on :8000
+#   just worker            # 4. this example's agent + model workers
+# Then open http://localhost:8000, pick "Portable Coding Agent", and chat.
+#
+# No-server mode (one command, no Temporal at all):
+#   just local "add a docstring to the top function in main.py"
+#
+# First-time setup: `cp .env.example .env.local` from the repo root and fill it in
+# (Temporal connection + OPENAI_API_KEY). The agent's shell + file tools run in a sandbox:
+# CODING_AGENT_SANDBOX=docker (default, needs a Docker daemon) or =local (no isolation). See
+# README.md.
+
+set dotenv-path := "../../.env.local"
+set dotenv-load := true
+
+root := justfile_directory() / ".." / ".."
+ui := root / "ui"
+
+# List available recipes.
+default:
+    @just --list
+
+# Start a local Temporal dev server (Web UI: http://localhost:8233; needs the `temporal` CLI).
+temporal:
+    temporal server start-dev
+
+# Run the shared session-manager worker.
+session-manager:
+    cd "{{root}}" && uv run --group examples python -m examples.session_manager_worker
+
+# Serve the packaged FastAPI API + UI, pointed at this example's registry.
+server: app-build
+    cd "{{root}}" && uv run --group examples python -m examples.app "{{justfile_directory()}}/agents.toml" --host 0.0.0.0 --port 8000
+
+# Build the shared Svelte UI into temporal_agent_harness/ui/dist for the server to serve.
+app-build:
+    cd "{{ui}}" && pnpm run build
+
+# Run this example's agent + model workers.
+worker:
+    cd "{{root}}" && uv run --group examples python -m examples.portable_coding_agent.worker
+
+# No-server mode: run one coding request locally with no Temporal, in a sandbox.
+# e.g. `just local "write a script that prints the first 10 fibonacci numbers and run it"`.
+local task:
+    cd "{{root}}" && uv run --group examples python -m examples.portable_coding_agent.local_runner "{{task}}"
+
+# Delete offloaded large payloads older than 7 days (see temporal_agent_harness.utils.large_payload_gc).
+sweep-payloads:
+    cd "{{root}}" && uv run python -m temporal_agent_harness.utils.large_payload_gc --days 7

--- a/examples/portable_coding_agent/local_runner.py
+++ b/examples/portable_coding_agent/local_runner.py
@@ -1,0 +1,120 @@
+"""Run the sandboxed coding agent on a laptop with NO Temporal and no server.
+
+Same ``SandboxAgent`` as the durable workflow; the only difference is the sandbox
+client is used directly instead of through Temporal activities. This is the "runs
+on the end-user machine" mode. The trade against the durable worker: a crash
+mid-turn loses the in-flight turn, there is no retry across process death, and no
+server-side history. It keeps crash-resume of the conversation through a small
+checkpoint file.
+
+    uv run --group examples python -m examples.portable_coding_agent.local_runner \\
+        --session myproj "write a script that prints the first 10 fibonacci numbers and run it"
+
+Needs OPENAI_API_KEY. With ``CODING_AGENT_SANDBOX=docker`` (default) the tools run
+in a container; ``=local`` runs them on the host with no isolation (trusted use,
+or no Docker). The sandbox is created fresh per run, so the session id chains the
+conversation, not the sandbox filesystem; mount a project to work on existing
+code (see the README).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+from agents import Runner, function_tool
+from agents.sandbox import SandboxAgent
+
+from .codebase_search import (
+    CodebaseIndex,
+    _cache_path,
+    _openai_embedder,
+    _workspace_root,
+    format_hits,
+)
+from .plan import Todo, render_plan
+from .sandbox import local_run_config, sandbox_kind
+from .workflow import DEFAULT_MODEL, SYSTEM_INSTRUCTION
+
+
+def _checkpoint_path(session_id: str) -> Path:
+    home = Path(os.environ.get("AGENT_HOME", Path.home() / ".portable-coding-agent"))
+    return home / "sessions" / f"{session_id}.json"
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the sandboxed coding agent locally, no server.")
+    parser.add_argument("--session", help="session id (default: 'local')", default="local")
+    parser.add_argument("task", nargs="+", help="what to do")
+    args = parser.parse_args()
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        sys.exit("error: OPENAI_API_KEY env var not set")
+
+    checkpoint = _checkpoint_path(args.session)
+    saved = json.loads(checkpoint.read_text()) if checkpoint.exists() else {}
+    conversation: list = saved.get("conversation", [])
+    todos: list[dict] = saved.get("todos", [])
+
+    model = os.environ.get("CODING_AGENT_MODEL", DEFAULT_MODEL)
+
+    # Local variants of the same tools the durable workflow composes. Here they run directly:
+    # the plan is a local list, ask_user prompts the terminal, codebase_search reads the
+    # workspace, and task runs a nested sandboxed agent.
+    @function_tool
+    async def update_plan(todos_json: str) -> str:
+        """Record your step-by-step plan as a JSON array of {step, status} objects; replaces the
+        previous plan. status is pending / in_progress / completed."""
+        todos[:] = [Todo.model_validate(t).model_dump() for t in json.loads(todos_json)]
+        return render_plan([Todo.model_validate(t) for t in todos])
+
+    @function_tool
+    async def ask_user(question: str) -> str:
+        """Ask the user a question when the task is ambiguous or needs a decision only they can
+        make. Returns their answer."""
+        return await asyncio.to_thread(input, f"\n[agent asks] {question}\n> ")
+
+    @function_tool
+    async def codebase_search(query: str) -> str:
+        """Search the project by meaning and return the most relevant file regions as
+        `path:start-end`. Read those regions to see the code."""
+        root = _workspace_root()
+        index = CodebaseIndex(root, _openai_embedder(), cache_path=_cache_path(root))
+        index.index()
+        return format_hits(root, index.search(query))
+
+    @function_tool
+    async def task(instructions: str) -> str:
+        """Delegate a self-contained sub-task to a fresh sandboxed agent and return its result.
+        Give it everything it needs in `instructions`; it does not see this conversation."""
+        sub = SandboxAgent(name="Task", model=model, instructions=SYSTEM_INSTRUCTION)
+        sub_result = await Runner.run(sub, input=instructions, run_config=local_run_config())
+        return str(sub_result.final_output)
+
+    sdk_agent = SandboxAgent(
+        name="PortableCodingAgent",
+        model=model,
+        instructions=SYSTEM_INSTRUCTION,
+        tools=[update_plan, ask_user, codebase_search, task],
+    )
+    result = await Runner.run(
+        sdk_agent,
+        input=[*conversation, {"role": "user", "content": " ".join(args.task)}],
+        run_config=local_run_config(),
+    )
+
+    checkpoint.parent.mkdir(parents=True, exist_ok=True)
+    tmp = checkpoint.with_suffix(".tmp")
+    tmp.write_text(json.dumps({"conversation": result.to_input_list(), "todos": todos}))
+    tmp.replace(checkpoint)
+
+    print(str(result.final_output))
+    print(f"\n[session {args.session}: sandbox {sandbox_kind()!r}]")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/portable_coding_agent/local_runner.py
+++ b/examples/portable_coding_agent/local_runner.py
@@ -38,7 +38,8 @@ from .codebase_search import (
 )
 from .plan import Todo, render_plan
 from .sandbox import local_run_config, sandbox_kind
-from .workflow import DEFAULT_MODEL, SYSTEM_INSTRUCTION
+from .web import fetch_text
+from .workflow import DEFAULT_MODEL, SUBAGENT_ADDENDUM, SYSTEM_INSTRUCTION
 
 
 def _checkpoint_path(session_id: str) -> Path:
@@ -65,9 +66,17 @@ async def main() -> None:
 
     model = os.environ.get("CODING_AGENT_MODEL", DEFAULT_MODEL)
 
+    # Prepend project guidance if the workspace ships an AGENTS.md (an open convention). In local
+    # mode the workspace is the real repo, so this is the file the agent is about to work on.
+    guide = ""
+    guide_path = _workspace_root() / "AGENTS.md"
+    if guide_path.is_file():
+        guide = "\n\nProject guidance from AGENTS.md:\n" + guide_path.read_text()[:4000]
+    instructions = SYSTEM_INSTRUCTION + guide
+
     # Local variants of the same tools the durable workflow composes. Here they run directly:
     # the plan is a local list, ask_user prompts the terminal, codebase_search reads the
-    # workspace, and task runs a nested sandboxed agent.
+    # workspace, web_fetch pulls a URL, and task runs a nested sandboxed agent.
     @function_tool
     async def update_plan(plan: list[Todo]) -> str:
         """Record or update your step-by-step plan for the current task. Pass the FULL list every
@@ -77,36 +86,48 @@ async def main() -> None:
         return render_plan(plan)
 
     @function_tool
-    async def ask_user(question: str) -> str:
+    async def ask_user(question: str, choices: list[str] = []) -> str:
         """Ask the user a question when the task is ambiguous or needs a decision only they can
-        make. Returns their answer."""
+        make. Pass `choices` to offer options (empty for a free-form answer). Returns their answer."""
+        prompt = f"\n[agent asks] {question}\n"
+        if choices:
+            prompt += "\n".join(f"  {i}) {c}" for i, c in enumerate(choices, 1)) + "\n"
         try:
-            return await asyncio.to_thread(input, f"\n[agent asks] {question}\n> ")
+            answer = await asyncio.to_thread(input, prompt + "> ")
         except EOFError:
             return "(no answer: input is not available; proceed with a reasonable assumption)"
+        if choices and answer.strip().isdigit() and 1 <= int(answer) <= len(choices):
+            return choices[int(answer) - 1]
+        return answer
 
     @function_tool
     async def codebase_search(query: str) -> str:
-        """Search the project by meaning and return the most relevant file regions as
-        `path:start-end`. Read those regions to see the code."""
+        """Search the project by meaning and return the most relevant file regions with their code.
+        Use it to find where something lives before reading or editing."""
         root = _workspace_root()
         index = CodebaseIndex(root, _openai_embedder(), cache_path=_cache_path(root))
         index.index()
         return format_hits(root, index.search(query))
 
     @function_tool
-    async def task(instructions: str) -> str:
+    async def web_fetch(url: str) -> str:
+        """Fetch a web page or raw file over HTTP(S) and return its text, for documentation or an
+        error message the repository does not contain."""
+        return await fetch_text(url)
+
+    @function_tool
+    async def task(task_instructions: str) -> str:
         """Delegate a self-contained sub-task to a fresh sandboxed agent and return its result.
-        Give it everything it needs in `instructions`; it does not see this conversation."""
-        sub = SandboxAgent(name="Task", model=model, instructions=SYSTEM_INSTRUCTION)
-        sub_result = await Runner.run(sub, input=instructions, run_config=local_run_config())
+        Give it everything it needs; it does not see this conversation."""
+        sub = SandboxAgent(name="Task", model=model, instructions=SYSTEM_INSTRUCTION + SUBAGENT_ADDENDUM)
+        sub_result = await Runner.run(sub, input=task_instructions, run_config=local_run_config())
         return str(sub_result.final_output)
 
     sdk_agent = SandboxAgent(
         name="PortableCodingAgent",
         model=model,
-        instructions=SYSTEM_INSTRUCTION,
-        tools=[update_plan, ask_user, codebase_search, task],
+        instructions=instructions,
+        tools=[update_plan, ask_user, codebase_search, web_fetch, task],
     )
     result = await Runner.run(
         sdk_agent,

--- a/examples/portable_coding_agent/local_runner.py
+++ b/examples/portable_coding_agent/local_runner.py
@@ -11,10 +11,11 @@ checkpoint file.
         --session myproj "write a script that prints the first 10 fibonacci numbers and run it"
 
 Needs OPENAI_API_KEY. With ``CODING_AGENT_SANDBOX=docker`` (default) the tools run
-in a container; ``=local`` runs them on the host with no isolation (trusted use,
-or no Docker). The sandbox is created fresh per run, so the session id chains the
-conversation, not the sandbox filesystem; mount a project to work on existing
-code (see the README).
+in an isolated container; ``=local`` runs them on the host with no isolation
+(trusted use, or no Docker). To work on an existing repo, use ``=local`` and set
+``CODING_AGENT_WORKSPACE`` to it: the agent then edits that repo in place and
+reads its ``AGENTS.md`` if present (see the README). Otherwise the sandbox starts
+empty and the session id only chains the conversation.
 """
 
 from __future__ import annotations

--- a/examples/portable_coding_agent/local_runner.py
+++ b/examples/portable_coding_agent/local_runner.py
@@ -56,7 +56,10 @@ async def main() -> None:
         sys.exit("error: OPENAI_API_KEY env var not set")
 
     checkpoint = _checkpoint_path(args.session)
-    saved = json.loads(checkpoint.read_text()) if checkpoint.exists() else {}
+    try:
+        saved = json.loads(checkpoint.read_text()) if checkpoint.exists() else {}
+    except (OSError, ValueError):
+        saved = {}  # a truncated or corrupt checkpoint starts a fresh conversation
     conversation: list = saved.get("conversation", [])
     todos: list[dict] = saved.get("todos", [])
 
@@ -66,17 +69,21 @@ async def main() -> None:
     # the plan is a local list, ask_user prompts the terminal, codebase_search reads the
     # workspace, and task runs a nested sandboxed agent.
     @function_tool
-    async def update_plan(todos_json: str) -> str:
-        """Record your step-by-step plan as a JSON array of {step, status} objects; replaces the
-        previous plan. status is pending / in_progress / completed."""
-        todos[:] = [Todo.model_validate(t).model_dump() for t in json.loads(todos_json)]
-        return render_plan([Todo.model_validate(t) for t in todos])
+    async def update_plan(plan: list[Todo]) -> str:
+        """Record or update your step-by-step plan for the current task. Pass the FULL list every
+        time; it replaces the previous plan. Each item is {step, status} where status is
+        pending / in_progress / completed. Keep exactly one step in_progress."""
+        todos[:] = [t.model_dump() for t in plan]
+        return render_plan(plan)
 
     @function_tool
     async def ask_user(question: str) -> str:
         """Ask the user a question when the task is ambiguous or needs a decision only they can
         make. Returns their answer."""
-        return await asyncio.to_thread(input, f"\n[agent asks] {question}\n> ")
+        try:
+            return await asyncio.to_thread(input, f"\n[agent asks] {question}\n> ")
+        except EOFError:
+            return "(no answer: input is not available; proceed with a reasonable assumption)"
 
     @function_tool
     async def codebase_search(query: str) -> str:

--- a/examples/portable_coding_agent/plan.py
+++ b/examples/portable_coding_agent/plan.py
@@ -1,0 +1,53 @@
+"""The agent's plan tool.
+
+A coding agent that works multi-step keeps a visible plan: it lays out the
+steps, marks one in progress, and ticks them off as it goes, so a human can
+follow along and the agent stays on track. That is what `update_plan` records.
+
+It is an inline harness tool, not a sandbox tool: the plan is the agent's own
+state (durable workflow state in the durable mode), not an action on the
+project, so it runs in-process and writes to the injected `sink`.
+
+NB: no `from __future__ import annotations`. The annotations are read at runtime
+to build the model-facing schema, so they must be concrete types.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+from temporal_agent_harness.harness import agent
+
+TodoStatus = Literal["pending", "in_progress", "completed"]
+
+
+class Todo(BaseModel):
+    """One step in the plan."""
+
+    step: str
+    """Short imperative description, e.g. "Add a test for the parser"."""
+    status: TodoStatus = "pending"
+    """Keep exactly one step `in_progress` at a time."""
+
+
+def render_plan(todos: list[Todo]) -> str:
+    if not todos:
+        return "(no plan yet)"
+    return "\n".join(f"[{t.status}] {t.step}" for t in todos)
+
+
+@agent.tool_defn(inherently_safe=True)
+async def update_plan(todos: list[Todo], sink: agent.Injected[list]) -> str:
+    """Record or update your step-by-step plan for the current task. Pass the FULL list every
+    time; it replaces the previous plan. Each item is `{step, status}` where status is one of
+    "pending", "in_progress", "completed". Lay out the steps before you start, mark one step
+    `in_progress`, and mark steps `completed` as you finish them, keeping exactly one in progress.
+    Skip the plan for a trivial one-step change."""
+    items = [t if isinstance(t, Todo) else Todo.model_validate(t) for t in todos]
+    sink[:] = items
+    done = sum(1 for t in items if t.status == "completed")
+    active = next((t.step for t in items if t.status == "in_progress"), None)
+    return f"Plan updated ({done}/{len(items)} done)" + (f"; in progress: {active}" if active else "")
+
+
+PLAN_TOOLS = [update_plan]

--- a/examples/portable_coding_agent/sandbox.py
+++ b/examples/portable_coding_agent/sandbox.py
@@ -21,9 +21,10 @@ lives on the worker that created it (see the README's note on placement).
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from agents import RunConfig
-from agents.sandbox import SandboxRunConfig
+from agents.sandbox import Manifest, SandboxRunConfig
 from agents.sandbox.session.sandbox_client import (
     BaseSandboxClient,
     BaseSandboxClientOptions,
@@ -36,6 +37,26 @@ SANDBOX_NAME = "coding-sandbox"
 
 def sandbox_kind() -> str:
     return os.environ.get("CODING_AGENT_SANDBOX", "docker").strip().lower()
+
+
+def workspace_root() -> Path:
+    """The project the agent works on. Search reads it; the local backend edits it in place."""
+    return Path(os.environ.get("CODING_AGENT_WORKSPACE", ".")).resolve()
+
+
+def sandbox_manifest(kind: str | None = None) -> Manifest | None:
+    """Root the LOCAL backend at the project so the agent edits it in place; None otherwise.
+
+    The docker backend cannot bind-mount a host directory (its SDK options expose no mount),
+    so it keeps an isolated workspace. The unix-local backend, given a caller-provided root, is
+    never deleted or cleared by the SDK (``workspace_root_owned`` stays False and we use no
+    snapshot), so edits land in the real repo and persist on disk. This is opt-in: it needs both
+    ``CODING_AGENT_SANDBOX=local`` and ``CODING_AGENT_WORKSPACE`` set.
+    """
+    kind = kind or sandbox_kind()
+    if kind == "local" and os.environ.get("CODING_AGENT_WORKSPACE"):
+        return Manifest(root=str(workspace_root()))
+    return None
 
 
 def _image() -> str:
@@ -77,5 +98,9 @@ def sandbox_options(kind: str | None = None) -> BaseSandboxClientOptions:
 def local_run_config() -> RunConfig:
     """RunConfig for the no-Temporal local runner: the real client, used directly."""
     return RunConfig(
-        sandbox=SandboxRunConfig(client=build_sandbox_client(), options=sandbox_options())
+        sandbox=SandboxRunConfig(
+            client=build_sandbox_client(),
+            options=sandbox_options(),
+            manifest=sandbox_manifest(),
+        )
     )

--- a/examples/portable_coding_agent/sandbox.py
+++ b/examples/portable_coding_agent/sandbox.py
@@ -1,0 +1,81 @@
+"""Sandbox selection for the coding agent.
+
+The agent's shell and file edits run inside a sandbox, so model-driven commands
+cannot touch the host beyond the sandbox. Two backends, chosen by
+``CODING_AGENT_SANDBOX``:
+
+- ``docker`` (default): a throwaway container per session. Real isolation; needs
+  a Docker daemon. The image is ``CODING_AGENT_SANDBOX_IMAGE`` (default
+  ``python:3.12-slim``).
+- ``local``: the OpenAI Agents SDK's unix-local backend. It runs the same tools
+  directly on the host with NO isolation, for a machine you already trust (your
+  own laptop, working on your own repo) or where Docker is not available.
+
+These are the OpenAI Agents SDK's own sandbox backends. The durable worker wraps
+the chosen one in the harness's ``temporal_sandbox_client`` so sandbox
+operations become activities; the local runner uses it directly. Keep the
+setting the same on every worker that serves one session: a session's sandbox
+lives on the worker that created it (see the README's note on placement).
+"""
+
+from __future__ import annotations
+
+import os
+
+from agents import RunConfig
+from agents.sandbox import SandboxRunConfig
+from agents.sandbox.session.sandbox_client import (
+    BaseSandboxClient,
+    BaseSandboxClientOptions,
+)
+
+# The provider name the worker registers and the workflow references. One
+# constant so the two sides cannot drift.
+SANDBOX_NAME = "coding-sandbox"
+
+
+def sandbox_kind() -> str:
+    return os.environ.get("CODING_AGENT_SANDBOX", "docker").strip().lower()
+
+
+def _image() -> str:
+    return os.environ.get("CODING_AGENT_SANDBOX_IMAGE", "python:3.12-slim")
+
+
+def build_sandbox_client(kind: str | None = None) -> BaseSandboxClient:
+    """The real sandbox backend (registered on a worker, or used directly by the
+    local runner). Imports are local so a worker that never uses Docker does not
+    import the Docker SDK, and vice versa."""
+    kind = kind or sandbox_kind()
+    if kind == "docker":
+        import docker
+        from agents.sandbox.sandboxes.docker import DockerSandboxClient
+
+        return DockerSandboxClient(docker_client=docker.from_env())
+    if kind == "local":
+        from agents.sandbox.sandboxes.unix_local import UnixLocalSandboxClient
+
+        return UnixLocalSandboxClient()
+    raise ValueError(f"CODING_AGENT_SANDBOX must be 'docker' or 'local', got {kind!r}")
+
+
+def sandbox_options(kind: str | None = None) -> BaseSandboxClientOptions:
+    """Options matching the active backend. Safe to build in workflow code (a
+    plain config object; it constructs no client)."""
+    kind = kind or sandbox_kind()
+    if kind == "docker":
+        from agents.sandbox.sandboxes.docker import DockerSandboxClientOptions
+
+        return DockerSandboxClientOptions(image=_image())
+    if kind == "local":
+        from agents.sandbox.sandboxes.unix_local import UnixLocalSandboxClientOptions
+
+        return UnixLocalSandboxClientOptions()
+    raise ValueError(f"CODING_AGENT_SANDBOX must be 'docker' or 'local', got {kind!r}")
+
+
+def local_run_config() -> RunConfig:
+    """RunConfig for the no-Temporal local runner: the real client, used directly."""
+    return RunConfig(
+        sandbox=SandboxRunConfig(client=build_sandbox_client(), options=sandbox_options())
+    )

--- a/examples/portable_coding_agent/web.py
+++ b/examples/portable_coding_agent/web.py
@@ -1,0 +1,44 @@
+"""Web fetch tool.
+
+For docs and error messages the repository does not contain, the agent can pull a URL's
+text. It does network I/O, so it is an activity (it runs on the worker, off the workflow).
+It is not marked inherently safe: fetching an arbitrary URL from the worker is a real
+capability (think SSRF), so under a gating policy it should be approved; a production build
+would add a domain allowlist.
+
+NB: no ``from __future__ import annotations``; the annotations build the model-facing schema
+at runtime.
+"""
+
+from datetime import timedelta
+
+from temporalio.workflow import ActivityConfig
+
+from temporal_agent_harness.harness import agent
+
+_MAX_CHARS = 20_000
+
+
+async def fetch_text(url: str) -> str:
+    import httpx
+
+    async with httpx.AsyncClient(follow_redirects=True, timeout=20.0) as client:
+        resp = await client.get(url, headers={"User-Agent": "portable-coding-agent"})
+        resp.raise_for_status()
+        text = resp.text
+    if len(text) > _MAX_CHARS:
+        return text[:_MAX_CHARS] + "\n...[truncated]"
+    return text
+
+
+@agent.activity_tool_defn(
+    activity_config=ActivityConfig(start_to_close_timeout=timedelta(seconds=30)),
+)
+async def web_fetch(url: str) -> str:
+    """Fetch a web page or raw file over HTTP(S) and return its text, for documentation or error
+    messages the repository does not contain. Returns the response body (truncated if very large).
+    Prefer the repository itself for anything already in it; use this for external references."""
+    return await fetch_text(url)
+
+
+WEB_TOOLS = [web_fetch]

--- a/examples/portable_coding_agent/worker.py
+++ b/examples/portable_coding_agent/worker.py
@@ -1,0 +1,92 @@
+"""Workers for the portable coding agent.
+
+Run from the repo root with:
+    uv run --group examples python -m examples.portable_coding_agent.worker
+
+Two workers share one process here for convenience. In a fleet, split them:
+run SESSION workers (which host the sandboxes) and MODEL workers.
+
+- The SESSION worker hosts the workflow and the sandbox backend on ``TASK_QUEUE``.
+  The ``SandboxClientProvider`` is where the real sandbox (a Docker container, or
+  the unix-local backend) actually runs; the workflow reaches it through the
+  activities the plugin registers here. Eager execution stays on and the sticky
+  timeout is short so a session's sandbox operations return to the worker that
+  holds its container.
+- The MODEL worker hosts the OpenAI model activities on ``MODEL_QUEUE``.
+
+Env vars (set in .env.local; see .env.example):
+    TEMPORAL_CONFIG_FILE / TEMPORAL_PROFILE   Temporal connection profile
+    OPENAI_API_KEY                            required; the agent calls the OpenAI API
+    CODING_AGENT_SANDBOX                       docker (default) | local
+    CODING_AGENT_SANDBOX_IMAGE                 docker image (default: python:3.12-slim)
+    CODING_AGENT_TASK_QUEUE                    session task queue (default: portable-coding-agent)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from datetime import timedelta
+
+from temporalio.client import Client
+from temporalio.envconfig import ClientConfig
+from temporalio.worker import Worker
+
+from temporal_agent_harness.ai_sdks.openai_agents import (
+    ModelActivityParameters,
+    OpenAIAgentsPlugin,
+    SandboxClientProvider,
+)
+from temporal_agent_harness.harness import agent
+
+from .codebase_search import codebase_search
+from .sandbox import SANDBOX_NAME, build_sandbox_client, sandbox_kind
+from .workflow import MODEL_QUEUE, TASK_QUEUE, PortableCodingAgentWorkflow
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+
+    session_queue = os.environ.get("CODING_AGENT_TASK_QUEUE", TASK_QUEUE)
+    model_queue = f"{session_queue}-model" if session_queue != TASK_QUEUE else MODEL_QUEUE
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        sys.exit("error: OPENAI_API_KEY env var not set")
+
+    # Register the sandbox backend + route model calls to their own queue.
+    plugin = OpenAIAgentsPlugin(
+        model_params=ModelActivityParameters(
+            task_queue=model_queue,
+            start_to_close_timeout=timedelta(minutes=3),
+        ),
+        sandbox_clients=[SandboxClientProvider(SANDBOX_NAME, build_sandbox_client())],
+    )
+    connect_config = ClientConfig.load_client_connect_config()
+    client = await Client.connect(**connect_config, plugins=[plugin])
+
+    session_worker = Worker(
+        client,
+        task_queue=session_queue,
+        workflows=[PortableCodingAgentWorkflow],
+        # codebase_search is the one activity-backed tool; the rest are the sandbox's tools, the
+        # inline plan/subagent tools, and the ask_user callback. The plugin registers the sandbox
+        # provider + model activities.
+        activities=[agent.tool_activity(codebase_search)],
+        # Keep a session's sandbox operations returning to the worker that holds its container:
+        # eager execution on, and a short sticky timeout so a lost worker is re-dispatched fast.
+        disable_eager_activity_execution=False,
+        sticky_queue_schedule_to_start_timeout=timedelta(seconds=5),
+    )
+    model_worker = Worker(client, task_queue=model_queue, activities=[])
+    print(
+        f"portable coding agent workers ready: session={session_queue!r} model={model_queue!r} "
+        f"sandbox={sandbox_kind()!r}",
+        flush=True,
+    )
+    await asyncio.gather(session_worker.run(), model_worker.run())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/portable_coding_agent/worker.py
+++ b/examples/portable_coding_agent/worker.py
@@ -43,6 +43,7 @@ from temporal_agent_harness.harness import agent
 
 from .codebase_search import codebase_search
 from .sandbox import SANDBOX_NAME, build_sandbox_client, sandbox_kind
+from .web import web_fetch
 from .workflow import MODEL_QUEUE, TASK_QUEUE, PortableCodingAgentWorkflow
 
 
@@ -70,10 +71,10 @@ async def main() -> None:
         client,
         task_queue=session_queue,
         workflows=[PortableCodingAgentWorkflow],
-        # codebase_search is the one activity-backed tool; the rest are the sandbox's tools, the
-        # inline plan/subagent tools, and the ask_user callback. The plugin registers the sandbox
-        # provider + model activities.
-        activities=[agent.tool_activity(codebase_search)],
+        # codebase_search and web_fetch are the activity-backed tools; the rest are the sandbox's
+        # tools, the inline plan/subagent tools, and the ask_user callback. The plugin registers the
+        # sandbox provider + model activities.
+        activities=[agent.tool_activity(codebase_search), agent.tool_activity(web_fetch)],
         # Keep a session's sandbox operations returning to the worker that holds its container:
         # eager execution on, and a short sticky timeout so a lost worker is re-dispatched fast.
         disable_eager_activity_execution=False,

--- a/examples/portable_coding_agent/workflow.py
+++ b/examples/portable_coding_agent/workflow.py
@@ -40,6 +40,8 @@ from temporalio.workflow import ActivityConfig
 with workflow.unsafe.imports_passed_through():
     from agents import RunConfig, Runner, TResponseInputItem
     from agents.sandbox import SandboxAgent, SandboxRunConfig
+    from agents.sandbox.session.sandbox_session import SandboxSession
+    from agents.sandbox.session.sandbox_session_state import SandboxSessionState
 
     from temporal_agent_harness.ai_sdks.openai_agents.workflow import temporal_sandbox_client
     from temporal_agent_harness.ai_sdks.openai_agents_harness import as_openai_agent_tools
@@ -56,7 +58,7 @@ with workflow.unsafe.imports_passed_through():
     from .ask import ASK_TOOLS
     from .codebase_search import SEARCH_TOOLS
     from .plan import PLAN_TOOLS
-    from .sandbox import SANDBOX_NAME, sandbox_options
+    from .sandbox import SANDBOX_NAME, sandbox_manifest, sandbox_options
 
 
 TASK_QUEUE = "portable-coding-agent"
@@ -112,10 +114,27 @@ class PortableCodingAgentWorkflow:
         self._conversation: list[TResponseInputItem] = []
         # The plan, durable workflow state, edited in place by `update_plan`.
         self._todos: list = []
+        # The sandbox is created once for the session and reused every turn; only its serializable
+        # state lives in workflow state, so a lost worker can resume the same sandbox (subject to the
+        # placement note in the README). None until the first turn creates it.
+        self._sandbox_state: SandboxSessionState | None = None
+
+    def _sandbox_client(self):
+        return temporal_sandbox_client(
+            SANDBOX_NAME, config=ActivityConfig(start_to_close_timeout=timedelta(minutes=5))
+        )
 
     @workflow.run
     async def run(self, _config: AgentConfig) -> None:
-        await self._runner.run(self)
+        try:
+            await self._runner.run(self)
+        finally:
+            # The session is ours (owns_session=False in the SDK), so nothing else deletes it.
+            # Reclaim the sandbox when the agent closes; an abandoned workflow is swept out of band.
+            if self._sandbox_state is not None:
+                client = self._sandbox_client()
+                await client.delete(await client.resume(self._sandbox_state))
+                self._sandbox_state = None
 
     @agent.accepts
     async def ask(self, message: TextMessage) -> TextReply:
@@ -141,21 +160,30 @@ class PortableCodingAgentWorkflow:
             instructions=SYSTEM_INSTRUCTION,
             tools=tools,
         )
+        # Reuse one sandbox for the whole session: create it on the first turn, resume it after.
+        # Each sandbox operation (create / resume / exec / read / write / delete) is a Temporal
+        # activity. Passing a live session (not client/options) makes the SDK treat it as not-owned,
+        # so it does NOT delete the sandbox at the end of the run and files persist to the next turn.
+        client = self._sandbox_client()
+        if self._sandbox_state is None:
+            session: SandboxSession = await client.create(
+                manifest=sandbox_manifest(), options=sandbox_options()
+            )
+        else:
+            session = await client.resume(self._sandbox_state)
+        # Pass BOTH: the SDK prefers `session` (so it reuses this one and does not delete it), while
+        # `client`/`options` satisfy the harness runner's requirement that a temporal client is set.
         run_config = RunConfig(
             sandbox=SandboxRunConfig(
-                # Reference the worker-registered backend by name; each sandbox operation
-                # (create / exec / read / write / delete) becomes a Temporal activity.
-                client=temporal_sandbox_client(
-                    SANDBOX_NAME,
-                    config=ActivityConfig(start_to_close_timeout=timedelta(minutes=5)),
-                ),
-                options=sandbox_options(),
+                client=client, session=session, options=sandbox_options()
             )
         )
+
         input_items: list[TResponseInputItem] = [
             *self._conversation,
             {"role": "user", "content": message.text},
         ]
         result = await Runner.run(sdk_agent, input=input_items, run_config=run_config)
         self._conversation = result.to_input_list()
+        self._sandbox_state = session.state
         return TextReply(text=str(result.final_output))

--- a/examples/portable_coding_agent/workflow.py
+++ b/examples/portable_coding_agent/workflow.py
@@ -9,20 +9,21 @@ named backend through ``temporal_sandbox_client`` and each sandbox operation
 becomes a Temporal activity, served by the ``SandboxClientProvider`` the worker
 registers (see ``worker.py``).
 
-Sandbox lifetime is worth knowing. Today each message runs one ``Runner.run``,
-which creates a fresh sandbox on first tool use and the SDK deletes it at the end
-of the run, so file state does NOT carry across messages (only the durable
-conversation does). Reusing one sandbox across a session's messages means holding
-its session state in workflow state and passing it back on the next run; that is
-the main open item for this example (see the README).
+One sandbox is reused for the whole session: the first message creates it, later
+messages resume it, and it is deleted when the agent closes. The SDK deletes a
+sandbox at the end of a run unless a live session is passed in, so the workflow
+keeps only the serializable session state in workflow state and passes a resumed
+live session each turn (which the SDK treats as not-owned, so it survives), and a
+file written in one message is there in the next.
 
 Two placement facts worth knowing when a pool of workers serves many sessions:
 
-- Within a single message, the sandbox operations (create / exec / read / write /
-  delete) go to the workflow's own task queue and are dispatched eagerly, so they
-  tend to return to the worker that holds the container; a sandbox operation that
-  lands on a worker without it cannot serve it. Once the sandbox is reused across
-  messages this becomes a real session-affinity requirement.
+- The sandbox's operations (create / resume / exec / read / write / delete) go to
+  the workflow's own task queue and are dispatched eagerly, so they tend to return
+  to the worker that holds the container. Because the sandbox persists across
+  messages, this is a hard session-affinity requirement: an operation that lands
+  on a worker without the container cannot serve it, and the ``docker`` backend
+  can resume only on the host that still has it.
 - The MODEL call runs on its own task queue (set on the plugin in ``worker.py``),
   since it is the long, provider-bound step.
 

--- a/examples/portable_coding_agent/workflow.py
+++ b/examples/portable_coding_agent/workflow.py
@@ -59,11 +59,32 @@ with workflow.unsafe.imports_passed_through():
     from .codebase_search import SEARCH_TOOLS
     from .plan import PLAN_TOOLS
     from .sandbox import SANDBOX_NAME, sandbox_manifest, sandbox_options
+    from .web import WEB_TOOLS
 
 
 TASK_QUEUE = "portable-coding-agent"
 MODEL_QUEUE = f"{TASK_QUEUE}-model"
 DEFAULT_MODEL = "gpt-5-mini"
+# A subagent is another instance of this workflow driven as a child. Cap how deep delegation can
+# nest (1 = only the top-level agent delegates), so a subagent cannot spawn subagents without bound.
+MAX_DELEGATION_DEPTH = 1
+
+SUBAGENT_ADDENDUM = """
+
+You are a subagent handling one delegated sub-task. You cannot ask the user, so do not wait on \
+anyone: make a reasonable assumption, state it in your reply, and finish the sub-task yourself."""
+
+
+def _subagent_policy(agent_id: str | None) -> tuple[bool, bool]:
+    """Return (can_ask_user, can_delegate) from the agent's id depth.
+
+    A subagent's ``agent_id`` is a compound ``{parent}-{child}`` id (a top-level agent's is a
+    single segment or None), so the number of ``-`` separators is the delegation depth. Only the
+    top-level agent has a client attached to answer ``ask_user``; a subagent that asked would block
+    forever. Delegation is allowed only while under ``MAX_DELEGATION_DEPTH``.
+    """
+    depth = agent_id.count("-") if agent_id else 0
+    return depth == 0, depth < MAX_DELEGATION_DEPTH
 
 
 SYSTEM_INSTRUCTION = """\
@@ -78,7 +99,8 @@ before you rely on it. Work only inside the sandbox workspace.
 How to work:
 - UNDERSTAND first. Explore before you change anything: list directories, read the files you will \
 touch, and search. Use `codebase_search` to find relevant code by meaning ("where are retries \
-configured") and plain text search for exact strings. Read a file before you edit it.
+configured") and shell tools like `grep` and `find` for exact strings and file names. Read a file \
+before you edit it.
 - PLAN multi-step work with `update_plan`: lay out the steps, mark one `in_progress`, and mark \
 each `completed` as you finish, keeping exactly one in progress. Skip the plan for a trivial \
 one-step change.
@@ -86,7 +108,11 @@ one-step change.
 `ask_user` rather than guess.
 - DELEGATE a self-contained sub-task to a subagent when it helps (for example a focused search or \
 a mechanical change across files); give it everything it needs, use its result, and carry on.
-- Make small, surgical edits that match the project's existing style and conventions.
+- Use `web_fetch` for documentation or an error message that is not in the repository; prefer the \
+repository itself for anything already in it.
+- Make small, surgical edits that match the project's existing style and conventions. If an edit \
+does not apply cleanly, re-read the exact lines and retry with more surrounding context rather than \
+forcing it or guessing the file's contents.
 - VERIFY your work. Run the build or the relevant test after a change and fix what you broke; \
 prefer the narrowest check that proves the change.
 - Keep command output small: read and search targeted regions rather than dumping whole files or \
@@ -114,6 +140,8 @@ class PortableCodingAgentWorkflow:
         self._conversation: list[TResponseInputItem] = []
         # The plan, durable workflow state, edited in place by `update_plan`.
         self._todos: list = []
+        # Compound id when this instance is a subagent; gates ask_user + delegation depth.
+        self._agent_id = config.agent_id
         # The sandbox is created once for the session and reused every turn; only its serializable
         # state lives in workflow state, so a lost worker can resume the same sandbox (subject to the
         # placement note in the README). None until the first turn creates it.
@@ -145,19 +173,23 @@ class PortableCodingAgentWorkflow:
         # plan (inline, its sink is the workflow's todo list), ask_user (a callback the client
         # answers), codebase_search (an activity), and a `task` subagent toolset that drives
         # another instance of this agent as a child workflow.
+        can_ask, can_delegate = _subagent_policy(self._agent_id)
         tools = [
             *as_openai_agent_tools(self._runner, PLAN_TOOLS, injections={"sink": self._todos}),
-            *as_openai_agent_tools(self._runner, ASK_TOOLS),
             *as_openai_agent_tools(self._runner, SEARCH_TOOLS),
-            *as_openai_agent_tools(
+            *as_openai_agent_tools(self._runner, WEB_TOOLS),
+        ]
+        if can_ask:
+            tools += as_openai_agent_tools(self._runner, ASK_TOOLS)
+        if can_delegate:
+            tools += as_openai_agent_tools(
                 self._runner,
                 subagent_toolset(PortableCodingAgentWorkflow, key="task", task_queue=TASK_QUEUE),
-            ),
-        ]
+            )
         sdk_agent = SandboxAgent(
             name="PortableCodingAgent",
             model=DEFAULT_MODEL,
-            instructions=SYSTEM_INSTRUCTION,
+            instructions=SYSTEM_INSTRUCTION if can_ask else SYSTEM_INSTRUCTION + SUBAGENT_ADDENDUM,
             tools=tools,
         )
         # Reuse one sandbox for the whole session: create it on the first turn, resume it after.

--- a/examples/portable_coding_agent/workflow.py
+++ b/examples/portable_coding_agent/workflow.py
@@ -1,0 +1,146 @@
+"""A durable coding agent whose shell and file edits run in a SANDBOX.
+
+The user chats in plain text ("add a test for X", "why does this crash?") and a
+model in the loop works by running shell commands and editing files. Those tools
+are the OpenAI Agents SDK's sandbox tools (``SandboxAgent`` with the default
+filesystem + shell capabilities), so every command runs inside a sandbox, not on
+the worker. The harness makes the sandbox durable: the workflow references a
+named backend through ``temporal_sandbox_client`` and each sandbox operation
+becomes a Temporal activity, served by the ``SandboxClientProvider`` the worker
+registers (see ``worker.py``).
+
+Two placement facts worth knowing when a pool of workers serves many sessions:
+
+- A session's sandbox lives on the worker that created it (a Docker container on
+  that host). The sandbox activities go to the workflow's own task queue and are
+  dispatched eagerly, so they tend to return to that worker. With a pool this
+  wants the same locality guarantees as any session-bound worker state; a
+  sandbox operation that lands on a worker without the container cannot serve it.
+- The MODEL call runs on its own task queue (set on the plugin in ``worker.py``),
+  since it is the long, provider-bound step.
+
+The same sandbox agent runs with no server through ``local_runner.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.contrib.workflow_streams import WorkflowStream
+from temporalio.workflow import ActivityConfig
+
+with workflow.unsafe.imports_passed_through():
+    from agents import RunConfig, Runner, TResponseInputItem
+    from agents.sandbox import SandboxAgent, SandboxRunConfig
+
+    from temporal_agent_harness.ai_sdks.openai_agents.workflow import temporal_sandbox_client
+    from temporal_agent_harness.ai_sdks.openai_agents_harness import as_openai_agent_tools
+    from temporal_agent_harness.harness import agent
+    from temporal_agent_harness.harness.agent_protocol import (
+        AgentConfig,
+        TextMessage,
+        TextReply,
+        ToolApprovalPolicy,
+    )
+    from temporal_agent_harness.harness.agent_workflow import AgentWorkflowRunner
+    from temporal_agent_harness.harness.subagent_toolset import subagent_toolset
+
+    from .ask import ASK_TOOLS
+    from .codebase_search import SEARCH_TOOLS
+    from .plan import PLAN_TOOLS
+    from .sandbox import SANDBOX_NAME, sandbox_options
+
+
+TASK_QUEUE = "portable-coding-agent"
+MODEL_QUEUE = f"{TASK_QUEUE}-model"
+DEFAULT_MODEL = "gpt-5-mini"
+
+
+SYSTEM_INSTRUCTION = """\
+You are a coding agent working inside a sandbox. The user talks to you in plain language, and YOU \
+do the work by exploring the project, editing files, and running commands, then verifying the \
+result. You act only through your tools.
+
+How to work:
+- UNDERSTAND first. Explore before you change anything: list directories, read the files you will \
+touch, and search. Use `codebase_search` to find relevant code by meaning ("where are retries \
+configured") and plain text search for exact strings. Read a file before you edit it.
+- PLAN multi-step work with `update_plan`: lay out the steps, mark one `in_progress`, and mark \
+each `completed` as you finish, keeping exactly one in progress. Skip the plan for a trivial \
+one-step change.
+- ASK when it matters. If the task is ambiguous or needs a decision only the user can make, call \
+`ask_user` rather than guess.
+- DELEGATE a self-contained sub-task with `task` when it helps (for example a focused search or a \
+mechanical change across files); use its result and carry on.
+- Make small, surgical edits that match the project's existing style and conventions.
+- VERIFY your work. Run the build or the relevant test after a change and fix what you broke; \
+prefer the narrowest check that proves the change.
+- Work in parallel when it is safe: batch independent reads and searches into one step.
+- Keep going until the task is actually done. Then reply in brief prose: what you changed, which \
+files, and how you checked it. Never invent file contents or command output you did not see."""
+
+
+@workflow.defn(name="PortableCodingAgent")
+@agent.defn
+class PortableCodingAgentWorkflow:
+    @workflow.init
+    def __init__(self, config: AgentConfig) -> None:
+        # The sandbox is the safety boundary here: the model's commands run inside it, not on the
+        # worker, so this agent does not gate individual tool calls. (Per-command approval would be
+        # added with the harness approval policy if commands ran on the host.)
+        self._runner = AgentWorkflowRunner(
+            config,
+            stream=WorkflowStream(),
+            approval_policy_default=ToolApprovalPolicy.dangerously_skip_all(),
+        )
+        self._conversation: list[TResponseInputItem] = []
+        # The plan, durable workflow state, edited in place by `update_plan`.
+        self._todos: list = []
+
+    @workflow.run
+    async def run(self, _config: AgentConfig) -> None:
+        await self._runner.run(self)
+
+    @agent.accepts
+    async def ask(self, message: TextMessage) -> TextReply:
+        """Chat with the coding agent. Ask it to explain, fix, refactor, test, or run something; it
+        works in a sandbox by running shell commands and editing files, and replies with what it
+        did."""
+        # The sandbox supplies read / edit / shell. The rest are harness tools composed on top:
+        # plan (inline, its sink is the workflow's todo list), ask_user (a callback the client
+        # answers), codebase_search (an activity), and a `task` subagent toolset that drives
+        # another instance of this agent as a child workflow.
+        tools = [
+            *as_openai_agent_tools(self._runner, PLAN_TOOLS, injections={"sink": self._todos}),
+            *as_openai_agent_tools(self._runner, ASK_TOOLS),
+            *as_openai_agent_tools(self._runner, SEARCH_TOOLS),
+            *as_openai_agent_tools(
+                self._runner,
+                subagent_toolset(PortableCodingAgentWorkflow, key="task", task_queue=TASK_QUEUE),
+            ),
+        ]
+        sdk_agent = SandboxAgent(
+            name="PortableCodingAgent",
+            model=DEFAULT_MODEL,
+            instructions=SYSTEM_INSTRUCTION,
+            tools=tools,
+        )
+        run_config = RunConfig(
+            sandbox=SandboxRunConfig(
+                # Reference the worker-registered backend by name; each sandbox operation
+                # (create / exec / read / write / delete) becomes a Temporal activity.
+                client=temporal_sandbox_client(
+                    SANDBOX_NAME,
+                    config=ActivityConfig(start_to_close_timeout=timedelta(minutes=5)),
+                ),
+                options=sandbox_options(),
+            )
+        )
+        input_items: list[TResponseInputItem] = [
+            *self._conversation,
+            {"role": "user", "content": message.text},
+        ]
+        result = await Runner.run(sdk_agent, input=input_items, run_config=run_config)
+        self._conversation = result.to_input_list()
+        return TextReply(text=str(result.final_output))

--- a/examples/portable_coding_agent/workflow.py
+++ b/examples/portable_coding_agent/workflow.py
@@ -9,13 +9,20 @@ named backend through ``temporal_sandbox_client`` and each sandbox operation
 becomes a Temporal activity, served by the ``SandboxClientProvider`` the worker
 registers (see ``worker.py``).
 
+Sandbox lifetime is worth knowing. Today each message runs one ``Runner.run``,
+which creates a fresh sandbox on first tool use and the SDK deletes it at the end
+of the run, so file state does NOT carry across messages (only the durable
+conversation does). Reusing one sandbox across a session's messages means holding
+its session state in workflow state and passing it back on the next run; that is
+the main open item for this example (see the README).
+
 Two placement facts worth knowing when a pool of workers serves many sessions:
 
-- A session's sandbox lives on the worker that created it (a Docker container on
-  that host). The sandbox activities go to the workflow's own task queue and are
-  dispatched eagerly, so they tend to return to that worker. With a pool this
-  wants the same locality guarantees as any session-bound worker state; a
-  sandbox operation that lands on a worker without the container cannot serve it.
+- Within a single message, the sandbox operations (create / exec / read / write /
+  delete) go to the workflow's own task queue and are dispatched eagerly, so they
+  tend to return to the worker that holds the container; a sandbox operation that
+  lands on a worker without it cannot serve it. Once the sandbox is reused across
+  messages this becomes a real session-affinity requirement.
 - The MODEL call runs on its own task queue (set on the plugin in ``worker.py``),
   since it is the long, provider-bound step.
 
@@ -62,6 +69,10 @@ You are a coding agent working inside a sandbox. The user talks to you in plain 
 do the work by exploring the project, editing files, and running commands, then verifying the \
 result. You act only through your tools.
 
+Your sandbox may start empty or already hold the user's project, and it may not persist between \
+messages, so do not assume files you saw earlier are still there: check what is actually present \
+before you rely on it. Work only inside the sandbox workspace.
+
 How to work:
 - UNDERSTAND first. Explore before you change anything: list directories, read the files you will \
 touch, and search. Use `codebase_search` to find relevant code by meaning ("where are retries \
@@ -71,12 +82,16 @@ each `completed` as you finish, keeping exactly one in progress. Skip the plan f
 one-step change.
 - ASK when it matters. If the task is ambiguous or needs a decision only the user can make, call \
 `ask_user` rather than guess.
-- DELEGATE a self-contained sub-task with `task` when it helps (for example a focused search or a \
-mechanical change across files); use its result and carry on.
+- DELEGATE a self-contained sub-task to a subagent when it helps (for example a focused search or \
+a mechanical change across files); give it everything it needs, use its result, and carry on.
 - Make small, surgical edits that match the project's existing style and conventions.
 - VERIFY your work. Run the build or the relevant test after a change and fix what you broke; \
 prefer the narrowest check that proves the change.
+- Keep command output small: read and search targeted regions rather than dumping whole files or \
+long logs; pipe through head/tail or grep when you need only part.
 - Work in parallel when it is safe: batch independent reads and searches into one step.
+- Do not spin. If the same step fails a couple of times, change approach; if you are still \
+blocked, say what is blocking you (or ask) instead of looping.
 - Keep going until the task is actually done. Then reply in brief prose: what you changed, which \
 files, and how you checked it. Never invent file contents or command output you did not see."""
 

--- a/temporal_agent_harness/ai_sdks/openai_agents/_invoke_model_activity.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_invoke_model_activity.py
@@ -193,7 +193,11 @@ class ActivityModelInput(TypedDict, total=False):
 
     model_name: str | None
     system_instructions: str | None
-    input: Required[str | list[TResponseInputItem]]
+    # Opaque JSON, not the typed item union. The workflow already sends wire-shaped items, and
+    # validating them back into the union here made pydantic hand the SDK lazy ValidatorIterators
+    # for Iterable-typed fields (content / summary / output); detached from their validation
+    # context those cannot be re-serialized. Forwarding the items untouched keeps them consumable.
+    input: Required[str | list[Any]]
     model_settings: Required[ModelSettings]
     tools: list[ToolInput]
     output_schema: AgentOutputSchemaInput | None

--- a/temporal_agent_harness/utils/large_payload_gc.py
+++ b/temporal_agent_harness/utils/large_payload_gc.py
@@ -1,0 +1,137 @@
+"""Retention sweep for the large-payload offload store.
+
+``large_payload.py`` offloads oversized payloads and keys them by content
+hash. Neither the local driver nor the S3 driver ever deletes: the module's own
+note says offloaded objects "just accumulate" and points at a bucket lifecycle
+rule as the only cleanup. This adds an in-repo alternative, so a deployment that
+cannot set a bucket policy (or uses the local driver) still has a way to reclaim
+space.
+
+The sweep deletes offloaded objects older than a window. Age is measured from
+the object's last-modified time, which for these drivers is its FIRST-store time
+(both dedupe by content hash and skip re-writing an existing object, so re-use
+does not refresh the timestamp). Two consequences to size the window against:
+
+- An offloaded payload is safe to delete only once nothing can still claim it.
+  A claim lives in Event History, so keep the window LONGER than the namespace
+  retention period, and longer than the oldest live workflow that might replay.
+- Because re-use does not refresh the timestamp, a long-lived workflow that
+  keeps referencing one old payload could have it swept. In practice the agent's
+  offloaded payloads are per-turn conversation snapshots whose bytes change every
+  turn, so each turn writes a fresh object and the old ones become unreferenced.
+  Do not point this at a store whose objects are long-lived and re-referenced.
+
+Run it from cron or a Temporal Schedule::
+
+    python -m temporal_agent_harness.utils.large_payload_gc --days 7
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from temporal_agent_harness.utils.large_payload import _BASE_DIR
+
+
+@dataclass
+class SweepResult:
+    scanned: int = 0
+    deleted: int = 0
+    freed_bytes: int = 0
+
+
+def sweep_local(older_than_epoch: float, base_dir: Path | None = None) -> SweepResult:
+    """Delete offloaded blobs (and stale temp files) under the local store whose
+    mtime is older than ``older_than_epoch``. A missing store is not an error."""
+    base = Path(base_dir) if base_dir is not None else _BASE_DIR
+    result = SweepResult()
+    if not base.exists():
+        return result
+    for path in base.iterdir():
+        # The local driver writes `{sha256}.bin` and, briefly, `.tmp` files it
+        # renames into place; a crashed store can strand a `.tmp`, so both age
+        # out through here.
+        if not path.is_file() or path.suffix not in (".bin", ".tmp"):
+            continue
+        try:
+            stat = path.stat()
+        except OSError:
+            continue  # deleted underneath us; a sweep can run beside live traffic
+        result.scanned += 1
+        if stat.st_mtime < older_than_epoch:
+            try:
+                path.unlink()
+            except OSError:
+                continue
+            result.deleted += 1
+            result.freed_bytes += stat.st_size
+    return result
+
+
+async def sweep_s3(
+    older_than_epoch: float, bucket: str | None = None
+) -> SweepResult:
+    """Delete objects in the S3 offload bucket older than ``older_than_epoch``.
+
+    Uses aioboto3 and the standard AWS credential/endpoint chain, matching
+    ``large_payload._s3_storage_driver`` (so ``AWS_ENDPOINT_URL`` retargets it at
+    MinIO or a mock the same way)."""
+    import aioboto3
+
+    bucket = bucket or os.environ.get("LARGE_PAYLOAD_S3_BUCKET")
+    if not bucket:
+        raise RuntimeError("sweep_s3 requires LARGE_PAYLOAD_S3_BUCKET (or an explicit bucket)")
+    result = SweepResult()
+    session = aioboto3.Session()
+    async with session.client("s3") as s3:
+        paginator = s3.get_paginator("list_objects_v2")
+        async for page in paginator.paginate(Bucket=bucket):
+            expired = []
+            for obj in page.get("Contents", []):
+                result.scanned += 1
+                if obj["LastModified"].timestamp() < older_than_epoch:
+                    expired.append({"Key": obj["Key"]})
+                    result.deleted += 1
+                    result.freed_bytes += obj.get("Size", 0)
+            # DeleteObjects takes up to 1000 keys, the list page size, so one
+            # delete per page covers it.
+            if expired:
+                await s3.delete_objects(Bucket=bucket, Delete={"Objects": expired, "Quiet": True})
+    return result
+
+
+async def sweep(older_than_epoch: float) -> SweepResult:
+    """Sweep the store selected by ``LARGE_PAYLOAD_DRIVER`` (mirrors the driver
+    selection in ``large_payload``)."""
+    kind = os.environ.get("LARGE_PAYLOAD_DRIVER", "local").strip().lower()
+    if kind == "local":
+        return sweep_local(older_than_epoch)
+    if kind == "s3":
+        return await sweep_s3(older_than_epoch)
+    raise ValueError(f"unknown LARGE_PAYLOAD_DRIVER={kind!r}; expected 'local' or 's3'")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Delete offloaded payloads older than a window.")
+    parser.add_argument(
+        "--days", type=float, default=7.0, help="delete objects older than this many days (default 7)"
+    )
+    args = parser.parse_args()
+    if args.days <= 0:
+        parser.error("--days must be positive")
+    # No wall-clock inside a workflow here: this is an ops CLI, not workflow code.
+    cutoff = time.time() - args.days * 86_400
+    result = asyncio.run(sweep(cutoff))
+    print(
+        f"scanned {result.scanned}, deleted {result.deleted}, "
+        f"freed {result.freed_bytes / 1_048_576:.1f} MB (older than {args.days} days)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/examples/portable_coding_agent/test_codebase_search.py
+++ b/tests/examples/portable_coding_agent/test_codebase_search.py
@@ -1,0 +1,75 @@
+"""Tests for the semantic-search machinery (examples.portable_coding_agent.codebase_search).
+
+A deterministic keyword-count embedder stands in for the real embedding model, so
+ranking, incremental content-hash caching, and chunking are all exercised offline.
+"""
+
+from pathlib import Path
+
+from examples.portable_coding_agent.codebase_search import (
+    CodebaseIndex,
+    _chunks,
+    format_hits,
+)
+
+VOCAB = ["retry", "token", "parse", "fibonacci"]
+
+
+def _stub_embed(texts):
+    # Similar text -> similar vector, so cosine ranking is meaningful without a real model.
+    return [[float(t.lower().count(w)) for w in VOCAB] for t in texts]
+
+
+def _repo(base: Path) -> Path:
+    # A subdirectory, so a cache file kept beside it is not itself indexed.
+    repo = base / "repo"
+    repo.mkdir(parents=True)
+    (repo / "retry.py").write_text("def retry():\n    # retry with backoff, retry again\n    ...\n")
+    (repo / "auth.py").write_text("def make_token():\n    return build_token()\n")
+    (repo / "math_utils.py").write_text("def fibonacci(n):\n    ...\n")
+    (repo / "node_modules").mkdir()
+    (repo / "node_modules" / "dep.py").write_text("retry retry retry\n")  # must be skipped
+    return repo
+
+
+def test_search_ranks_the_relevant_file_first(tmp_path: Path):
+    index = CodebaseIndex(_repo(tmp_path), _stub_embed)
+    index.index()
+    hits = index.search("how does retry backoff work", k=3)
+    assert hits, "expected matches"
+    assert hits[0][0] == "retry.py"
+
+
+def test_vendored_dirs_are_skipped(tmp_path: Path):
+    index = CodebaseIndex(_repo(tmp_path), _stub_embed)
+    index.index()
+    assert all("node_modules" not in path for path, *_ in index.search("retry", k=10))
+
+
+def test_content_hash_cache_makes_reindex_incremental(tmp_path: Path):
+    repo = _repo(tmp_path)
+    cache = tmp_path / "cache.json"  # sibling of repo/, not indexed
+    first = CodebaseIndex(repo, _stub_embed, cache_path=cache)
+    embedded_first = first.index()
+    assert embedded_first > 0
+
+    # A fresh index over the same unchanged tree re-embeds nothing (all hashes cached).
+    second = CodebaseIndex(repo, _stub_embed, cache_path=cache)
+    assert second.index() == 0
+
+    # Changing one file re-embeds only its chunk.
+    (repo / "auth.py").write_text("def make_token():\n    return refreshed_token()\n")
+    third = CodebaseIndex(repo, _stub_embed, cache_path=cache)
+    assert third.index() == 1
+
+
+def test_chunks_split_and_keep_line_ranges():
+    text = "\n".join(f"line {i}" for i in range(1, 131))
+    chunks = _chunks(text)
+    assert len(chunks) >= 2
+    assert chunks[0][0] == 1
+    assert chunks[1][0] == chunks[0][1] + 1
+
+
+def test_format_hits_empty():
+    assert format_hits(Path("/x"), []) == "no matches"

--- a/tests/examples/portable_coding_agent/test_codebase_search.py
+++ b/tests/examples/portable_coding_agent/test_codebase_search.py
@@ -40,6 +40,29 @@ def test_search_ranks_the_relevant_file_first(tmp_path: Path):
     assert hits[0][0] == "retry.py"
 
 
+def test_search_results_carry_the_code(tmp_path: Path):
+    # Results include the matched chunk body, not just line ranges, so they are usable even
+    # when the tool cannot read the file back (e.g. an isolated sandbox).
+    index = CodebaseIndex(_repo(tmp_path), _stub_embed)
+    index.index()
+    top = index.search("retry backoff", k=1)[0]
+    body = top[4]
+    assert "retry" in body
+    assert "retry.py" in format_hits(index._root, [top])
+    assert body in format_hits(index._root, [top])
+
+
+def test_secret_and_lockfiles_are_skipped(tmp_path: Path):
+    repo = _repo(tmp_path)
+    (repo / ".env").write_text("OPENAI_API_KEY=retry-secret\n")
+    (repo / "uv.lock").write_text("retry\n")
+    index = CodebaseIndex(repo, _stub_embed)
+    index.index()
+    paths = {path for path, *_ in index.search("retry", k=10)}
+    assert ".env" not in paths
+    assert "uv.lock" not in paths
+
+
 def test_vendored_dirs_are_skipped(tmp_path: Path):
     index = CodebaseIndex(_repo(tmp_path), _stub_embed)
     index.index()

--- a/tests/examples/portable_coding_agent/test_plan.py
+++ b/tests/examples/portable_coding_agent/test_plan.py
@@ -1,0 +1,29 @@
+"""Tests for the plan tool's pure pieces (examples.portable_coding_agent.plan)."""
+
+import pytest
+
+from examples.portable_coding_agent.plan import Todo, render_plan
+
+
+def test_render_empty_plan():
+    assert render_plan([]) == "(no plan yet)"
+
+
+def test_render_plan_lines():
+    todos = [
+        Todo(step="read config.py", status="completed"),
+        Todo(step="add the flag", status="in_progress"),
+        Todo(step="write a test"),
+    ]
+    assert render_plan(todos) == (
+        "[completed] read config.py\n[in_progress] add the flag\n[pending] write a test"
+    )
+
+
+def test_todo_defaults_to_pending():
+    assert Todo(step="x").status == "pending"
+
+
+def test_todo_rejects_unknown_status():
+    with pytest.raises(ValueError):
+        Todo(step="x", status="blocked")

--- a/tests/examples/portable_coding_agent/test_sandbox.py
+++ b/tests/examples/portable_coding_agent/test_sandbox.py
@@ -1,0 +1,50 @@
+"""Tests for sandbox backend selection (examples.portable_coding_agent.sandbox).
+
+These check the routing (env -> backend type, and options matching the backend)
+without creating a container, so they run anywhere. The live sandbox execution is
+exercised by hand (see the example README).
+"""
+
+import os
+
+import pytest
+
+from examples.portable_coding_agent import sandbox as sb
+
+
+@pytest.fixture(autouse=True)
+def _restore_env():
+    prev = {k: os.environ.get(k) for k in ("CODING_AGENT_SANDBOX", "CODING_AGENT_SANDBOX_IMAGE")}
+    try:
+        yield
+    finally:
+        for k, v in prev.items():
+            os.environ.pop(k, None) if v is None else os.environ.__setitem__(k, v)
+
+
+def test_default_kind_is_docker():
+    os.environ.pop("CODING_AGENT_SANDBOX", None)
+    assert sb.sandbox_kind() == "docker"
+
+
+def test_local_backend_builds_without_docker():
+    os.environ["CODING_AGENT_SANDBOX"] = "local"
+    client = sb.build_sandbox_client()
+    assert type(client).__name__ == "UnixLocalSandboxClient"
+    assert type(sb.sandbox_options()).__name__ == "UnixLocalSandboxClientOptions"
+
+
+def test_docker_options_carry_the_image():
+    os.environ["CODING_AGENT_SANDBOX"] = "docker"
+    os.environ["CODING_AGENT_SANDBOX_IMAGE"] = "python:3.12-slim"
+    opts = sb.sandbox_options()
+    assert type(opts).__name__ == "DockerSandboxClientOptions"
+    assert opts.image == "python:3.12-slim"
+
+
+def test_unknown_kind_is_rejected():
+    os.environ["CODING_AGENT_SANDBOX"] = "vm"
+    with pytest.raises(ValueError, match="docker.*local"):
+        sb.build_sandbox_client()
+    with pytest.raises(ValueError, match="docker.*local"):
+        sb.sandbox_options()

--- a/tests/examples/portable_coding_agent/test_subagent_wiring.py
+++ b/tests/examples/portable_coding_agent/test_subagent_wiring.py
@@ -2,7 +2,10 @@
 
 from temporal_agent_harness.harness.subagent_toolset import subagent_toolset
 
-from examples.portable_coding_agent.workflow import PortableCodingAgentWorkflow
+from examples.portable_coding_agent.workflow import (
+    PortableCodingAgentWorkflow,
+    _subagent_policy,
+)
 
 
 def test_task_toolset_generates_start_send_stop():
@@ -14,3 +17,12 @@ def test_task_toolset_generates_start_send_stop():
     assert "start_task" in names
     assert "stop_task" in names
     assert any("ask" in n for n in names)
+
+
+def test_subagent_policy_gates_ask_and_delegation_by_depth():
+    # Top-level (no id, or a single-segment id): can ask the user and can delegate.
+    assert _subagent_policy(None) == (True, True)
+    assert _subagent_policy("abcdef") == (True, True)
+    # A subagent (compound id) cannot ask the user, and at the depth cap cannot delegate further.
+    assert _subagent_policy("abcdef-123456") == (False, False)
+    assert _subagent_policy("abcdef-123456-789abc") == (False, False)

--- a/tests/examples/portable_coding_agent/test_subagent_wiring.py
+++ b/tests/examples/portable_coding_agent/test_subagent_wiring.py
@@ -1,0 +1,16 @@
+"""Static check that the `task` subagent toolset wires up (no workflow started)."""
+
+from temporal_agent_harness.harness.subagent_toolset import subagent_toolset
+
+from examples.portable_coding_agent.workflow import PortableCodingAgentWorkflow
+
+
+def test_task_toolset_generates_start_send_stop():
+    tools = subagent_toolset(
+        PortableCodingAgentWorkflow, key="task", task_queue="portable-coding-agent"
+    )
+    names = {t.__name__ for t in tools}
+    # start_<key>, one send tool per @agent.accepts handler (ask), and stop_<key>.
+    assert "start_task" in names
+    assert "stop_task" in names
+    assert any("ask" in n for n in names)

--- a/tests/utils/test_large_payload_gc.py
+++ b/tests/utils/test_large_payload_gc.py
@@ -1,0 +1,125 @@
+"""Tests for the large-payload retention sweep.
+
+The local sweep is exercised directly against a temp store. The S3 sweep uses
+the same threaded moto server as test_large_payload.py, driving the sweep's
+list/delete/pagination through real HTTP.
+
+Run with: `uv run pytest tests/utils/test_large_payload_gc.py -v`
+"""
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from temporal_agent_harness.utils import large_payload_gc as gc
+
+BUCKET = "large-payload-gc-test-bucket"
+
+
+def _age(path: Path, seconds: int) -> None:
+    then = time.time() - seconds
+    os.utime(path, (then, then))
+
+
+def test_local_sweep_deletes_old_keeps_fresh_and_cleans_tmp(tmp_path: Path):
+    (tmp_path / "old.bin").write_bytes(b"x" * 1000)
+    (tmp_path / "fresh.bin").write_bytes(b"y")
+    (tmp_path / "crashed.bin.tmp").write_bytes(b"partial")
+    _age(tmp_path / "old.bin", 60 * 86_400)
+    _age(tmp_path / "crashed.bin.tmp", 60 * 86_400)
+
+    result = gc.sweep_local(time.time() - 30 * 86_400, base_dir=tmp_path)
+
+    assert result.scanned == 3
+    assert result.deleted == 2
+    assert result.freed_bytes >= 1000
+    assert not (tmp_path / "old.bin").exists()
+    assert not (tmp_path / "crashed.bin.tmp").exists()
+    assert (tmp_path / "fresh.bin").read_bytes() == b"y"
+
+
+def test_local_sweep_of_missing_store_reports_zero(tmp_path: Path):
+    result = gc.sweep_local(time.time(), base_dir=tmp_path / "never-created")
+    assert (result.scanned, result.deleted, result.freed_bytes) == (0, 0, 0)
+
+
+def test_local_sweep_ignores_non_blob_files(tmp_path: Path):
+    (tmp_path / "notes.txt").write_text("not a blob")
+    _age(tmp_path / "notes.txt", 60 * 86_400)
+    result = gc.sweep_local(time.time() - 30 * 86_400, base_dir=tmp_path)
+    assert result.scanned == 0
+    assert (tmp_path / "notes.txt").exists()
+
+
+@pytest.fixture(autouse=True)
+def _restore_env():
+    keys = (
+        "AWS_ENDPOINT_URL",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_DEFAULT_REGION",
+        "LARGE_PAYLOAD_S3_BUCKET",
+    )
+    prev = {k: os.environ.get(k) for k in keys}
+    try:
+        yield
+    finally:
+        for k, v in prev.items():
+            os.environ.pop(k, None) if v is None else os.environ.__setitem__(k, v)
+
+
+@pytest.fixture()
+def s3_server():
+    from moto.server import ThreadedMotoServer
+
+    server = ThreadedMotoServer(ip_address="127.0.0.1", port=0)
+    server.start()
+    _, port = server.get_host_and_port()
+    endpoint = f"http://127.0.0.1:{port}"
+    os.environ["AWS_ENDPOINT_URL"] = endpoint
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    os.environ["LARGE_PAYLOAD_S3_BUCKET"] = BUCKET
+    try:
+        import boto3
+
+        boto3.client("s3", endpoint_url=endpoint).create_bucket(Bucket=BUCKET)
+        yield endpoint
+    finally:
+        server.stop()
+
+
+async def test_s3_sweep_deletes_objects_older_than_cutoff(s3_server):
+    import boto3
+
+    client = boto3.client("s3", endpoint_url=s3_server)
+    for key in ("a.bin", "b.bin", "c.bin"):
+        client.put_object(Bucket=BUCKET, Key=key, Body=b"data")
+
+    # moto stamps LastModified at put time; a cutoff in the future treats them
+    # all as expired, which exercises list + batched delete + the counters.
+    result = await gc.sweep_s3(time.time() + 3600)
+    assert result.scanned == 3
+    assert result.deleted == 3
+    assert client.list_objects_v2(Bucket=BUCKET).get("KeyCount", 0) == 0
+
+
+async def test_s3_sweep_keeps_objects_newer_than_cutoff(s3_server):
+    import boto3
+
+    client = boto3.client("s3", endpoint_url=s3_server)
+    client.put_object(Bucket=BUCKET, Key="fresh.bin", Body=b"data")
+
+    result = await gc.sweep_s3(time.time() - 3600)
+    assert result.scanned == 1
+    assert result.deleted == 0
+    assert client.list_objects_v2(Bucket=BUCKET).get("KeyCount", 0) == 1
+
+
+async def test_s3_sweep_requires_a_bucket(s3_server):
+    os.environ.pop("LARGE_PAYLOAD_S3_BUCKET")
+    with pytest.raises(RuntimeError, match="LARGE_PAYLOAD_S3_BUCKET"):
+        await gc.sweep_s3(time.time())


### PR DESCRIPTION
This PR adds a sandboxed `portable_coding_agent` example, a small harness fix the sandbox path needs, and a retention sweep for the large-payload offload store.

It is a draft, meant as a discussion starter. The history is a stack of focused commits: the sweep, the harness fix, the example, and follow-ups that harden it after review.

## Portable coding agent example, sandboxed

`examples/portable_coding_agent/` is a coding agent whose shell and file edits run inside a sandbox, so model-driven commands cannot touch the host beyond it. It runs two ways from one codebase, both as the OpenAI Agents SDK's `SandboxAgent`:

- **Durable**, as a Temporal workflow. The sandbox is reached through the harness's `temporal_sandbox_client`, so each sandbox operation is an activity, and the worker registers the backend with `SandboxClientProvider`. One sandbox is reused for the whole session (created on the first message, resumed on later ones, deleted on close), so files persist from one message to the next. This is the first example wiring the harness's sandbox seam.
- **Local**, in one process with no Temporal and no server. With `CODING_AGENT_SANDBOX=local` and `CODING_AGENT_WORKSPACE` set, it edits a real repo in place.

`CODING_AGENT_SANDBOX` picks the backend: `docker` (default, isolated container) or `local` (unix-local, no isolation). The model call runs on its own task queue. The tool surface on top of the sandbox's read / edit / shell: `update_plan` (planning), `codebase_search` (a content-hash-cached embedding index that returns the matched code), `ask_user` (a callback in durable mode with optional choices; a terminal prompt locally), `task` (subagent delegation via `subagent_toolset`, no-ask and depth-capped so it cannot recurse without bound), and `web_fetch` (external docs).

## Harness fix: keep the model activity's input as opaque JSON

`invoke_model_activity` typed its `input` as `list[TResponseInputItem]` and let the Temporal data converter validate the round-tripped items back into that union. For `Iterable`-typed item fields pydantic then handed the SDK lazy `ValidatorIterator`s, and once detached from their validation context those cannot be re-serialized: iterating one hits a `pydantic_core` panic. Typing `input` as opaque JSON (`list[Any]`) forwards exactly what the workflow sent, which is what the SDK model layer wants anyway. One line plus a comment, as its own commit.

## Large-payload retention sweep

`temporal_agent_harness/utils/large_payload_gc.py`. `large_payload.py`'s own note says offloaded objects "just accumulate." This adds an in-repo sweep (local driver and S3) with a CLI:

```bash
python -m temporal_agent_harness.utils.large_payload_gc --days 7
```

## What is verified

- **Durable sandbox persistence** (the main fix): a two-message session driven against a dev server. History shows the sandbox created once and resumed on the second message (not recreated), one container served the whole session, and a file written on message 1 was present in that container on message 2 (checked with `docker exec`, not the model's word).
- **Local in-place editing**: the unix-local backend rooted at a workspace read an existing repo file and wrote a file that landed on the host repo, and `client.delete` left the directory intact.
- The full suite is green (258 passed): the search machinery, the subagent / ask / delegation policy, backend selection, and the sweep are unit-tested.

## Not wired here, by design

- Editing a repo under `docker` isolation: the SDK's Docker options have no host bind mount, so in-place editing uses the `local` backend; a seed/apply flow for docker is a next step.
- Per-command approval of the sandbox's own shell/edit tools: isolation is the boundary; gating individual commands would use the SDK's `needs_approval` integrated with the durable approval flow.
- `AGENTS.md` ingestion is local-mode only, where the workspace is the real repo.
- A full durable run of the `ask_user` callback and the `task` subagent: they rest on the harness's own unit-tested mechanisms, and CI here does not run the model loop or spin a container.

The model default is `gpt-5-mini`; override with `CODING_AGENT_MODEL`.
