### PR TITLE
Thread-scoped Slack sessions, in-thread continuation, always-ack-200

### DIFF
--- a/nexus/ui_connector/agent/driver.go
+++ b/nexus/ui_connector/agent/driver.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// AgentNexusEndpoint is the Nexus endpoint name the driver targets.
-	AgentNexusEndpoint = "nexus-agent-endpoint"
+	AgentNexusEndpoint = "support-agent-nexus"
 	turnEventsTopic    = "turn_events"
 )
 

--- a/nexus/ui_connector/router/wire.go
+++ b/nexus/ui_connector/router/wire.go
@@ -19,6 +19,11 @@ type Input struct {
 // interaction sub-field is set.
 func (i Input) ThreadID() string {
 	if i.Message != nil {
+		if i.Message.ThreadID != "" {
+			return i.Message.ThreadID
+		}
+		// Platforms that don't populate a dedicated thread root (e.g. Teams) key
+		// threading off the message's own timestamp instead.
 		return i.Message.Timestamp
 	}
 	if i.Slash != nil {
@@ -40,10 +45,16 @@ func (i Input) SenderID() string {
 
 // IncomingMessage carries the raw message delivered from the platform.
 type IncomingMessage struct {
-	MessageID        string
-	Sender           string
-	Text             string
-	Timestamp        string
+	MessageID string
+	Sender    string
+	Text      string
+	Timestamp string
+	// ThreadID is the thread root the reply should be posted under: the thread's
+	// parent ts for a threaded reply, or the message's own ts for a top-level
+	// message (which starts a new thread). Also scopes the agent session. Left
+	// empty by platforms (e.g. Teams) that don't have this concept; ThreadID()
+	// falls back to Timestamp in that case.
+	ThreadID         string
 	ConversationType string
 	ServiceURL       string
 	ChannelID        string

--- a/nexus/ui_connector/slack/cmd/webhook/main.go
+++ b/nexus/ui_connector/slack/cmd/webhook/main.go
@@ -75,7 +75,7 @@ func main() {
 		log.Printf("Slack bot user ID: %s (forwarding only messages that mention the bot)", bot.UserID)
 	}
 
-	handler := slackinbound.NewServer(tc, flags.taskQueue, flags.slackSigningSecret, bot.UserID)
+	handler := slackinbound.NewServer(tc, flags.taskQueue, flags.slackSigningSecret, bot.UserID, "agent-")
 	addr := ":" + flags.webhookPort
 	log.Printf("Slack webhook server listening on %s", addr)
 	if err := http.ListenAndServe(addr, handler); err != nil {

--- a/nexus/ui_connector/slack/inbound/server.go
+++ b/nexus/ui_connector/slack/inbound/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/slack-go/slack/slackevents"
 	"github.com/temporal-community/temporal-agent-harness/nexus/ui_connector/router"
 	slackoutbound "github.com/temporal-community/temporal-agent-harness/nexus/ui_connector/slack/outbound"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/client"
 )
 
@@ -29,16 +30,21 @@ type webhookServer struct {
 	taskQueue     string
 	signingSecret string
 	botUserID     string
-	mux           *http.ServeMux
+	// agentWorkflowIDPrefix must match the adapter's AGENT_WORKFLOW_ID_PREFIX
+	// (default "agent-"): the agent session workflow ID is this prefix + sessionID.
+	// Used to check whether a thread already has a live agent session.
+	agentWorkflowIDPrefix string
+	mux                   *http.ServeMux
 }
 
-func NewServer(tc client.Client, taskQueue, signingSecret, botUserID string) *webhookServer {
+func NewServer(tc client.Client, taskQueue, signingSecret, botUserID, agentWorkflowIDPrefix string) *webhookServer {
 	s := &webhookServer{
-		tc:            tc,
-		taskQueue:     taskQueue,
-		signingSecret: signingSecret,
-		botUserID:     botUserID,
-		mux:           http.NewServeMux(),
+		tc:                    tc,
+		taskQueue:             taskQueue,
+		signingSecret:         signingSecret,
+		botUserID:             botUserID,
+		agentWorkflowIDPrefix: agentWorkflowIDPrefix,
+		mux:                   http.NewServeMux(),
 	}
 	s.mux.HandleFunc(routeEvents, s.handleEvents)
 	s.mux.HandleFunc(routeInteractions, s.handleInteractions)
@@ -101,25 +107,65 @@ func (s *webhookServer) handleEvents(w http.ResponseWriter, r *http.Request) {
 
 	case slackevents.CallbackEvent:
 		if ev, ok := evt.InnerEvent.Data.(*slackevents.MessageEvent); ok {
-			if ev.BotID != "" {
-				return
+			// Never act on the bot's own messages (including its streamed replies,
+			// which Slack echoes back as events); otherwise defer to shouldHandle.
+			// Either way we fall through to the single WriteHeader(200) ack below —
+			// never bare-return, or the Lambda proxy adapter reports "Status code
+			// not set on response" (a 5xx to Slack, which then retries).
+			if ev.BotID == "" && s.shouldHandle(r.Context(), ev) {
+				s.signalIncomingMessage(r.Context(), ev)
 			}
-			if s.botUserID != "" && !strings.Contains(ev.Text, "<@"+s.botUserID+">") {
-				return
-			}
-			s.signalIncomingMessage(r.Context(), ev)
 		}
 	}
 	w.WriteHeader(http.StatusOK)
 }
 
+// shouldHandle decides whether an inbound human message should reach the agent.
+// It qualifies if it @-mentions the bot (starting a new thread, or addressing the
+// bot anywhere), OR it is a reply in a thread the bot has already engaged — i.e.
+// an agent session workflow already exists for that thread. The latter lets a
+// user continue in-thread without re-mentioning the bot, while unrelated human
+// threads (no session) are left alone.
+func (s *webhookServer) shouldHandle(ctx context.Context, ev *slackevents.MessageEvent) bool {
+	if s.botUserID == "" || strings.Contains(ev.Text, "<@"+s.botUserID+">") {
+		return true
+	}
+	if ev.ThreadTimeStamp == "" {
+		return false
+	}
+	return s.sessionExists(ctx, threadSessionID(ev.Channel, ev.ThreadTimeStamp))
+}
+
+// sessionExists reports whether a live agent session workflow already exists for
+// sessionID — the gate that limits mention-free continuation to threads the bot
+// actually started.
+func (s *webhookServer) sessionExists(ctx context.Context, sessionID string) bool {
+	resp, err := s.tc.DescribeWorkflowExecution(ctx, s.agentWorkflowIDPrefix+sessionID, "")
+	if err != nil {
+		return false
+	}
+	return resp.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+}
+
+// threadSessionID scopes an agent session to one Slack thread: the channel plus
+// the thread root. A top-level message uses its own ts as the root (it starts a
+// new thread), so each conversation gets an isolated session.
+func threadSessionID(channel, threadRoot string) string {
+	return fmt.Sprintf("slack:%s:%s", channel, threadRoot)
+}
+
 func (s *webhookServer) signalIncomingMessage(ctx context.Context, ev *slackevents.MessageEvent) {
-	sessionID := fmt.Sprintf("slack:%s", ev.Channel)
+	threadRoot := ev.ThreadTimeStamp
+	if threadRoot == "" {
+		threadRoot = ev.TimeStamp
+	}
+	sessionID := threadSessionID(ev.Channel, threadRoot)
 	msg := router.IncomingMessage{
 		MessageID: ev.TimeStamp,
 		Sender:    ev.User,
 		Text:      ev.Text,
 		Timestamp: ev.TimeStamp,
+		ThreadID:  threadRoot,
 	}
 	wfID := router.RouterWorkflowID(defaultIdentity, sessionID, ev.TimeStamp)
 	if _, err := s.tc.ExecuteWorkflow(ctx,

--- a/nexus/ui_connector/slack/outbound/driver.go
+++ b/nexus/ui_connector/slack/outbound/driver.go
@@ -86,8 +86,10 @@ func (d Driver) AcknowledgeApproval(workflow.Context, router.ApprovalAcknowledge
 }
 
 // RegisterActivities registers platform's methods on w under the activity names Driver
-// dispatches to. Call this from the worker binary alongside NewDriver.
-func RegisterActivities(w worker.Worker, platform *SlackPlatform) {
+// dispatches to. Call this from the worker binary alongside NewDriver. w is
+// worker.Registry (not worker.Worker) so this also works for a Lambda worker's
+// lambdaworker.Options, which implements Registry but not the full Worker interface.
+func RegisterActivities(w worker.Registry, platform *SlackPlatform) {
 	w.RegisterActivityWithOptions(platform.BeginStream, activity.RegisterOptions{Name: beginStreamActivity})
 	w.RegisterActivityWithOptions(platform.UpdateStream, activity.RegisterOptions{Name: updateStreamActivity})
 	w.RegisterActivityWithOptions(platform.FinishStream, activity.RegisterOptions{Name: finishStreamActivity})
@@ -105,13 +107,16 @@ type ApprovalButtonValue struct {
 	Approved  bool   `json:"a"`
 }
 
-// parseChannel strips the provider prefix from a session ID (e.g. "slack:C12345" → "C12345").
+// parseChannel extracts the channel from a session ID. Sessions are
+// "provider:channel" or, when thread-scoped, "provider:channel:threadRoot"
+// (e.g. "slack:C12345" or "slack:C12345:1699.0001" → "C12345"). The channel is
+// always the second colon-delimited segment; a trailing thread root is ignored.
 func parseChannel(sessionID string) (string, error) {
-	_, ch, found := strings.Cut(sessionID, ":")
-	if !found || ch == "" {
-		return "", fmt.Errorf("invalid session ID %q: expected \"provider:id\" format", sessionID)
+	parts := strings.SplitN(sessionID, ":", 3)
+	if len(parts) < 2 || parts[1] == "" {
+		return "", fmt.Errorf("invalid session ID %q: expected \"provider:channel[:threadRoot]\" format", sessionID)
 	}
-	return ch, nil
+	return parts[1], nil
 }
 
 // SlackPlatform is the real Activity implementation backing Driver: its methods make

--- a/nexus/ui_connector/slack/outbound/driver_test.go
+++ b/nexus/ui_connector/slack/outbound/driver_test.go
@@ -24,9 +24,13 @@ func TestParseChannel(t *testing.T) {
 		{"slack:C12345", "C12345", false},
 		{"slack:C0B6KE9B1LJ", "C0B6KE9B1LJ", false},
 		{"discord:987654", "987654", false},
+		// Thread-scoped sessions carry a trailing thread root, which must be ignored.
+		{"slack:C12345:1699887766.001100", "C12345", false},
+		{"slack:C0B6KE9B1LJ:1783689596.364049", "C0B6KE9B1LJ", false},
 		{"", "", true},
 		{"nocolon", "", true},
 		{"slack:", "", true},
+		{"slack::1699.0001", "", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.input, func(t *testing.T) {
@@ -52,7 +56,7 @@ func TestSlackPlatform_BeginStream_InvalidSessionID(t *testing.T) {
 		TextMetadata: router.TextMetadata{SessionID: "nocolon"},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "provider:id")
+	assert.Contains(t, err.Error(), "invalid session ID")
 }
 
 func TestSlackPlatform_UpdateStream_InvalidSessionID(t *testing.T) {
@@ -61,7 +65,7 @@ func TestSlackPlatform_UpdateStream_InvalidSessionID(t *testing.T) {
 		Handle:       router.StreamHandle{ID: "stream-1", SessionID: "nocolon"},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "provider:id")
+	assert.Contains(t, err.Error(), "invalid session ID")
 }
 
 func TestSlackPlatform_FinishStream_InvalidSessionID(t *testing.T) {
@@ -70,7 +74,7 @@ func TestSlackPlatform_FinishStream_InvalidSessionID(t *testing.T) {
 		Handle:       router.StreamHandle{ID: "stream-1", SessionID: "nocolon"},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "provider:id")
+	assert.Contains(t, err.Error(), "invalid session ID")
 }
 
 func TestSlackPlatform_UpdateStream_RequiresStreamID(t *testing.T) {
@@ -160,7 +164,7 @@ func TestSlackPlatform_PostMessage_InvalidSessionID(t *testing.T) {
 		Text:      "hello",
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "provider:id")
+	assert.Contains(t, err.Error(), "invalid session ID")
 }
 
 func TestSlackPlatform_PostPrompt_UnknownType(t *testing.T) {


### PR DESCRIPTION
## What changed

Porting logical changes that were in https://github.com/temporal-community/temporal-agent-harness/tree/lambdify to a branch that we can easily merge to `main`.

## Why

Lambda worker stuff doesn't really belong here, I'll move the lambdification to the right place and delete the `lambdify` branch.