### PR TITLE
Parameterize connector by env

### DIFF
--- a/nexus/ui_connector/agent/driver.go
+++ b/nexus/ui_connector/agent/driver.go
@@ -157,12 +157,27 @@ func extractCitations(delta map[string]any) []router.Citation {
 
 // Driver implements router.BackendDriver against the temporal-agent-harness's Nexus agent
 // service.
-type Driver struct{}
+type Driver struct {
+	// NexusEndpoint is the Nexus endpoint name to target. Leave empty to use
+	// AgentNexusEndpoint. Set this explicitly when running multiple
+	// environments (e.g. prod/staging/ondemand) against the same Temporal
+	// Cloud account — Nexus endpoint names must be unique account-wide, not
+	// just namespace-wide, so each environment needs its own.
+	NexusEndpoint string
+}
+
+// nexusEndpoint returns d.NexusEndpoint, or AgentNexusEndpoint if unset.
+func (d *Driver) nexusEndpoint() string {
+	if d.NexusEndpoint == "" {
+		return AgentNexusEndpoint
+	}
+	return d.NexusEndpoint
+}
 
 // StartTurn dispatches a message, slash command, or approval decision to the agent
 // nexus service, translating the backend's response into a generic router.StartResult.
 func (d *Driver) StartTurn(ctx workflow.Context, input router.Input) (router.StartResult, error) {
-	agentClient := workflow.NewNexusClient(AgentNexusEndpoint, harnessgen.AgentService.ServiceName)
+	agentClient := workflow.NewNexusClient(d.nexusEndpoint(), harnessgen.AgentService.ServiceName)
 
 	switch {
 	case input.Message != nil:
@@ -272,7 +287,7 @@ func resolveApproval(ctx workflow.Context, agentClient workflow.NexusClient, ses
 // PollTurn polls the Nexus agent response stream starting from cursor and decodes each
 // item into a generic router.Delta.
 func (d *Driver) PollTurn(ctx workflow.Context, handle router.TurnHandle, cursor int64) (router.PollResult, error) {
-	agentClient := workflow.NewNexusClient(AgentNexusEndpoint, harnessgen.AgentService.ServiceName)
+	agentClient := workflow.NewNexusClient(d.nexusEndpoint(), harnessgen.AgentService.ServiceName)
 
 	var pollOut harnessgen.PollMessagesOutput
 	if err := agentClient.ExecuteOperation(ctx, harnessgen.AgentService.PollMessages,

--- a/nexus/ui_connector/slack/cmd/webhook/main.go
+++ b/nexus/ui_connector/slack/cmd/webhook/main.go
@@ -16,6 +16,7 @@ type flags struct {
 	temporalAddress    string
 	connectorNamespace string
 	taskQueue          string
+	identity           string
 	webhookPort        string
 }
 
@@ -41,6 +42,11 @@ func ensureFlags() *flags {
 	if taskQueue == "" {
 		taskQueue = "nexus-connector-slack"
 	}
+	// Distinguishes this server's router workflows from any other identity
+	// sharing the same connectorNamespace (e.g. running multiple environments
+	// against one Temporal namespace). Empty defers to inbound.NewServer's
+	// own default.
+	identity := os.Getenv("CONNECTOR_IDENTITY")
 	webhookPort := os.Getenv("WEBHOOK_PORT")
 	if webhookPort == "" {
 		webhookPort = "8080"
@@ -51,6 +57,7 @@ func ensureFlags() *flags {
 		temporalAddress:    temporalAddress,
 		connectorNamespace: connectorNamespace,
 		taskQueue:          taskQueue,
+		identity:           identity,
 		webhookPort:        webhookPort,
 	}
 }
@@ -75,7 +82,7 @@ func main() {
 		log.Printf("Slack bot user ID: %s (forwarding mentions, plus replies in threads the bot was mentioned in)", bot.UserID)
 	}
 
-	handler := slackinbound.NewServer(tc, flags.taskQueue, flags.slackSigningSecret, bot.UserID)
+	handler := slackinbound.NewServer(tc, flags.taskQueue, flags.identity, flags.slackSigningSecret, bot.UserID)
 	addr := ":" + flags.webhookPort
 	log.Printf("Slack webhook server listening on %s", addr)
 	if err := http.ListenAndServe(addr, handler); err != nil {

--- a/nexus/ui_connector/slack/inbound/server.go
+++ b/nexus/ui_connector/slack/inbound/server.go
@@ -28,15 +28,25 @@ const (
 type webhookServer struct {
 	tc            client.Client
 	taskQueue     string
+	identity      string
 	signingSecret string
 	botUserID     string
 	mux           *http.ServeMux
 }
 
-func NewServer(tc client.Client, taskQueue, signingSecret, botUserID string) *webhookServer {
+// NewServer wires up a Slack webhook handler. identity distinguishes this
+// server's router workflows from any other identity sharing the same
+// Temporal namespace (e.g. running prod/staging/ondemand environments
+// against one "connector" namespace) — it's baked into every router
+// workflow ID this server starts. Pass "" to use defaultIdentity.
+func NewServer(tc client.Client, taskQueue, identity, signingSecret, botUserID string) *webhookServer {
+	if identity == "" {
+		identity = defaultIdentity
+	}
 	s := &webhookServer{
 		tc:            tc,
 		taskQueue:     taskQueue,
+		identity:      identity,
 		signingSecret: signingSecret,
 		botUserID:     botUserID,
 		mux:           http.NewServeMux(),
@@ -141,7 +151,7 @@ func threadSessionID(channel, threadRoot string) string {
 // starting a router workflow, and querying the backend, for every reply in threads
 // that never involved the bot.
 func (s *webhookServer) threadHasBotSession(ctx context.Context, channel, threadRoot string) bool {
-	prefix := router.RouterWorkflowIDPrefix(defaultIdentity, threadSessionID(channel, threadRoot))
+	prefix := router.RouterWorkflowIDPrefix(s.identity, threadSessionID(channel, threadRoot))
 	resp, err := s.tc.ListWorkflow(ctx, &workflowservice.ListWorkflowExecutionsRequest{
 		Query:    fmt.Sprintf("WorkflowId STARTS_WITH %q", prefix),
 		PageSize: 1,
@@ -167,12 +177,12 @@ func (s *webhookServer) signalIncomingMessage(ctx context.Context, ev *slackeven
 		ThreadID:                threadRoot,
 		RequiresExistingSession: !mentioned,
 	}
-	wfID := router.RouterWorkflowID(defaultIdentity, sessionID, ev.TimeStamp)
+	wfID := router.RouterWorkflowID(s.identity, sessionID, ev.TimeStamp)
 	if _, err := s.tc.ExecuteWorkflow(ctx,
 		client.StartWorkflowOptions{ID: wfID, TaskQueue: s.taskQueue},
 		router.WorkflowName,
 		router.Input{
-			Identity:  defaultIdentity,
+			Identity:  s.identity,
 			SessionID: sessionID,
 			Message:   &msg,
 		},
@@ -201,12 +211,12 @@ func (s *webhookServer) handleSlashCommands(w http.ResponseWriter, r *http.Reque
 
 	sessionID := fmt.Sprintf("slack:%s", channelID)
 
-	wfID := router.RouterWorkflowID(defaultIdentity, sessionID, triggerID)
+	wfID := router.RouterWorkflowID(s.identity, sessionID, triggerID)
 	if _, err := s.tc.ExecuteWorkflow(r.Context(),
 		client.StartWorkflowOptions{ID: wfID, TaskQueue: s.taskQueue},
 		router.WorkflowName,
 		router.Input{
-			Identity:  defaultIdentity,
+			Identity:  s.identity,
 			SessionID: sessionID,
 			Slash: &router.SlashCommand{
 				Name:     command,
@@ -248,13 +258,13 @@ func (s *webhookServer) handleInteractions(w http.ResponseWriter, r *http.Reques
 		}
 
 		// Start a dedicated workflow to call approveToolCall via Nexus.
-		wfID := router.RouterWorkflowID(defaultIdentity, val.SessionID, "approval-"+val.ToolID)
+		wfID := router.RouterWorkflowID(s.identity, val.SessionID, "approval-"+val.ToolID)
 		if _, err := s.tc.ExecuteWorkflow(r.Context(),
 			client.StartWorkflowOptions{ID: wfID, TaskQueue: s.taskQueue},
 			router.WorkflowName,
 			router.Input{
 				SessionID: val.SessionID,
-				Identity:  defaultIdentity,
+				Identity:  s.identity,
 				Approval: &router.ApprovalDecision{
 					ToolID:   val.ToolID,
 					ToolName: val.ToolName,


### PR DESCRIPTION
## What changed

Enable us to change env vars so we can have different versions of the workflow be easily searchable

## Why

Make it easier to have staging/prod envs