### PR TITLE
Use same repo dir for nexus package rather than remote

### DIFF
--- a/nexus/durable_tools_gateway/pyproject.toml
+++ b/nexus/durable_tools_gateway/pyproject.toml
@@ -13,8 +13,10 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-nexus-mcp = { path = "nexus_mcp", editable = true } 
-temporal-agent-harness = { git = "https://github.com/temporal-community/temporal-agent-harness.git", branch = "main" }
+nexus-mcp = { path = "nexus_mcp", editable = true }
+# Same-repo path, not a remote pin. A hardcoded branch here breaks any
+# consumer pinning temporal-agent-harness to a different branch.
+temporal-agent-harness = { path = "../..", editable = true }
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## What changed

No need to pull from remote, for now they're both in the same repo.

## Why

Otherwise it's pinned to remote main, can't work off an off-branch dependency.