### PR TITLE
Fix sending all replies in thread to connector from webhook

### DIFF
--- a/nexus/ui_connector/router/workflow.go
+++ b/nexus/ui_connector/router/workflow.go
@@ -27,7 +27,16 @@ type RouterWorkflow struct {
 // interactionID should be the platform's own unique ID for the event (Slack
 // message timestamp, trigger_id for slash commands, etc.).
 func RouterWorkflowID(identity, sessionID, interactionID string) string {
-	return fmt.Sprintf("connector-%s-%s-%s", identity, sessionID, interactionID)
+	return RouterWorkflowIDPrefix(identity, sessionID) + interactionID
+}
+
+// RouterWorkflowIDPrefix returns the shared prefix of every RouterWorkflowID for a
+// given session, with everything up to but excluding interactionID. Every
+// interaction within one session (e.g. every reply in a Slack thread) produces a
+// workflow ID with this same prefix, so it can be used to search for any workflow
+// ever started for the session without knowing which interactionID triggered it.
+func RouterWorkflowIDPrefix(identity, sessionID string) string {
+	return fmt.Sprintf("connector-%s-%s-", identity, sessionID)
 }
 
 func NewRouterWorkflow(outboundDriver OutboundDriver, backendDriver BackendDriver) *RouterWorkflow {

--- a/nexus/ui_connector/slack/cmd/webhook/main.go
+++ b/nexus/ui_connector/slack/cmd/webhook/main.go
@@ -72,7 +72,7 @@ func main() {
 		log.Fatalf("Failed to initialise Slack bot: %v", err)
 	}
 	if bot.UserID != "" {
-		log.Printf("Slack bot user ID: %s (forwarding only messages that mention the bot)", bot.UserID)
+		log.Printf("Slack bot user ID: %s (forwarding mentions, plus replies in threads the bot was mentioned in)", bot.UserID)
 	}
 
 	handler := slackinbound.NewServer(tc, flags.taskQueue, flags.slackSigningSecret, bot.UserID)

--- a/nexus/ui_connector/slack/inbound/server.go
+++ b/nexus/ui_connector/slack/inbound/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/slack-go/slack/slackevents"
 	"github.com/temporal-community/temporal-agent-harness/nexus/ui_connector/router"
 	slackoutbound "github.com/temporal-community/temporal-agent-harness/nexus/ui_connector/slack/outbound"
+	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 )
 
@@ -106,7 +107,10 @@ func (s *webhookServer) handleEvents(w http.ResponseWriter, r *http.Request) {
 			// below - a bare return reads as a 5xx to the Lambda proxy and Slack retries.
 			if ev.BotID == "" {
 				mentioned := s.isMentioned(ev)
-				if mentioned || ev.ThreadTimeStamp != "" {
+				switch {
+				case mentioned:
+					s.signalIncomingMessage(r.Context(), ev, mentioned)
+				case ev.ThreadTimeStamp != "" && s.threadHasBotSession(r.Context(), ev.Channel, ev.ThreadTimeStamp):
 					s.signalIncomingMessage(r.Context(), ev, mentioned)
 				}
 			}
@@ -124,6 +128,29 @@ func (s *webhookServer) isMentioned(ev *slackevents.MessageEvent) bool {
 // new thread), so each conversation gets an isolated session.
 func threadSessionID(channel, threadRoot string) string {
 	return fmt.Sprintf("slack:%s:%s", channel, threadRoot)
+}
+
+// threadHasBotSession reports whether any router workflow was ever started for this
+// thread - which only happens when some message in it mentioned the bot, since a
+// mention-free message only reaches signalIncomingMessage once this check already
+// passed. The bot may have been mentioned on the thread root or on any reply deep in
+// the thread, so the triggering message's own ts (baked into the trailing segment of
+// its workflow ID) isn't known in advance; every router workflow for this thread
+// shares the same "connector-<identity>-<sessionID>-" prefix though, since sessionID
+// is scoped to the thread rather than the message. A prefix search on that avoids
+// starting a router workflow, and querying the backend, for every reply in threads
+// that never involved the bot.
+func (s *webhookServer) threadHasBotSession(ctx context.Context, channel, threadRoot string) bool {
+	prefix := router.RouterWorkflowIDPrefix(defaultIdentity, threadSessionID(channel, threadRoot))
+	resp, err := s.tc.ListWorkflow(ctx, &workflowservice.ListWorkflowExecutionsRequest{
+		Query:    fmt.Sprintf("WorkflowId STARTS_WITH %q", prefix),
+		PageSize: 1,
+	})
+	if err != nil {
+		log.Printf("threadHasBotSession: list workflows for prefix %s failed: %v", prefix, err)
+		return false
+	}
+	return len(resp.GetExecutions()) > 0
 }
 
 func (s *webhookServer) signalIncomingMessage(ctx context.Context, ev *slackevents.MessageEvent, mentioned bool) {

--- a/nexus/ui_connector/slack/inbound/server_test.go
+++ b/nexus/ui_connector/slack/inbound/server_test.go
@@ -1,0 +1,131 @@
+package slackinbound
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/temporal-community/temporal-agent-harness/nexus/ui_connector/router"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/mocks"
+)
+
+const testBotUserID = "BOT123"
+
+func postEvent(t *testing.T, s *webhookServer, body string) {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, routeEvents, strings.NewReader(body))
+	response := httptest.NewRecorder()
+	s.handleEvents(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.Code)
+	}
+}
+
+func expectRouterWorkflowStart(t *testing.T, tc *mocks.Client, wfID string, requiresExistingSession bool) {
+	t.Helper()
+	tc.On(
+		"ExecuteWorkflow",
+		mock.Anything,
+		mock.MatchedBy(func(options client.StartWorkflowOptions) bool {
+			return options.ID == wfID
+		}),
+		router.WorkflowName,
+		mock.MatchedBy(func(input router.Input) bool {
+			return input.Message != nil && input.Message.RequiresExistingSession == requiresExistingSession
+		}),
+	).Return(nil, nil).Once()
+}
+
+// expectThreadSessionLookup mocks the ListWorkflow prefix search threadHasBotSession
+// issues for a given thread, returning `found` executions.
+func expectThreadSessionLookup(t *testing.T, tc *mocks.Client, wfIDPrefix string, found bool) {
+	t.Helper()
+	var executions []*workflowpb.WorkflowExecutionInfo
+	if found {
+		executions = []*workflowpb.WorkflowExecutionInfo{{}}
+	}
+	tc.On(
+		"ListWorkflow",
+		mock.Anything,
+		mock.MatchedBy(func(req *workflowservice.ListWorkflowExecutionsRequest) bool {
+			return req.Query == `WorkflowId STARTS_WITH "`+wfIDPrefix+`"`
+		}),
+	).Return(&workflowservice.ListWorkflowExecutionsResponse{Executions: executions}, nil).Once()
+}
+
+// TestHandleEventsForwardsMention covers both a mention on a fresh top-level
+// message and a mention on an existing thread reply - both should forward
+// immediately without probing for a prior session.
+func TestHandleEventsForwardsMention(t *testing.T) {
+	cases := []struct {
+		name     string
+		ts       string
+		threadTS string
+		wfID     string
+	}{
+		{"top-level", "100.000", "", "connector-default-slack:C1:100.000-100.000"},
+		{"thread-reply", "200.000", "100.000", "connector-default-slack:C1:100.000-200.000"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := mocks.NewClient(t)
+			expectRouterWorkflowStart(t, mockClient, tc.wfID, false)
+			server := NewServer(mockClient, "task-queue", "", testBotUserID)
+
+			postEvent(t, server, `{
+				"type":"event_callback",
+				"event":{"type":"message","channel":"C1","user":"U1","ts":"`+tc.ts+`","thread_ts":"`+tc.threadTS+`","text":"<@BOT123> hi"}
+			}`)
+			mockClient.AssertNotCalled(t, "ListWorkflow", mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// TestHandleEventsForwardsUnmentionedReplyWhenThreadWasEverMentioned covers both the
+// case where the thread root itself was the mention, and the trickier case where the
+// mention happened on some earlier reply deep in the thread (not the root) - in both
+// cases the router workflow that the mention started has a different workflow-ID
+// suffix than the root's own ts, so the lookup must match on the shared thread
+// prefix rather than reconstructing one specific ID.
+func TestHandleEventsForwardsUnmentionedReplyWhenThreadWasEverMentioned(t *testing.T) {
+	mockClient := mocks.NewClient(t)
+	expectThreadSessionLookup(t, mockClient, "connector-default-slack:C1:100.000-", true)
+	expectRouterWorkflowStart(t, mockClient, "connector-default-slack:C1:100.000-300.000", true)
+	server := NewServer(mockClient, "task-queue", "", testBotUserID)
+
+	postEvent(t, server, `{
+		"type":"event_callback",
+		"event":{"type":"message","channel":"C1","user":"U1","ts":"300.000","thread_ts":"100.000","text":"just a reply"}
+	}`)
+}
+
+func TestHandleEventsDropsUnmentionedReplyWhenThreadWasNeverMentioned(t *testing.T) {
+	mockClient := mocks.NewClient(t)
+	expectThreadSessionLookup(t, mockClient, "connector-default-slack:C1:100.000-", false)
+	server := NewServer(mockClient, "task-queue", "", testBotUserID)
+
+	postEvent(t, server, `{
+		"type":"event_callback",
+		"event":{"type":"message","channel":"C1","user":"U1","ts":"200.000","thread_ts":"100.000","text":"just a reply"}
+	}`)
+
+	mockClient.AssertNotCalled(t, "ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHandleEventsDropsUnmentionedTopLevelMessage(t *testing.T) {
+	mockClient := mocks.NewClient(t)
+	server := NewServer(mockClient, "task-queue", "", testBotUserID)
+
+	postEvent(t, server, `{
+		"type":"event_callback",
+		"event":{"type":"message","channel":"C1","user":"U1","ts":"100.000","text":"just chatting"}
+	}`)
+
+	mockClient.AssertNotCalled(t, "ListWorkflow", mock.Anything, mock.Anything)
+	mockClient.AssertNotCalled(t, "ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}


### PR DESCRIPTION
## What changed

Use list workflow (cheaper op) to prevent us from sending all thread replies to the connector.

## Why

So we don't spend a lot of resources starting workflows to only query if an agent session exists when we can just describe it.