### PR TITLE
Keep the stream-event discriminator on the workflow side

### DIFF
--- a/temporal_agent_harness/ai_sdks/openai_agents/_temporal_model_stub.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_temporal_model_stub.py
@@ -299,9 +299,13 @@ class _TemporalModelStub(Model):  # type:ignore[reportUnusedClass]
             "streaming_batch_interval": self.model_params.streaming_batch_interval,
         }
 
-        events = await workflow.execute_activity_method(
-            ModelActivity.invoke_model_activity_streaming,
+        # Dispatched by name, not by method: only an explicit result_type carries
+        # TResponseStreamEvent's Annotated discriminator, without which the events'
+        # lenient reconstruction picks the wrong union variant.
+        events = await workflow.execute_activity(
+            "invoke_model_activity_streaming",
             streaming_input,
+            result_type=list[TResponseStreamEvent],
             summary=summary,
             task_queue=self.model_params.task_queue,
             schedule_to_close_timeout=self.model_params.schedule_to_close_timeout,

--- a/tests/ai_sdks/openai_agents/test_stream_event_discriminator.py
+++ b/tests/ai_sdks/openai_agents/test_stream_event_discriminator.py
@@ -1,0 +1,140 @@
+# ABOUTME: Regression test for the raw OpenAI stream events a workflow gets back from the
+# streaming model activity. Serialized live-API payloads do not validate strictly against
+# openai's response models, so the plugin's converter falls back to openai's lenient
+# construct_type — which needs TResponseStreamEvent's Annotated discriminator to pick the right
+# union variant. Temporal resolves an activity's return hint without include_extras, so the
+# workflow has to name that type itself; before it did, the terminal response.completed came back
+# as the union's first variant and the agent turn died with "Model did not produce a final
+# response!". openai memoizes each union's resolved discriminator process-wide, so a worker that
+# had really run the activity was accidentally immune; a process that only replays the workflow
+# (serving a query against a running agent) starts cold — hence the cache clear here.
+#
+# Run with: uv run pytest tests/ai_sdks/openai_agents/test_stream_event_discriminator.py -v
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import Any
+
+import pytest_asyncio
+from agents import ModelSettings, ModelTracing
+from openai._models import DISCRIMINATOR_CACHE
+
+from temporalio import activity, workflow
+from temporalio.converter import DataConverter
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from temporal_agent_harness.ai_sdks.openai_agents import (
+    ModelActivityParameters,
+    OpenAIPayloadConverter,
+)
+from temporal_agent_harness.ai_sdks.openai_agents._temporal_model_stub import (
+    _TemporalModelStub,
+)
+
+_STREAM_EVENTS: list[dict[str, Any]] = [
+    # openai marks `name` required on this event, but the live API omits it.
+    {
+        "type": "response.function_call_arguments.done",
+        "arguments": "{}",
+        "item_id": "fc_1",
+        "output_index": 0,
+        "sequence_number": 1,
+    },
+    # A structured-output response: the converter writes the JSON schema under the field
+    # name `schema_`, while openai's model validates it under its alias, `schema`.
+    {
+        "type": "response.completed",
+        "sequence_number": 2,
+        "response": {
+            "id": "resp_1",
+            "created_at": 0.0,
+            "model": "gpt-test",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": False,
+            "tool_choice": "auto",
+            "tools": [],
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "Answer",
+                    "schema_": {"type": "object", "properties": {}},
+                }
+            },
+        },
+    },
+]
+
+
+@activity.defn(name="invoke_model_activity_streaming")
+async def streaming_activity_returning_live_payload(
+    input: dict[str, Any],
+) -> list[dict[str, Any]]:
+    return _STREAM_EVENTS
+
+
+@workflow.defn
+class StreamEventTypesWorkflow:
+    @workflow.run
+    async def run(self) -> list[str]:
+        stub = _TemporalModelStub(
+            "gpt-test",
+            model_params=ModelActivityParameters(
+                start_to_close_timeout=timedelta(seconds=10),
+                streaming_topic="stream-event-discriminator",
+            ),
+            agent=None,
+        )
+        return [
+            type(event).__name__
+            async for event in stub.stream_response(
+                None,
+                "hello",
+                ModelSettings(),
+                [],
+                None,
+                [],
+                ModelTracing.DISABLED,
+                previous_response_id=None,
+                conversation_id=None,
+                prompt=None,
+            )
+        ]
+
+
+@pytest_asyncio.fixture
+async def client_and_queue():
+    env = await WorkflowEnvironment.start_time_skipping(
+        data_converter=DataConverter(payload_converter_class=OpenAIPayloadConverter)
+    )
+    task_queue = f"stream-event-discriminator-{uuid.uuid4()}"
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        workflows=[StreamEventTypesWorkflow],
+        activities=[streaming_activity_returning_live_payload],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ):
+        try:
+            yield env.client, task_queue
+        finally:
+            await env.shutdown()
+
+
+async def test_streamed_events_keep_their_union_variant(client_and_queue):
+    client, task_queue = client_and_queue
+    DISCRIMINATOR_CACHE.clear()
+
+    event_types = await client.execute_workflow(
+        StreamEventTypesWorkflow.run,
+        id=f"stream-event-discriminator-{uuid.uuid4()}",
+        task_queue=task_queue,
+    )
+
+    assert event_types == [
+        "ResponseFunctionCallArgumentsDoneEvent",
+        "ResponseCompletedEvent",
+    ]


### PR DESCRIPTION
Attaching to a running agent session issues a query, and a query replays the workflow in a process that never executed the model activity. That replay dies:

```
[TMPRL1100] Nondeterminism error: Activity type of scheduled event 'docker-sandbox_session_exec'
does not match activity type of activity command 'docker-sandbox_client_delete'
```

The workflow asks the converter for the streaming activity's result using the hint Temporal derives from the activity definition, and Temporal resolves return annotations without `include_extras` — so `TResponseStreamEvent` arrives as a bare `Union` and loses its discriminator. Live payloads never validate strictly (`openai` marks `ResponseFunctionCallArgumentsDoneEvent.name` required while the API omits it; and the pydantic converter serializes by field name but validates by alias, which breaks `response.text.format.schema_`), so the lenient fallback always runs — and without the discriminator openai's `construct_type` falls back to "first variant that doesn't fail". The terminal `response.completed` came back as a `ResponseAudioDeltaEvent`, `final_response` stayed `None`, the agent raised "Model did not produce a final response!", and that unwound into a `finally` that tore down the sandbox — emitting `client_delete` where history held the next `session_exec`.

openai memoizes each union's resolved discriminator process-wide, so a worker that had really executed the activity was accidentally immune. That is why this only ever surfaced on replay-only processes, and why it reads as intermittent.

Dispatching by name with an explicit `result_type=list[TResponseStreamEvent]` gets the annotated type to the converter. `execute_activity_method` has no `result_type` parameter, so typed method dispatch cannot carry it — hence the name literal, which trades rename-safety for correctness.

Verified against a real 541-event history: `NondeterminismError` at event 120 → full clean replay through event 541, in a cold process, at `PYTHONHASHSEED` unset/0/42. The new test clears openai's `DISCRIMINATOR_CACHE` so it stays meaningful in a shared pytest process; its first draft passed against unfixed code, so the fixture was tightened until both events fail strict validation.

Note: `temporalio/contrib/openai_agents/_temporal_model_stub.py` carries the byte-identical dispatch and the same lenient converter, so the SDK looks exposed the same way. Not addressed here — it needs its own reproduction first.

Draft: the correctness and prose audits have not been run on this yet.
