### PR TITLE
Emit model-invocation events for non-streamed turns (fixes #50)

### DIFF
--- a/docs/internal/agentevent-workflow-stream.md
+++ b/docs/internal/agentevent-workflow-stream.md
@@ -111,7 +111,10 @@ stream, not the resurrected entries.
   `agent_protocol/events.py`.
 - **Two publish paths onto the same topic:**
   - *In-workflow* — `_pub` → `WorkflowTopicHandle.publish` (`agent_workflow.py`): lifecycle events,
-    the approval cascade, inline-tool `tool_start`/`tool_end`, subagent parent-side markers.
+    the approval cascade, inline-tool `tool_start`/`tool_end`, subagent parent-side markers, and a
+    **non-streamed** model call's `model_interaction_*` + `tool_requested` (published by the
+    OpenAI integration's workflow-side `ModelCallObserver` around the model activity, since a
+    non-streamed call has no activity-side event stream to observe).
   - *Out-of-workflow* — `AgentWorkflowRunner.publisher_from_activity` → `WorkflowStreamClient`
     (delivered as the publish Signal): Gemini/OpenAI streamed `reply_delta`, `model_interaction_*`,
     and activity-tool `tool_start`/`tool_end`. Raw provider tokens are folded into semantic

--- a/docs/internal/core-concepts.md
+++ b/docs/internal/core-concepts.md
@@ -72,8 +72,9 @@ above (`turn_started`, `reply_delta`, `tool_*`, …).
   in `agent_protocol/events.py`.)
 - **One topic, two producers.** All events publish to the single `turn_events` topic on the agent's
   `WorkflowStream`: **in-workflow** via `_pub` (lifecycle, the approval cascade, inline-tool
-  brackets) and **from inside activities** via `publisher_from_activity` (streamed `reply_delta`,
-  `model_interaction_*`, activity-tool brackets). Raw provider tokens are folded into `AgentEvent`s
+  brackets, and — for a non-streamed model call — its `model_interaction_*` bracket) and **from
+  inside activities** via `publisher_from_activity` (streamed `reply_delta`, `model_interaction_*`,
+  activity-tool brackets). Raw provider tokens are folded into `AgentEvent`s
   *inside* the activity — the lowest-level thing that crosses the activity→workflow→client boundary
   is already a semantic event, never raw bytes.
 - **It's a durable, replayable stream, not a fire-and-forget feed.** Each event is a Temporal Signal
@@ -211,13 +212,26 @@ the visible one, but not the only one):
    still apply. (For a framework with its own tool loop, this is the hardest part — interpose
    `run_tool` into the framework's loop.)
 
+**Streaming is not the seam — the model call is.** Only `reply_delta` / `thought_summary` /
+`text_annotation` are streaming artifacts. `model_interaction_started` / `…_ended` (with
+`TokenUsage`) and `tool_requested` are *facts about the turn* — the model was invoked, here is its
+span, what it cost, what it asked for — equally true of a non-streamed call. So an integration must
+emit them at the **model-invocation boundary for every model call**, not from inside its streaming
+observer, or the event stream silently degrades (losing cost visibility) for anyone who doesn't
+stream. Concretely: the OpenAI integration publishes them from the activity-side observer when
+streaming and from a workflow-side `ModelCallObserver` (`model_call_observer_provider`) when not;
+Pydantic AI streams internally whenever an `event_stream_handler` is set, so `run()` and
+`run_stream()` are already identical; Gemini's Interactions path is streaming-only.
+
 Two integrations, two provenances:
 - **Gemini** (`ai_sdks/google_genai_plugin/`) — **harness-authored**; the harness wrote the
   activity-wrapping itself (not an official Temporal SDK integration).
 - **OpenAI Agents SDK** (`ai_sdks/openai_agents/` + `ai_sdks/openai_agents_harness.py`) — a
-  **vendored copy** of `temporalio.contrib.openai_agents` + generic streaming seams
-  (`stream_to_provider` / `observer_factory`), with harness specifics in the sibling module. (See
-  `python-idioms-for-java-spring-devs.md` for decorator mechanics and the re-vendoring note.)
+  **vendored copy** of `temporalio.contrib.openai_agents` + generic seams
+  (`stream_to_provider` / `observer_factory` for the streamed path,
+  `model_call_observer_provider` for the non-streamed one), with harness specifics in the sibling
+  module. (See `python-idioms-for-java-spring-devs.md` for decorator mechanics and the re-vendoring
+  note.)
 
 ## Model output is not one blob — it's typed parts
 

--- a/examples/openai_hello/README.md
+++ b/examples/openai_hello/README.md
@@ -10,18 +10,25 @@ streaming activity, to the live turn stream the web UI consumes.
 - **Streaming, not blocking.** The turn runs `Runner.run_streamed(...)` (not `Runner.run`).
   Only the streamed path routes model calls through `invoke_model_activity_streaming`, and it's
   that activity that feeds each raw OpenAI event to the harness observer.
-- **The observer seam.** The worker builds the plugin with the two harness hooks:
+- **The observer seams.** The worker builds the plugin with the harness hooks:
   ```python
   OpenAIAgentsPlugin(
-      model_params=ModelActivityParameters(stream_to_provider=stream_to_provider),
+      model_params=ModelActivityParameters(
+          stream_to_provider=stream_to_provider,
+          model_call_observer_provider=model_call_observer_provider,
+      ),
       observer_factory=harness_observer_factory,
   )
   ```
-  `stream_to_provider` resolves the in-flight turn's stream context ambiently off the running
-  workflow (no runner threading); `harness_observer_factory` turns it into the observer that
-  translates raw OpenAI events into harness vocabulary — `model_interaction_started` →
-  `reply_delta` … `tool_requested` … `model_interaction_ended`. There are **no run hooks**:
-  the model-interaction bracket comes from the observer.
+  `stream_to_provider` reads the in-flight turn's stream context off the run context the workflow
+  threads in (`Runner.run_streamed(..., context=self._runner)`); `harness_observer_factory` turns
+  it into the observer that translates raw OpenAI events into harness vocabulary —
+  `model_interaction_started` → `reply_delta` … `tool_requested` … `model_interaction_ended`.
+  There are **no run hooks**: the model-interaction bracket comes from the observer.
+  `model_call_observer_provider` is the non-streamed counterpart — it brackets a `Runner.run`
+  model call from workflow code, so `model_interaction_*` (with token usage) and `tool_requested`
+  are reported whether or not tokens are streamed. Only `reply_delta` / `thought_summary` /
+  `text_annotation` are streaming-specific.
 - **Harness-owned tools.** `get_weather` is a normal `@agent.tool_defn`, adapted onto the SDK
   with `as_openai_agent_tool(...)`, so the harness keeps approval + `tool_start`/`tool_end`.
 

--- a/examples/openai_hello/worker.py
+++ b/examples/openai_hello/worker.py
@@ -14,6 +14,13 @@ The plugin is wired for the HARNESS STREAMING PATH:
     translates raw OpenAI events into the harness turn-stream vocabulary live.
 Drop either one and streaming falls back to the plugin's plain raw-topic behavior.
 
+``model_params.model_call_observer_provider=model_call_observer_provider`` is the
+non-streaming counterpart: it brackets a ``Runner.run`` model call in workflow code so
+``model_interaction_started`` / ``…_ended`` (with token usage) and ``tool_requested`` reach the
+turn stream even when nothing is token-streamed. This agent always streams, but the hook is
+wired so switching the call site to ``Runner.run(..., context=self._runner)`` keeps the same
+observability.
+
 Env vars (set in .env.local — see .env.example):
     TEMPORAL_CONFIG_FILE / TEMPORAL_PROFILE   Temporal connection profile
     OPENAI_API_KEY                            required — the agent calls the OpenAI API
@@ -38,6 +45,7 @@ from temporal_agent_harness.ai_sdks.openai_agents import (
 )
 from temporal_agent_harness.ai_sdks.openai_agents_harness import (
     harness_observer_factory,
+    model_call_observer_provider,
     stream_to_provider,
 )
 
@@ -64,6 +72,10 @@ async def main() -> None:
             heartbeat_timeout=timedelta(seconds=30),
             # The harness streaming seam: route streamed events to the in-flight turn.
             stream_to_provider=stream_to_provider,
+            # Its non-streaming counterpart: bracket every `Runner.run` model call
+            # workflow-side, so model_interaction_started/ended (with token usage) and
+            # tool_requested land on the turn stream whether or not tokens streamed.
+            model_call_observer_provider=model_call_observer_provider,
         ),
         observer_factory=harness_observer_factory,
     )

