### PR TITLE
Allow webhook to strip an optionally provided slash command prefix

### DIFF
--- a/nexus/ui_connector/slack/cmd/webhook/main.go
+++ b/nexus/ui_connector/slack/cmd/webhook/main.go
@@ -18,6 +18,7 @@ type flags struct {
 	taskQueue          string
 	identity           string
 	webhookPort        string
+	slashCommandPrefix string
 }
 
 func ensureFlags() *flags {
@@ -51,6 +52,9 @@ func ensureFlags() *flags {
 	if webhookPort == "" {
 		webhookPort = "8080"
 	}
+	// Prefix for slash commands. Set this when other bots share the same
+	// Slack workspace. Leave empty if not.
+	slashCommandPrefix := os.Getenv("SLASH_CMD_PREFIX")
 	return &flags{
 		slackBotToken:      slackBotToken,
 		slackSigningSecret: slackSigningSecret,
@@ -59,6 +63,7 @@ func ensureFlags() *flags {
 		taskQueue:          taskQueue,
 		identity:           identity,
 		webhookPort:        webhookPort,
+		slashCommandPrefix: slashCommandPrefix,
 	}
 }
 
@@ -82,7 +87,7 @@ func main() {
 		log.Printf("Slack bot user ID: %s (forwarding mentions, plus replies in threads the bot was mentioned in)", bot.UserID)
 	}
 
-	handler := slackinbound.NewServer(tc, flags.taskQueue, flags.identity, flags.slackSigningSecret, bot.UserID)
+	handler := slackinbound.NewServer(tc, flags.taskQueue, flags.identity, flags.slackSigningSecret, bot.UserID, flags.slashCommandPrefix)
 	addr := ":" + flags.webhookPort
 	log.Printf("Slack webhook server listening on %s", addr)
 	if err := http.ListenAndServe(addr, handler); err != nil {

--- a/nexus/ui_connector/slack/inbound/server.go
+++ b/nexus/ui_connector/slack/inbound/server.go
@@ -26,12 +26,13 @@ const (
 )
 
 type webhookServer struct {
-	tc            client.Client
-	taskQueue     string
-	identity      string
-	signingSecret string
-	botUserID     string
-	mux           *http.ServeMux
+	tc                 client.Client
+	taskQueue          string
+	identity           string
+	signingSecret      string
+	botUserID          string
+	slashCommandPrefix string
+	mux                *http.ServeMux
 }
 
 // NewServer wires up a Slack webhook handler. identity distinguishes this
@@ -39,17 +40,25 @@ type webhookServer struct {
 // Temporal namespace (e.g. running prod/staging/ondemand environments
 // against one "connector" namespace) — it's baked into every router
 // workflow ID this server starts. Pass "" to use defaultIdentity.
-func NewServer(tc client.Client, taskQueue, identity, signingSecret, botUserID string) *webhookServer {
+//
+// slashCommandPrefix removes a "<prefix>-" prefix from the command name.
+// Use this when several bots share one Slack workspace. Slack requires
+// unique command names per workspace, so each bot's manifest can register
+// prefixed commands, like "/bot-dev-cmd". This strips the prefix so the
+// command matches a known name, like "cmd". Pass "" if this bot has no
+// prefix.
+func NewServer(tc client.Client, taskQueue, identity, signingSecret, botUserID, slashCommandPrefix string) *webhookServer {
 	if identity == "" {
 		identity = defaultIdentity
 	}
 	s := &webhookServer{
-		tc:            tc,
-		taskQueue:     taskQueue,
-		identity:      identity,
-		signingSecret: signingSecret,
-		botUserID:     botUserID,
-		mux:           http.NewServeMux(),
+		tc:                 tc,
+		taskQueue:          taskQueue,
+		identity:           identity,
+		signingSecret:      signingSecret,
+		botUserID:          botUserID,
+		slashCommandPrefix: slashCommandPrefix,
+		mux:                http.NewServeMux(),
 	}
 	s.mux.HandleFunc(routeEvents, s.handleEvents)
 	s.mux.HandleFunc(routeInteractions, s.handleInteractions)
@@ -198,6 +207,11 @@ func (s *webhookServer) handleSlashCommands(w http.ResponseWriter, r *http.Reque
 	}
 
 	command := strings.TrimPrefix(r.FormValue("command"), "/")
+	if s.slashCommandPrefix != "" {
+		// Strip the prefix if present. If not present, leave the command
+		// as-is. It will not match a known command later.
+		command = strings.TrimPrefix(command, s.slashCommandPrefix+"-")
+	}
 	channelID := r.FormValue("channel_id")
 	triggerID := r.FormValue("trigger_id")
 	userID := r.FormValue("user_id")

--- a/nexus/ui_connector/slack/inbound/server_test.go
+++ b/nexus/ui_connector/slack/inbound/server_test.go
@@ -3,6 +3,7 @@ package slackinbound
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -41,6 +42,35 @@ func expectRouterWorkflowStart(t *testing.T, tc *mocks.Client, wfID string, requ
 	).Return(nil, nil).Once()
 }
 
+// postSlashCommand sends a slash-command form body to handleSlashCommands.
+// It skips signature verification, like postEvent does.
+func postSlashCommand(t *testing.T, s *webhookServer, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, routeCommands, strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response := httptest.NewRecorder()
+	s.handleSlashCommands(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.Code)
+	}
+	return response
+}
+
+// expectSlashWorkflowStart mocks the workflow start for a slash command.
+// It checks the final command name and arg, after prefix stripping.
+func expectSlashWorkflowStart(t *testing.T, tc *mocks.Client, name, arg string) {
+	t.Helper()
+	tc.On(
+		"ExecuteWorkflow",
+		mock.Anything,
+		mock.Anything,
+		router.WorkflowName,
+		mock.MatchedBy(func(input router.Input) bool {
+			return input.Slash != nil && input.Slash.Name == name && input.Slash.Arg == arg
+		}),
+	).Return(nil, nil).Once()
+}
+
 // expectThreadSessionLookup mocks the ListWorkflow prefix search threadHasBotSession
 // issues for a given thread, returning `found` executions.
 func expectThreadSessionLookup(t *testing.T, tc *mocks.Client, wfIDPrefix string, found bool) {
@@ -75,7 +105,7 @@ func TestHandleEventsForwardsMention(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := mocks.NewClient(t)
 			expectRouterWorkflowStart(t, mockClient, tc.wfID, false)
-			server := NewServer(mockClient, "task-queue", "", testBotUserID)
+			server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "")
 
 			postEvent(t, server, `{
 				"type":"event_callback",
@@ -96,7 +126,7 @@ func TestHandleEventsForwardsUnmentionedReplyWhenThreadWasEverMentioned(t *testi
 	mockClient := mocks.NewClient(t)
 	expectThreadSessionLookup(t, mockClient, "connector-default-slack:C1:100.000-", true)
 	expectRouterWorkflowStart(t, mockClient, "connector-default-slack:C1:100.000-300.000", true)
-	server := NewServer(mockClient, "task-queue", "", testBotUserID)
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "")
 
 	postEvent(t, server, `{
 		"type":"event_callback",
@@ -107,7 +137,7 @@ func TestHandleEventsForwardsUnmentionedReplyWhenThreadWasEverMentioned(t *testi
 func TestHandleEventsDropsUnmentionedReplyWhenThreadWasNeverMentioned(t *testing.T) {
 	mockClient := mocks.NewClient(t)
 	expectThreadSessionLookup(t, mockClient, "connector-default-slack:C1:100.000-", false)
-	server := NewServer(mockClient, "task-queue", "", testBotUserID)
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "")
 
 	postEvent(t, server, `{
 		"type":"event_callback",
@@ -119,7 +149,7 @@ func TestHandleEventsDropsUnmentionedReplyWhenThreadWasNeverMentioned(t *testing
 
 func TestHandleEventsDropsUnmentionedTopLevelMessage(t *testing.T) {
 	mockClient := mocks.NewClient(t)
-	server := NewServer(mockClient, "task-queue", "", testBotUserID)
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "")
 
 	postEvent(t, server, `{
 		"type":"event_callback",
@@ -128,4 +158,49 @@ func TestHandleEventsDropsUnmentionedTopLevelMessage(t *testing.T) {
 
 	mockClient.AssertNotCalled(t, "ListWorkflow", mock.Anything, mock.Anything)
 	mockClient.AssertNotCalled(t, "ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestHandleSlashCommandsStripsConfiguredPrefix checks that a prefixed
+// command, like "/bot-build-name-cmd", resolves to "cmd".
+func TestHandleSlashCommandsStripsConfiguredPrefix(t *testing.T) {
+	mockClient := mocks.NewClient(t)
+	expectSlashWorkflowStart(t, mockClient, "scope", "docs")
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "bot-build-name")
+
+	postSlashCommand(t, server, url.Values{
+		"command":    {"/bot-build-name-scope"},
+		"channel_id": {"C1"},
+		"trigger_id": {"T1"},
+		"text":       {"docs"},
+	})
+}
+
+// TestHandleSlashCommandsLeavesCommandUnchangedWhenNoPrefixConfigured checks
+// that with no prefix set, the command name does not change.
+func TestHandleSlashCommandsLeavesCommandUnchangedWhenNoPrefixConfigured(t *testing.T) {
+	mockClient := mocks.NewClient(t)
+	expectSlashWorkflowStart(t, mockClient, "scope", "docs")
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "")
+
+	postSlashCommand(t, server, url.Values{
+		"command":    {"/scope"},
+		"channel_id": {"C1"},
+		"trigger_id": {"T1"},
+		"text":       {"docs"},
+	})
+}
+
+// TestHandleSlashCommandsLeavesMismatchedPrefixUnstripped checks that a
+// command missing the expected prefix does not change. It is forwarded as-is.
+func TestHandleSlashCommandsLeavesMismatchedPrefixUnstripped(t *testing.T) {
+	mockClient := mocks.NewClient(t)
+	expectSlashWorkflowStart(t, mockClient, "scope", "docs")
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "bot-build-id")
+
+	postSlashCommand(t, server, url.Values{
+		"command":    {"/scope"},
+		"channel_id": {"C1"},
+		"trigger_id": {"T1"},
+		"text":       {"docs"},
+	})
 }


### PR DESCRIPTION
## What changed

Add `SLASH_CMD_PREFIX` env var that gets threaded through to `handleSlashCommand` in the webhook server. `handleSlashCommand` will strip this prefix from the command before passing the command to the agent.

## Why

This allows us to have multiple versions of the same bot (dev/staging/prod) in the same workspace and have the command prefixed by `/<bot-build>_<cmd>`, but have the backend (agent) still handle just the `cmd` part without needing to know whether it's a dev/staging/prod build.