--- a/examples/react_agent/README.md
+++ b/examples/react_agent/README.md
@@ -47,10 +47,13 @@ Ask it a question and it chains tools to find the answer:
   `Runner.run_streamed(...)`, so model calls route through the streaming activity and the harness
   observer translates raw OpenAI events into the live turn stream (`model_interaction_started` →
   `reply_delta` … `tool_requested` … `tool_start` / `tool_end` → `model_interaction_ended`). Set
-  `REACT_AGENT_STREAM=0` (in the **worker's** environment) and the turn runs `Runner.run(...)`
-  instead: it completes and returns one reply. Tool cards, the `ask_user` flow, and the final reply
-  still appear on the turn stream; token-by-token `reply_delta` and the `model_interaction_*`
-  brackets do not. (The terminal client renders either mode.)
+  `REACT_AGENT_STREAM=0` (in the **worker's** environment) and the turn runs
+  `Runner.run(..., context=self._runner)` instead: it completes and returns one reply. The
+  `model_interaction_*` brackets (with token usage), `tool_requested`, tool cards, the `ask_user`
+  flow, and the final reply **all still appear** — a model call and what it cost are facts about the
+  turn, not streaming artifacts. Only the token-by-token deltas (`reply_delta`, `thought_summary`,
+  `text_annotation`) are absent, because those are the genuinely streaming-specific part. (The
+  terminal client renders either mode.)
 - **Human-in-the-loop via a callback tool.** `ask_user` is an `@agent.callback_tool_defn` tool: it
   has **no server-side body**. When the model calls it, the harness publishes a `callback_requested`
   event and **parks the turn in-workflow** (durably — no activity timeout) until an external client

--- a/examples/react_agent/worker.py
+++ b/examples/react_agent/worker.py
@@ -19,6 +19,13 @@ Drop either hook, or omit the ``context=self._runner`` on ``run_streamed``, and 
 stream target — the streamed call raises unless you also set ``model_params.streaming_topic``
 (the plugin's plain raw-topic fallback, not wired here).
 
+and for the NON-STREAMING PATH (``REACT_AGENT_STREAM=0``):
+  * ``model_params.model_call_observer_provider=model_call_observer_provider`` — brackets each
+    ``Runner.run`` model call in workflow code, publishing ``model_interaction_started`` /
+    ``…_ended`` (with token usage) and ``tool_requested``. Those are facts about the turn, not
+    streaming artifacts, so turning tokens off must not turn them off. It reads the same run
+    context, so the workflow passes ``context=self._runner`` on ``Runner.run`` too.
+
 Env vars (set in the repo-root .env.local — see .env.example):
     TEMPORAL_CONFIG_FILE / TEMPORAL_PROFILE   Temporal connection profile
     OPENAI_API_KEY                            required — the agent calls the OpenAI API
@@ -45,6 +52,7 @@ from temporal_agent_harness.ai_sdks.openai_agents import (
 )
 from temporal_agent_harness.ai_sdks.openai_agents_harness import (
     harness_observer_factory,
+    model_call_observer_provider,
     stream_to_provider,
 )
 
@@ -93,6 +101,10 @@ async def main() -> None:
             heartbeat_timeout=timedelta(seconds=30),
             # The harness streaming seam: route streamed events to the in-flight turn.
             stream_to_provider=stream_to_provider,
+            # Its non-streaming counterpart: bracket every `Runner.run` model call
+            # workflow-side, so model_interaction_started/ended (with token usage) and
+            # tool_requested land on the turn stream whether or not tokens streamed.
+            model_call_observer_provider=model_call_observer_provider,
         ),
         mcp_server_providers=[
             StatelessMCPServerProvider(

--- a/examples/react_agent/workflow.py
+++ b/examples/react_agent/workflow.py
@@ -9,9 +9,11 @@ Streaming is a toggle (``REACT_AGENT_STREAM``, default on — see ``STREAM_RESPO
 runs the model with ``Runner.run_streamed(..., context=self._runner)`` — passing the harness runner
 as the SDK run context is what lets the streaming seam resolve the in-flight turn — so model calls
 route through the streaming activity and the harness observer translates raw OpenAI events into the
-live turn stream. Non-streaming uses ``Runner.run(...)``: the turn runs to completion and returns
-one reply, with tool lifecycle / ``ask_user`` / the final reply still on the turn stream but no
-``reply_delta`` or ``model_interaction_*``. The
+live turn stream. Non-streaming uses ``Runner.run(..., context=self._runner)``: the turn runs to
+completion and returns one reply, and the run context is still threaded because the model-invocation
+bracket (``model_interaction_started`` / ``…_ended`` with token usage) and ``tool_requested`` are
+facts about the turn either way — only the token-by-token deltas (``reply_delta``,
+``thought_summary``, ``text_annotation``) go missing. The
 local tools are durable harness activity tools adapted onto the SDK with ``as_openai_agent_tools``
 (so the harness owns the approval policy and each tool's ``tool_start`` / ``tool_end`` /
 ``tool_error`` events); the F1 tools come from a durable, activity-backed MCP server registered on
@@ -139,10 +141,13 @@ class ReactAgentWorkflow:
             async for _event in result.stream_events():
                 pass
         else:
-            # Non-streaming: run the whole turn to completion, then return one reply. No context
-            # and no stream seam. Tool cards, ask_user, and the final reply still appear on the turn
-            # stream; token-by-token reply_delta and model_interaction_* do not.
-            result = await Runner.run(sdk_agent, input=input_items)
+            # Non-streaming: run the whole turn to completion, then return one reply.
+            # context=self._runner is needed HERE TOO — the non-streaming seam
+            # (model_call_observer_provider) reads the in-flight turn off it, so the
+            # model-invocation bracket and its token usage still land on the turn stream.
+            # Only the token-by-token deltas (reply_delta / thought_summary /
+            # text_annotation) are absent on this path.
+            result = await Runner.run(sdk_agent, input=input_items, context=self._runner)
 
         self._conversation = result.to_input_list()
         return TextReply(text=str(result.final_output))

--- a/temporal_agent_harness/ai_sdks/integration_helpers/__init__.py
+++ b/temporal_agent_harness/ai_sdks/integration_helpers/__init__.py
@@ -15,9 +15,18 @@ sdk-python. Wired into the vendored ``openai_agents`` streaming activity via
 :func:`select_observer`; the harness-specific observer lives in
 :mod:`temporal_agent_harness.ai_sdks.openai_agents_harness`.
 
-See :py:class:`StreamObserver` for the live-streaming observer contract.
+See :py:class:`StreamObserver` for the live-streaming observer contract (raw
+provider events, observed in the activity) and :py:class:`ModelCallObserver` for
+the model-invocation contract (the started/ended bracket and its usage, observed
+in the workflow around EVERY model call — streamed or not).
 """
 
+from temporal_agent_harness.ai_sdks.integration_helpers._model_call_observer import (
+    ModelCallObserver,
+    ModelCallObserverProvider,
+    NullModelCallObserver,
+    select_model_call_observer,
+)
 from temporal_agent_harness.ai_sdks.integration_helpers._stream_observer import (
     ObserverFactory,
     RawTopicObserver,
@@ -26,8 +35,12 @@ from temporal_agent_harness.ai_sdks.integration_helpers._stream_observer import 
 )
 
 __all__ = [
+    "ModelCallObserver",
+    "ModelCallObserverProvider",
+    "NullModelCallObserver",
     "ObserverFactory",
     "RawTopicObserver",
     "StreamObserver",
+    "select_model_call_observer",
     "select_observer",
 ]

--- a/temporal_agent_harness/ai_sdks/integration_helpers/_model_call_observer.py
+++ b/temporal_agent_harness/ai_sdks/integration_helpers/_model_call_observer.py
@@ -1,0 +1,97 @@
+"""Model-invocation observer contract shared across AI-SDK Temporal integrations.
+
+The sibling :mod:`._stream_observer` contract covers what is genuinely
+*streaming-specific*: the raw provider events of a token-streamed call, observed
+inside the activity as they arrive.  This contract covers what is **not**
+streaming-specific at all — the fact that a model was invoked, how long the call
+took, what it cost, and what it asked for.  Those are facts about the turn, true
+whether or not the reply tokens were streamed out, so a non-streamed call must be
+able to report them too.
+
+Where the two run differs, and that difference is the whole point:
+
+* a :class:`~._stream_observer.StreamObserver` lives **in the activity**, because
+  that is the only place the live event stream exists;
+* a :class:`ModelCallObserver` lives **in the workflow**, wrapped around the
+  model activity's dispatch — the one place every model call passes through,
+  streamed or not.  It is therefore synchronous and must not do I/O: it only
+  brackets the ``await`` on the activity.
+
+An SDK plugin resolves one per non-streamed call from a
+:data:`ModelCallObserverProvider` and never inspects what it gets back, exactly
+as it does with the streaming routing token.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, Protocol
+
+__all__ = [
+    "ModelCallObserver",
+    "ModelCallObserverProvider",
+    "NullModelCallObserver",
+    "select_model_call_observer",
+]
+
+
+class ModelCallObserver(Protocol):
+    """Brackets ONE non-streamed model call, workflow-side.
+
+    A synchronous context manager, entered immediately before the model activity
+    is dispatched and exited once it settles — so the bracket measures the true
+    model-call latency — with :meth:`on_response` called in between on success,
+    carrying the provider's response (usage, requested tool calls, …).
+
+    Synchronous and side-effect-light on purpose: it runs in workflow code, so it
+    may only do deterministic, non-blocking work (e.g. publishing onto a
+    :class:`~temporalio.contrib.workflow_streams.WorkflowStream`).
+    """
+
+    def __enter__(self) -> ModelCallObserver: ...
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool | None: ...
+
+    def on_response(self, response: Any) -> None: ...
+
+
+# Per-call provider: ``(requested_model_id, run_context) -> observer | None``.
+# Mirrors ``ModelActivityParameters.stream_to_provider``: the ``run_context`` is
+# whatever the caller threaded through the SDK (e.g. ``Runner.run(..., context=...)``),
+# opaque to the plugin, so an embedding runtime can turn its own handle into an
+# observer. Returning ``None`` means "don't observe this call".
+ModelCallObserverProvider = Callable[[Optional[str], Any], Optional["ModelCallObserver"]]
+
+
+class NullModelCallObserver:
+    """The "no observer configured" sentinel — a do-nothing :class:`ModelCallObserver`.
+
+    Lets a plugin wrap every model call in one uniform ``with`` block instead of
+    branching on whether an observer was resolved.
+    """
+
+    def __enter__(self) -> NullModelCallObserver:
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool | None:
+        # Never swallow the model call's failure.
+        return False
+
+    def on_response(self, response: Any) -> None:
+        pass
+
+
+def select_model_call_observer(
+    *,
+    provider: Optional[ModelCallObserverProvider],
+    model: str | None,
+    run_context: Any,
+) -> ModelCallObserver:
+    """Resolve the per-call workflow-side observer, never returning ``None``.
+
+    No provider configured — or a provider that declines this call by returning
+    ``None`` — yields a :class:`NullModelCallObserver`, so the call site is a
+    plain ``with`` with no ``is None`` branch.
+    """
+    if provider is None:
+        return NullModelCallObserver()
+    return provider(model, run_context) or NullModelCallObserver()

--- a/temporal_agent_harness/ai_sdks/openai_agents/_model_parameters.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_model_parameters.py
@@ -118,3 +118,27 @@ class ModelActivityParameters:
     .. warning::
         Streaming support is experimental and may change in future
         versions."""
+
+    model_call_observer_provider: Callable[[str | None, Any], Any] | None = None
+    """Optional per-call provider of a workflow-side observer for NON-streamed
+    model calls (``Runner.run``). Called once (in workflow context) with
+    ``(requested_model_id, run_context)`` — the same pair
+    :attr:`stream_to_provider` gets, where ``run_context`` is exactly the object
+    the caller passed as ``Runner.run(..., context=...)``.
+
+    It must return a
+    :class:`~temporal_agent_harness.ai_sdks.integration_helpers.ModelCallObserver`
+    (or ``None`` to skip observing this call). The stub enters it immediately
+    before dispatching the model activity, calls ``on_response(model_response)``
+    on success, and exits it once the call settles — so an embedding runtime can
+    record the model-invocation bracket, its latency, its token usage, and the
+    tool calls the model requested even when nothing is token-streamed.
+
+    This is deliberately SEPARATE from :attr:`stream_to_provider`: what a model
+    call *is and costs* is not a streaming artifact, so observing it must not
+    require streaming. The streamed path (``Runner.run_streamed``) reports the
+    same facts through its observer, inside the streaming activity — this hook is
+    the non-streamed counterpart, and the two never both fire for one call.
+
+    Runs in workflow code, so the returned observer must be deterministic and
+    non-blocking (publishing onto a ``WorkflowStream`` is fine; I/O is not)."""

--- a/temporal_agent_harness/ai_sdks/openai_agents/_temporal_model_stub.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_temporal_model_stub.py
@@ -32,6 +32,9 @@ from agents.tool import (
 from openai.types.responses.response_prompt_param import ResponsePromptParam
 
 from temporalio import workflow
+from temporal_agent_harness.ai_sdks.integration_helpers import (
+    select_model_call_observer,
+)
 from temporal_agent_harness.ai_sdks.openai_agents._invoke_model_activity import (
     ActivityModelInput,
     AgentOutputSchemaInput,
@@ -207,6 +210,26 @@ class _TemporalModelStub(Model):  # type:ignore[reportUnusedClass]
             prompt=prompt,
         )
 
+        # Bracket the dispatch with the configured workflow-side observer. The
+        # streamed path reports the model-invocation facts (span, usage, requested
+        # tool calls) from inside the streaming activity; a non-streamed call has no
+        # such activity-side seam, so it reports them from here — the one point every
+        # non-streamed model call passes through. Resolving to a null observer when
+        # nothing is configured keeps this a plain `with`.
+        observer = select_model_call_observer(
+            provider=self.model_params.model_call_observer_provider,
+            model=self.model_name,
+            run_context=self._run_context,
+        )
+        with observer:
+            response = await self._dispatch_model_activity(activity_input, summary)
+            observer.on_response(response)
+            return response
+
+    async def _dispatch_model_activity(
+        self, activity_input: ActivityModelInput, summary: str | None
+    ) -> ModelResponse:
+        """Run one non-streamed model call as its (local or normal) activity."""
         if self.model_params.use_local_activity:
             return await workflow.execute_local_activity_method(
                 ModelActivity.invoke_model_activity,

--- a/temporal_agent_harness/ai_sdks/openai_agents_harness.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents_harness.py
@@ -2,10 +2,12 @@
 # harness-specific that the vendored `openai_agents/` package deliberately does NOT know about:
 # the live translator (`OpenAIStreamObserver`) that folds raw OpenAI Responses stream events into
 # the harness turn-stream vocabulary, the observer factory + `stream_to_provider` that route those
-# events to the in-flight turn with zero explicit threading, and `as_openai_agent_tool(s)` adapting
-# harness tools onto the SDK. Kept a sibling of the vendored tree (not inside it) so that tree stays
-# pristine for future upstream merges. Mirrors the structure of the Gemini plugin's
-# `_interactions_activity._StreamEventPublisher`.
+# events to the in-flight turn with zero explicit threading, its non-streaming counterpart
+# (`OpenAIModelCallObserver` + `model_call_observer_provider`) that brackets a `Runner.run` model
+# call workflow-side so the model-invocation events are not a streaming-only privilege, and
+# `as_openai_agent_tool(s)` adapting harness tools onto the SDK. Kept a sibling of the vendored tree
+# (not inside it) so that tree stays pristine for future upstream merges. Mirrors the structure of
+# the Gemini plugin's `_interactions_activity._StreamEventPublisher`.
 
 """Harness integration for the OpenAI Agents SDK.
 
@@ -17,10 +19,14 @@ Wire it onto a worker by building the vendored plugin with the harness seam:
 ... )
 >>> from temporal_agent_harness.ai_sdks.openai_agents_harness import (
 ...     harness_observer_factory,
+...     model_call_observer_provider,
 ...     stream_to_provider,
 ... )
 >>> plugin = OpenAIAgentsPlugin(
-...     model_params=ModelActivityParameters(stream_to_provider=stream_to_provider),
+...     model_params=ModelActivityParameters(
+...         stream_to_provider=stream_to_provider,
+...         model_call_observer_provider=model_call_observer_provider,
+...     ),
 ...     observer_factory=harness_observer_factory,
 ... )
 
@@ -28,6 +34,15 @@ With that in place, an agent's ``Runner.run_streamed(...)`` model calls stream
 ``reply_delta`` / ``thought_summary`` / ``text_annotation`` / ``tool_requested`` and
 ``model_interaction_started`` / ``…_ended`` onto the harness turn stream live — the same
 vocabulary the Gemini plugin produces.
+
+**Non-streamed turns report the same model-invocation facts.** ``Runner.run(...)``
+publishes ``model_interaction_started`` / ``…_ended`` (with token usage) and
+``tool_requested`` too, via ``model_call_observer_provider`` — those are facts about the
+turn, not streaming artifacts, so the turn stream must not get weaker just because
+tokens weren't streamed. Only the genuinely streaming-specific deltas (``reply_delta``,
+``thought_summary``, ``text_annotation``) are absent. Both paths read the run context the
+workflow threads in, so pass ``context=<your runner>`` on ``Runner.run(...)`` as well as
+on ``Runner.run_streamed(...)``.
 
 .. warning::
     Streaming support is experimental and may change in future versions.
@@ -79,8 +94,10 @@ if TYPE_CHECKING:
     from agents.items import TResponseStreamEvent
 
 __all__ = [
+    "OpenAIModelCallObserver",
     "OpenAIStreamObserver",
     "harness_observer_factory",
+    "model_call_observer_provider",
     "stream_to_provider",
     "as_openai_agent_tool",
     "as_openai_agent_tools",
@@ -239,6 +256,96 @@ class OpenAIStreamObserver:
                 tool_input=_parse_tool_args(raw),
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# Non-streamed calls: the model-invocation bracket, published workflow-side
+# ---------------------------------------------------------------------------
+#
+# `model_interaction_started` / `…_ended` (with usage) and `tool_requested` are facts
+# about the TURN — the model was invoked, here is its span, what it cost, and what it
+# asked for. They are true whether or not the reply tokens were streamed out, so they
+# must not be reachable only through the streaming seam. `Runner.run` has no
+# activity-side event stream to observe, so this observer brackets the model activity
+# from the WORKFLOW side instead and reads the same facts off the returned
+# `ModelResponse`.
+#
+# Only `reply_delta` / `thought_summary` / `text_annotation` are genuinely
+# streaming-specific, and they stay absent when not streaming — that is the real
+# difference between the two modes, and the only one.
+
+
+class OpenAIModelCallObserver:
+    """Publish one NON-streamed OpenAI model call's interaction bracket, workflow-side.
+
+    A :class:`ModelCallObserver` — the non-streaming counterpart of
+    :class:`OpenAIStreamObserver`, resolved per call by
+    :func:`model_call_observer_provider`. ``Runner.run`` collects the whole response
+    inside the model activity and hands it back to the workflow, so there is no live
+    event stream to fold; instead this brackets the activity dispatch (``__enter__``
+    → ``model_interaction_started``, ``__exit__`` → ``model_interaction_ended``, so
+    the span is the real model-call latency) and reads the rest off the returned
+    ``ModelResponse``: its token usage, and one ``tool_requested`` per function call
+    the model asked for — keyed by the SDK ``call_id``, the same id
+    ``as_openai_agent_tool`` hands to ``run_tool``, so ``tool_requested`` and the
+    eventual ``tool_start`` / ``tool_end`` share a ``tool_id``.
+
+    Publishes through the live in-workflow runner (not
+    :meth:`~AgentWorkflowRunner.publisher_from_activity`, which only works inside an
+    activity). The ended bracket always closes, even when the model call fails —
+    usage then stays ``None``.
+    """
+
+    def __init__(self, runner: AgentWorkflowRunner, *, model: str | None = None) -> None:
+        self._runner = runner
+        # The requested model id, known at dispatch, so BOTH brackets name it —
+        # matching the streamed observer.
+        self._model = model
+        self._usage: TokenUsage | None = None
+
+    def __enter__(self) -> OpenAIModelCallObserver:
+        # Open the span before the activity is dispatched, so it measures the whole call.
+        self._runner.publish(ModelInteractionStarted(model=self._model))
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool | None:
+        # Always close the started bracket, even if the model call raised (usage then
+        # stays None). Never swallow the failure: the turn owns it.
+        self._runner.publish(ModelInteractionEnded(model=self._model, usage=self._usage))
+        return False
+
+    def on_response(self, response: Any) -> None:
+        """Read usage and the model's tool requests off a completed ``ModelResponse``."""
+        self._usage = _to_token_usage(getattr(response, "usage", None))
+        for item in getattr(response, "output", None) or []:
+            if isinstance(item, ResponseFunctionToolCall):
+                self._runner.publish(
+                    ToolRequested(
+                        tool_id=item.call_id,
+                        tool_name=item.name,
+                        tool_input=_parse_tool_args(item.arguments or ""),
+                    )
+                )
+
+
+def model_call_observer_provider(
+    model: str | None, run_context: Any
+) -> OpenAIModelCallObserver | None:
+    """Per-call observer provider for non-streamed calls (wired as
+    ``model_params.model_call_observer_provider``).
+
+    Called once per ``Runner.run`` model request, in workflow context, with the
+    requested model id and the object the agent passed as
+    ``Runner.run(..., context=self._runner)`` — the same threading the streamed path
+    needs, which is why the non-streaming call site must pass ``context`` too.
+    Returns ``None`` when that is not a harness runner or no turn is in flight, so the
+    call proceeds unobserved rather than raising.
+    """
+    if not isinstance(run_context, AgentWorkflowRunner):
+        return None
+    if run_context.current_stream_context is None:
+        return None
+    return OpenAIModelCallObserver(run_context, model=model)
 
 
 def _parse_tool_args(raw: str) -> dict[str, Any]:

--- a/temporal_agent_harness/ai_sdks/pydantic_ai_harness.py
+++ b/temporal_agent_harness/ai_sdks/pydantic_ai_harness.py
@@ -34,6 +34,12 @@ model call publishes ``reply_delta`` / ``thought_summary`` / ``tool_requested`` 
 ``model_interaction_started`` / ``…_ended`` onto the harness turn stream live — the same vocabulary
 the Gemini and OpenAI integrations produce.
 
+Note there is no streamed/non-streamed split to worry about here: setting an
+``event_stream_handler`` makes Pydantic AI iterate the model response as a stream even for a plain
+``agent.run(...)``, so a caller gets the identical turn-stream vocabulary either way. (The OpenAI
+integration has to close that gap explicitly — see ``model_call_observer_provider`` in
+:mod:`~temporal_agent_harness.ai_sdks.openai_agents_harness`.)
+
 .. warning::
     Streaming support is experimental and may change in future versions.
 """

--- a/tests/ai_sdks/openai_agents/test_model_call_observer.py
+++ b/tests/ai_sdks/openai_agents/test_model_call_observer.py
@@ -1,0 +1,217 @@
+# ABOUTME: Unit-tests the OpenAI Agents NON-streaming model-invocation bracket
+# (OpenAIModelCallObserver + model_call_observer_provider) in isolation — drives the observer over a
+# synthetic `ModelResponse` with a fake in-workflow runner (no Temporal server, no OPENAI_API_KEY)
+# and asserts the harness turn-stream vocabulary a non-streamed turn must still produce: the
+# model_interaction_started/ended span, its token accounting, and one tool_requested per function
+# call the model asked for. Guards issue #50 — those are facts about the turn, so turning token
+# streaming off must not drop them.
+#
+# Run with: uv run pytest tests/ai_sdks/openai_agents/test_model_call_observer.py -v
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agents.items import ModelResponse
+from agents.usage import Usage
+from openai.types.responses import ResponseFunctionToolCall, ResponseOutputMessage
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from temporal_agent_harness.ai_sdks import openai_agents_harness as h
+from temporal_agent_harness.ai_sdks.integration_helpers import (
+    NullModelCallObserver,
+    select_model_call_observer,
+)
+from temporal_agent_harness.harness.agent_protocol import (
+    AgentEventType,
+    ModelInteractionEnded,
+    ModelInteractionStarted,
+    ToolRequested,
+)
+from temporal_agent_harness.harness.stream_context import TurnStreamContext
+
+
+class _FakeRunner:
+    """Stands in for the in-workflow AgentWorkflowRunner: records every published payload.
+
+    Mirrors the two members the observer path touches — ``current_stream_context`` (the
+    provider's "is a turn in flight?" gate) and ``publish``, which the real runner raises from
+    when called between turns.
+    """
+
+    def __init__(self, context: TurnStreamContext | None) -> None:
+        self.current_stream_context = context
+        self.events: list[Any] = []
+
+    def publish(self, event: Any) -> None:
+        if self.current_stream_context is None:
+            raise RuntimeError("publish() called with no active turn")
+        self.events.append(event)
+
+
+@pytest.fixture
+def fake_runner(monkeypatch: pytest.MonkeyPatch) -> _FakeRunner:
+    """A recording stand-in, swapped in for the provider's ``isinstance`` gate so the real
+    provider → observer path runs end to end against an in-memory sink (no workflow, no
+    Temporal server). The gate itself is covered separately by the "declines" tests."""
+    monkeypatch.setattr(h, "AgentWorkflowRunner", _FakeRunner)
+    return _FakeRunner(TurnStreamContext(turn_id="t-1", turn_number=1, agent_id="agent-abc"))
+
+
+def _usage() -> Usage:
+    return Usage(
+        input_tokens=11,
+        output_tokens=22,
+        total_tokens=33,
+        input_tokens_details=InputTokensDetails.model_construct(cached_tokens=5),
+        output_tokens_details=OutputTokensDetails.model_construct(reasoning_tokens=7),
+    )
+
+
+def _fn_call(call_id: str, name: str, arguments: str) -> ResponseFunctionToolCall:
+    return ResponseFunctionToolCall.model_construct(
+        type="function_call", id=f"item_{call_id}", call_id=call_id, name=name, arguments=arguments
+    )
+
+
+def _message() -> ResponseOutputMessage:
+    return ResponseOutputMessage.model_construct(
+        type="message", id="msg_1", role="assistant", status="completed", content=[]
+    )
+
+
+def _response(output: list[Any], usage: Usage | None = None) -> ModelResponse:
+    return ModelResponse(output=output, usage=usage or _usage(), response_id="resp_1")
+
+
+def test_non_streamed_call_publishes_bracket_usage_and_tool_requests(fake_runner: _FakeRunner):
+    obs = h.model_call_observer_provider("gpt-5.1", fake_runner)
+    assert obs is not None
+
+    with obs:
+        # The span opens at dispatch, before the model activity is awaited — so it measures
+        # the real model-call latency, exactly as the streamed path does.
+        assert len(fake_runner.events) == 1
+        assert isinstance(fake_runner.events[0], ModelInteractionStarted)
+        obs.on_response(
+            _response([_message(), _fn_call("call_XYZ", "lookup", '{"q": "cats"}')])
+        )
+
+    published = fake_runner.events
+    assert isinstance(published[0], ModelInteractionStarted)
+    assert published[0].model == "gpt-5.1"
+    assert isinstance(published[-1], ModelInteractionEnded)
+
+    starts = [e for e in published if isinstance(e, ModelInteractionStarted)]
+    ends = [e for e in published if isinstance(e, ModelInteractionEnded)]
+    assert len(starts) == 1 and len(ends) == 1
+
+    # Token accounting survives non-streaming — the sharpest edge in issue #50.
+    ended = ends[0]
+    assert ended.model == "gpt-5.1"
+    assert ended.usage is not None
+    assert ended.usage.input_tokens == 11
+    assert ended.usage.output_tokens == 22
+    assert ended.usage.total_tokens == 33
+    assert ended.usage.cached_tokens == 5
+    assert ended.usage.thought_tokens == 7
+    assert ended.usage.tool_use_tokens is None
+
+    # One tool_requested per function call, keyed by the SDK call_id (the same id run_tool
+    # uses), published BEFORE the bracket closes — matching the streamed ordering.
+    requested = [e for e in published if isinstance(e, ToolRequested)]
+    assert len(requested) == 1
+    assert requested[0].tool_id == "call_XYZ"
+    assert requested[0].tool_name == "lookup"
+    assert requested[0].tool_input == {"q": "cats"}
+    assert published.index(requested[0]) < published.index(ended)
+
+
+def test_parallel_tool_calls_each_get_their_own_request(fake_runner: _FakeRunner):
+    obs = h.model_call_observer_provider("gpt-5.1", fake_runner)
+    assert obs is not None
+    with obs:
+        obs.on_response(
+            _response(
+                [
+                    _fn_call("call_A", "get_coordinates", '{"city": "Paris"}'),
+                    _fn_call("call_B", "get_weather", '{"lat": 1, "lon": 2}'),
+                ]
+            )
+        )
+
+    requested = [e for e in fake_runner.events if isinstance(e, ToolRequested)]
+    assert [(r.tool_id, r.tool_name) for r in requested] == [
+        ("call_A", "get_coordinates"),
+        ("call_B", "get_weather"),
+    ]
+    assert requested[0].tool_input == {"city": "Paris"}
+
+
+def test_bracket_closes_when_the_model_call_fails(fake_runner: _FakeRunner):
+    # A failed model call must still close its started bracket (usage stays None, since no
+    # response ever came back) and must not have its exception swallowed.
+    obs = h.model_call_observer_provider(None, fake_runner)
+    assert obs is not None
+    with pytest.raises(RuntimeError, match="boom"):
+        with obs:
+            raise RuntimeError("boom")
+
+    kinds = [e.type for e in fake_runner.events]
+    assert kinds == [
+        AgentEventType.MODEL_INTERACTION_STARTED,
+        AgentEventType.MODEL_INTERACTION_ENDED,
+    ]
+    ended = fake_runner.events[-1]
+    assert ended.usage is None and ended.model is None
+
+
+def test_malformed_tool_arguments_degrade_to_empty_input(fake_runner: _FakeRunner):
+    obs = h.model_call_observer_provider("gpt-5.1", fake_runner)
+    assert obs is not None
+    with obs:
+        obs.on_response(_response([_fn_call("call_BAD", "lookup", "{not json")]))
+
+    requested = [e for e in fake_runner.events if isinstance(e, ToolRequested)]
+    assert len(requested) == 1 and requested[0].tool_input == {}
+
+
+def test_missing_usage_still_closes_the_bracket(fake_runner: _FakeRunner):
+    # `ModelResponse.usage` is typed non-optional, so the observer reads it defensively rather
+    # than trusting the annotation — usage is best-effort accounting, not a reason to break a
+    # turn. A response that reports none must still close its bracket.
+    obs = h.model_call_observer_provider("gpt-5.1", fake_runner)
+    assert obs is not None
+    with obs:
+        obs.on_response(SimpleNamespace(output=[], usage=None))
+
+    ended = fake_runner.events[-1]
+    assert isinstance(ended, ModelInteractionEnded) and ended.usage is None
+
+
+def test_provider_declines_when_there_is_no_harness_turn():
+    # Not a harness runner at all (e.g. Runner.run called without context=) -> unobserved,
+    # rather than raising and breaking the model call.
+    assert h.model_call_observer_provider("gpt-5.1", object()) is None
+    assert h.model_call_observer_provider("gpt-5.1", None) is None
+
+
+def test_provider_declines_between_turns(fake_runner: _FakeRunner):
+    fake_runner.current_stream_context = None
+    assert h.model_call_observer_provider("gpt-5.1", fake_runner) is None
+
+
+def test_select_falls_back_to_a_null_observer():
+    # No provider configured, or a provider that declines: the plugin's call site stays a plain
+    # `with` and the model call runs exactly as it did before observers existed.
+    unconfigured = select_model_call_observer(provider=None, model="m", run_context=None)
+    declining = select_model_call_observer(
+        provider=lambda _m, _c: None, model="m", run_context=None
+    )
+    for observer in (unconfigured, declining):
+        assert isinstance(observer, NullModelCallObserver)
+        with observer as entered:
+            entered.on_response(_response([]))


### PR DESCRIPTION
Fixes #50.

## The bug

`model_interaction_started` / `…_ended` (with token usage) and `tool_requested` were published only by `OpenAIStreamObserver`, which runs **inside the streaming activity**. `Runner.run` never enters that activity, so a non-streamed turn silently lost its model spans and all token accounting — cost and latency visibility disappearing exactly where someone running headless is most likely to want it.

## The principle

A model call's span, cost, and requested tools are **facts about the turn** — true whether or not the reply tokens were streamed out. Only `reply_delta` / `thought_summary` / `text_annotation` are streaming artifacts. So the bracket now gets emitted at the **model-invocation boundary for every model call**, and the streaming observer is left responsible only for the deltas.

## Changes

- **`integration_helpers/_model_call_observer.py`** (new) — an SDK-agnostic contract. `ModelCallObserver` brackets one model call from **workflow** code; it's the deliberate sibling of `StreamObserver`, which brackets from the activity because that's the only place a live stream exists. `select_model_call_observer` resolves to a null observer so a call site with nothing configured stays a plain `with`.
- **`ModelActivityParameters.model_call_observer_provider`** — the vendored plugin's non-streamed seam, mirroring `stream_to_provider`'s `(model_id, run_context)` signature and its opacity to the plugin. `_TemporalModelStub.get_response` wraps its dispatch in the resolved observer; the dispatch itself moved verbatim into `_dispatch_model_activity`.
- **`OpenAIModelCallObserver` / `model_call_observer_provider`** — the harness glue, publishing via the live in-workflow runner: `started` at dispatch (so the span is real call latency), one `tool_requested` per requested function call keyed by the SDK `call_id` (sharing a `tool_id` with the later `tool_start`/`tool_end`), `ended` with mapped usage. The bracket closes even when the call fails, without swallowing the failure.
- **Examples/docs** — `react_agent` threads `context=self._runner` on its `Runner.run` branch, both example workers wire the provider, and the READMEs / `core-concepts.md` / `agentevent-workflow-stream.md` passages that described the missing events as *expected* behavior are corrected.

## The other inner loops

The issue asked; both were checked:

- **Pydantic AI — no gap.** Setting an `event_stream_handler` makes Pydantic AI iterate the response as a stream even for `agent.run()` (`models/__init__.py:217-226`), and the harness always sets it. `pydantic_ai_hello` already calls plain `.run(...)` and gets the full vocabulary.
- **Gemini — not applicable.** `TemporalAsyncInteractions.create` raises on `stream=False`; there is no non-streaming path to degrade.

Both noted in the code so they aren't re-investigated.

## Verification

New `tests/ai_sdks/openai_agents/test_model_call_observer.py` (8 tests): bracket ordering, usage mapping, parallel tool calls, the failure path, malformed args, and both provider-declines gates. Full suite **239 passed**; the 4 `tests/nexus_agent_adapter/test_handler_integration.py` errors are environmental (the Temporal dev server won't start locally — `ConnectionRefused`) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
