### PR TITLE
Batch stream updates when sending them back to messaging platform

### DIFF
--- a/nexus/ui_connector/README.md
+++ b/nexus/ui_connector/README.md
@@ -23,9 +23,9 @@ entirely the job of `backend` (interpreting input) and `outbound` (rendering del
 One folder per platform. Contracts + orchestration live in `router/`.
 
 ```
-router/            core: workflow + the two ports + shared request type
+router/            core: workflow + the ports + shared request type
   workflow.go        RouterWorkflow.Run, WorkflowName, RouterWorkflowID
-  interfaces.go       OutboundDriver, BackendDriver (the two ports)
+  interfaces.go       OutboundDriver, Streamer, BackendDriver (the ports)
   wire.go             Input (the RouterWorkflow argument type)
 
 slack/             everything Slack
@@ -53,24 +53,47 @@ imports nothing platform-specific. Never add a `router` -> platform import.
 
 ## Writing a new driver (e.g. Discord)
 
-You're implementing one or both ports in `router/interfaces.go`.
+You're implementing `OutboundDriver` in `router/interfaces.go`, and `BackendDriver` too
+if you're also adding a new agent backend.
 
 ### 1. `OutboundDriver` - deliver replies to the platform
 
+One interface, fully required - the compiler checks all of it at once:
+
 ```go
 type OutboundDriver interface {
-    SupportsStreaming(input Input) bool
-    BeginStream(ctx workflow.Context, input BeginStreamInput) (StreamHandle, error)
-    UpdateStream(ctx workflow.Context, input UpdateStreamInput) error
-    FinishStream(ctx workflow.Context, input FinishStreamInput) error
+    Streamer // SupportsStreaming, BeginStream, UpdateStream, FinishStream, StreamPollInterval
+
     PostMessage(ctx workflow.Context, input TextMetadata) error
     PostApprovalPrompt(ctx workflow.Context, input ApprovalPromptInput) error
     AcknowledgeApproval(ctx workflow.Context, input ApprovalAcknowledgementInput) error
 }
 ```
 
-- `SupportsStreaming` = false -> router calls `PostMessage` once with the full text
-  instead of streaming. Use this if the platform can't do incremental edits.
+Can your platform do incremental message edits?
+
+- **Yes** - implement `Streamer`'s five methods yourself (see `slack/outbound/driver.go`).
+  `SupportsStreaming` can vary per input: Teams returns `true` for a personal chat,
+  `false` for a shared channel/group one, and falls back to `PostMessage` for the
+  latter. `StreamPollInterval` sets how long router waits between poll calls so text
+  can build up into fewer, larger `UpdateStream` calls - return 0 if you don't need
+  this (most don't; only Slack does today, since `chat.appendStream` is a
+  rate-limited call per delta).
+- **No** - embed `router.NoStreaming` in your `Driver` struct instead of writing those
+  five methods:
+
+  ```go
+  type Driver struct {
+      router.NoStreaming
+      // ... your fields
+  }
+  ```
+
+Either way, add `var _ router.OutboundDriver = (*Driver)(nil)` in your package. That's
+what actually catches a missing method - the compiler flags it right there, at the
+point your `Driver` is supposed to satisfy the whole interface.
+
+Other notes:
 - Real platform I/O is non-deterministic -> **must run as Activities**, not directly in
   the interface methods. Pattern (see `slack/outbound/driver.go`):
   - `Driver` struct: thin dispatcher, only calls `workflow.ExecuteActivity`.

--- a/nexus/ui_connector/router/interfaces.go
+++ b/nexus/ui_connector/router/interfaces.go
@@ -1,50 +1,95 @@
 package router
 
-import "go.temporal.io/sdk/workflow"
+import (
+	"errors"
+	"time"
 
-// OutboundDriver is implemented by a platform-specific workflow-side adapter and called
-// directly by RouterWorkflow. Concrete drivers durably dispatch platform I/O to
-// activity implementations (for example, SlackPlatform or the Python Teams worker).
-type OutboundDriver interface {
-	// SupportsStreaming reports whether the inbound conversation can receive
-	// incremental response updates.
+	"go.temporal.io/sdk/workflow"
+)
+
+// Poster sends a single, non-streamed message.
+type Poster interface {
+	PostMessage(ctx workflow.Context, input TextMetadata) error
+}
+
+// ApprovalHandler posts a tool-approval prompt and updates it once a decision resolves.
+// The decision itself comes back through the platform's own interaction webhook, not
+// through this interface.
+type ApprovalHandler interface {
+	PostApprovalPrompt(ctx workflow.Context, input ApprovalPromptInput) error
+	AcknowledgeApproval(ctx workflow.Context, input ApprovalAcknowledgementInput) error
+}
+
+// Streamer delivers a reply as a live, incrementally-updated message instead of one
+// final post.
+type Streamer interface {
+	// SupportsStreaming reports whether this input can stream. May vary per input -
+	// e.g. Teams streams a personal chat but not a shared channel/group one.
 	SupportsStreaming(input Input) bool
 
-	// BeginStream opens a response stream before any text deltas are delivered.
-	// It returns the durable handle that must be passed to subsequent updates and
-	// finalization. Drivers may emulate streaming by updating a single message.
+	// BeginStream opens a stream. Router only calls this when SupportsStreaming is true.
 	BeginStream(ctx workflow.Context, input BeginStreamInput) (StreamHandle, error)
 
 	// UpdateStream delivers one text delta to the open stream.
 	UpdateStream(ctx workflow.Context, input UpdateStreamInput) error
 
-	// FinishStream closes the open stream. The router will not send more updates
-	// for this handle afterward.
+	// FinishStream closes the stream. No more updates follow for this handle.
 	FinishStream(ctx workflow.Context, input FinishStreamInput) error
 
-	// PostMessage sends a single, non-streamed message.
-	PostMessage(ctx workflow.Context, input TextMetadata) error
-
-	// PostApprovalPrompt posts a tool-approval prompt with Approve/Deny buttons.
-	// The decision comes back via the messaging platform's interaction webhook, not
-	// through this interface.
-	PostApprovalPrompt(ctx workflow.Context, input ApprovalPromptInput) error
-
-	// AcknowledgeApproval updates the inbound interaction after its decision is resolved.
-	AcknowledgeApproval(ctx workflow.Context, input ApprovalAcknowledgementInput) error
+	// StreamPollInterval is the wait between poll calls while a stream is open. Zero:
+	// forward every delta right away. Non-zero: batch text into fewer, larger
+	// UpdateStream calls - use this when UpdateStream is expensive per call (e.g.
+	// Slack's rate-limited chat.appendStream). ToolStatus/ThoughtSummary/
+	// ApprovalRequested deltas always flush immediately, never batched.
+	StreamPollInterval(input Input) time.Duration
 }
 
-// ApprovalPromptInput carries the information needed to render a tool-approval
-// prompt (approve/deny buttons) on the messaging platform.
+// OutboundDriver is the full contract a platform driver implements.
+type OutboundDriver interface {
+	Poster
+	ApprovalHandler
+	Streamer
+}
+
+// NoStreaming is Streamer for a driver that can't stream. Embed it to skip writing the
+// five Streamer methods yourself:
+//
+//	type Driver struct {
+//	    router.NoStreaming
+//	    // ... your fields
+//	}
+//
+// Router never calls BeginStream/UpdateStream/FinishStream when SupportsStreaming is
+// false, so their bodies here are unreachable in normal use.
+type NoStreaming struct{}
+
+var _ Streamer = NoStreaming{}
+
+func (NoStreaming) SupportsStreaming(Input) bool { return false }
+
+func (NoStreaming) BeginStream(workflow.Context, BeginStreamInput) (StreamHandle, error) {
+	return StreamHandle{}, errors.New("router: streaming not supported")
+}
+
+func (NoStreaming) UpdateStream(workflow.Context, UpdateStreamInput) error {
+	return errors.New("router: streaming not supported")
+}
+
+func (NoStreaming) FinishStream(workflow.Context, FinishStreamInput) error {
+	return errors.New("router: streaming not supported")
+}
+
+func (NoStreaming) StreamPollInterval(Input) time.Duration { return 0 }
+
+// ApprovalPromptInput renders a tool-approval prompt (approve/deny buttons).
 type ApprovalPromptInput struct {
 	TextMetadata
 	ToolID    string
 	ToolName  string
-	ToolInput string // JSON-encoded model-facing input (for display)
+	ToolInput string // JSON, for display
 }
 
-// ApprovalAcknowledgementInput carries a resolved approval decision back to the
-// inbound platform. Each driver decides whether and how to update its prompt.
+// ApprovalAcknowledgementInput is a resolved approval decision, for updating the prompt.
 type ApprovalAcknowledgementInput struct {
 	TextMetadata
 	PromptID string
@@ -58,20 +103,15 @@ type TextMetadata struct {
 	ThreadID  string
 	Text      string
 	Citations []Citation
-	// Segments is the ordered sequence of every delta that made up this message/turn
-	// (reply text, tool status, thought summaries), for outbound drivers whose platform
-	// has no richer way to show tool status than inline text and so must reconstruct
-	// their own single flattened rendering (see teamsoutbound.flattenSegments and
-	// slackoutbound.flattenSegments). Populated for both the non-streaming PostMessage
-	// path and, once a stream segment ends, FinishStream.
+	// Segments is every delta of this message/turn, in order. Drivers with no richer
+	// way to show tool status than inline text render it from here (see
+	// slackoutbound/teamsoutbound flattenSegments).
 	Segments   []Delta
 	ServiceURL string
 	ChannelID  string
 }
 
-// Citation is a backend-agnostic reference to a source document supporting part of a
-// reply. EndIndex marks where in the reply text it belongs; -1 if unknown. Outbound
-// drivers decide whether and how to render it.
+// Citation is a source reference for part of a reply. EndIndex is -1 if unknown.
 type Citation struct {
 	URL      string
 	Title    string
@@ -84,8 +124,7 @@ type UpdateMessageInput struct {
 	MessageID string
 }
 
-// StreamHandle is durable provider and routing state returned by BeginStream
-// and passed to later stream calls.
+// StreamHandle is durable state returned by BeginStream and passed to later stream calls.
 type StreamHandle struct {
 	ID                  string
 	SessionID           string
@@ -102,7 +141,7 @@ type BeginStreamInput struct {
 type UpdateStreamInput struct {
 	TextMetadata
 	Handle         StreamHandle
-	Delta          string // reply text chunk; empty if this update instead carries ToolStatus/ThoughtSummary
+	Delta          string // reply text chunk; empty if this carries ToolStatus/ThoughtSummary instead
 	ToolStatus     *ToolStatus
 	ThoughtSummary string
 }
@@ -112,35 +151,28 @@ type FinishStreamInput struct {
 	Handle StreamHandle
 }
 
-// BackendDriver is implemented by a concrete backend integration (e.g. the Nexus-based
-// agent driver) and called directly by RouterWorkflow. All backend
-// interpretation - including what a slash command means, or how an approval decision
-// is resolved - lives behind this interface; router never inspects Input itself.
+// BackendDriver is the agent integration a router talks to (e.g. Nexus into
+// temporal-agent-harness). It owns all input interpretation; router forwards Input
+// unexamined.
 type BackendDriver interface {
-	// StartTurn dispatches input (i.e., a message, slash command, or approval decision) to
-	// the backend. See StartResult for how the router interprets the outcome.
+	// StartTurn dispatches input (message, slash command, or approval decision).
 	StartTurn(ctx workflow.Context, input Input) (StartResult, error)
 
-	// PollTurn returns the next batch of deltas for a turn started via StartTurn.
-	// Only called when StartResult.Handle was set. Call repeatedly, feeding
-	// NextCursor back in as cursor, until Closed is true.
+	// PollTurn returns the next batch of deltas. Call repeatedly with NextCursor until
+	// Closed is true.
 	PollTurn(ctx workflow.Context, handle TurnHandle, cursor int64) (PollResult, error)
 }
 
-// StartResult is the outcome of StartTurn. At most one field is populated:
-//   - Reply set: an immediate, synchronous answer was produced (e.g. a harness
-//     operator command); post it and stop - no turn was created.
-//   - Handle set: a turn was created; poll it via PollTurn.
-//   - neither set: nothing further to do (e.g. an approval decision was resolved
-//     fire-and-forget).
+// StartResult is the outcome of StartTurn. At most one field is set:
+//   - Reply: a synchronous answer - post it, no turn was created.
+//   - Handle: a turn was created; poll it.
+//   - neither: nothing further to do.
 type StartResult struct {
 	Reply  string
 	Handle *TurnHandle
 }
 
-// TurnHandle correlates a started turn with its response stream. It carries whatever a
-// driver's own PollTurn implementation needs to resume polling - SessionID here because
-// this driver's backend keys turns by session.
+// TurnHandle correlates a started turn with its response stream.
 type TurnHandle struct {
 	SessionID        string
 	TurnID           string
@@ -155,17 +187,15 @@ type PollResult struct {
 	Closed     bool
 }
 
-// Delta is one backend-agnostic unit of turn output. Exactly one of Text,
-// ToolStatus, ThoughtSummary, or ApprovalRequested is meaningfully populated for a
-// given delta; Citations may ride alongside one of those or arrive alone. Router
-// never inspects which; it only accumulates and forwards.
+// Delta is one unit of turn output. Exactly one of Text, ToolStatus, ThoughtSummary, or
+// ApprovalRequested is meaningfully populated; Citations may ride along or arrive alone.
 type Delta struct {
-	Text              string      // a reply-text chunk - the ONLY field citations are indexed against
-	Citations         []Citation  // citations for the reply text delivered so far
-	ToolStatus        *ToolStatus // non-nil if this delta reports a tool call's lifecycle
-	ThoughtSummary    string      // a thought-summary chunk (the model's internal reasoning, distinct from the reply)
+	Text              string // the only field citations are indexed against
+	Citations         []Citation
+	ToolStatus        *ToolStatus
+	ThoughtSummary    string
 	IsFinal           bool
-	ApprovalRequested *ApprovalRequest // non-nil if this delta is a tool-approval gate
+	ApprovalRequested *ApprovalRequest
 }
 
 // ToolStatusKind is the lifecycle state a ToolStatus delta reports.
@@ -177,19 +207,17 @@ const (
 	ToolErrored   ToolStatusKind = "errored"
 )
 
-// ToolStatus reports one tool call's lifecycle transition. ToolID correlates every
-// status delta for the same invocation (started -> completed/errored).
+// ToolStatus is one tool call's lifecycle transition. ToolID ties started to
+// completed/errored.
 type ToolStatus struct {
 	ToolID   string
 	ToolName string
 	Status   ToolStatusKind
-	Message  string // populated when Status is ToolErrored
+	Message  string // set when Status is ToolErrored
 }
 
-// ApprovalRequest signals that a tool call is gated pending a human decision. This
-// flows backend → router → outbound (router asks the outbound driver to prompt a human);
-// it is distinct from ApprovalDecision, which flows the other way (the human's answer,
-// inbound → router → backend).
+// ApprovalRequest gates a tool call pending a human decision. Flows backend -> router ->
+// outbound. ApprovalDecision is the reply, flowing the other way.
 type ApprovalRequest struct {
 	ToolID        string
 	ToolName      string

--- a/nexus/ui_connector/router/workflow.go
+++ b/nexus/ui_connector/router/workflow.go
@@ -69,14 +69,14 @@ func (w *RouterWorkflow) Run(ctx workflow.Context, input Input) error {
 		// An immediate, synchronous answer - no turn was created, nothing to poll.
 		return w.outbound.PostMessage(ctx, textMetadata(input, result.Reply))
 
-	case result.Handle != nil && !w.outbound.SupportsStreaming(input):
+	case result.Handle != nil && w.outbound.SupportsStreaming(input):
+		// A turn was created; consume its response stream and deliver it outbound.
+		return w.streamResp(ctx, *result.Handle, input)
+
+	case result.Handle != nil:
 		// Collect the complete response when the outbound conversation does not
 		// support native streaming, then post it as a single message.
 		return w.postResp(ctx, *result.Handle, input)
-
-	case result.Handle != nil:
-		// A turn was created; consume its response stream and deliver it outbound.
-		return w.streamResp(ctx, *result.Handle, input)
 
 	default:
 		// Fire-and-forget (e.g. an approval decision was resolved) - nothing further.
@@ -172,6 +172,7 @@ func (w *RouterWorkflow) postResp(ctx workflow.Context, handle TurnHandle, input
 // backend/outbound pairing: it only deals in Delta and OutboundDriver calls.
 func (w *RouterWorkflow) streamResp(ctx workflow.Context, handle TurnHandle, input Input) error {
 	cursor := handle.StreamHeadOffset
+	pollInterval := w.outbound.StreamPollInterval(input)
 
 	// Start the initial outbound stream before polling. If the outbound driver can't
 	// open a stream (e.g. its activity worker died mid-attempt with no retries left),
@@ -193,10 +194,34 @@ func (w *RouterWorkflow) streamResp(ctx workflow.Context, handle TurnHandle, inp
 	var segmentCitations []Citation
 	var segments []Delta
 
-	for {
+	// pendingText holds text not yet sent. flushPendingText sends it as one UpdateStream
+	// call. This only fills when pollInterval > 0. When pacing is off, it stays empty
+	// and flushPendingText does nothing.
+	var pendingText string
+	flushPendingText := func() {
+		if pendingText == "" {
+			return
+		}
+		text := pendingText
+		pendingText = ""
+		w.updateStream(ctx, input, streamHandle, Delta{Text: text})
+	}
+
+	for iteration := 0; ; iteration++ {
+		if pollInterval > 0 && iteration > 0 {
+			// Wait before polling again. The backend keeps buffering deltas during the
+			// wait, so nothing is lost. This lets text build up for one batched update.
+			if err := workflow.Sleep(ctx, pollInterval); err != nil {
+				flushPendingText()
+				w.endStream(ctx, input, streamHandle, segmentText, segmentCitations, segments)
+				return nil
+			}
+		}
+
 		res, err := w.backend.PollTurn(ctx, handle, cursor)
 		if err != nil {
 			workflow.GetLogger(ctx).Warn("streamResp: PollTurn failed", "error", err)
+			flushPendingText()
 			w.endStream(ctx, input, streamHandle, segmentText, segmentCitations, segments)
 			return nil
 		}
@@ -204,6 +229,7 @@ func (w *RouterWorkflow) streamResp(ctx workflow.Context, handle TurnHandle, inp
 
 		// A turn may close without an explicit final delta.
 		if res.Closed {
+			flushPendingText()
 			w.endStream(ctx, input, streamHandle, segmentText, segmentCitations, segments)
 			return nil
 		}
@@ -215,6 +241,7 @@ func (w *RouterWorkflow) streamResp(ctx workflow.Context, handle TurnHandle, inp
 				// approval card so the messages appear in order. Clearing the handle makes
 				// the next text delta start a new stream.
 				if streamHandle != nil && streamHandle.CloseBeforeApproval {
+					flushPendingText()
 					w.endStream(ctx, input, streamHandle, segmentText, segmentCitations, segments)
 					streamHandle = nil
 					segmentText = ""
@@ -246,14 +273,27 @@ func (w *RouterWorkflow) streamResp(ctx workflow.Context, handle TurnHandle, inp
 					}
 				}
 				segmentText += delta.Text
-				w.updateStream(ctx, input, streamHandle, delta)
+
+				isPureText := delta.Text != "" && delta.ToolStatus == nil && delta.ThoughtSummary == ""
+				if pollInterval > 0 && isPureText {
+					pendingText += delta.Text
+				} else {
+					// This is a tool status or thought summary. Send any queued text first,
+					// then send this delta on its own, to keep the order correct.
+					flushPendingText()
+					w.updateStream(ctx, input, streamHandle, delta)
+				}
 			}
 
 			if delta.IsFinal {
+				flushPendingText()
 				w.endStream(ctx, input, streamHandle, segmentText, segmentCitations, segments)
 				return nil
 			}
 		}
+
+		// Batch done. Send any queued text now, before the next wait.
+		flushPendingText()
 	}
 }
 

--- a/nexus/ui_connector/router/workflow_test.go
+++ b/nexus/ui_connector/router/workflow_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,7 +36,8 @@ func (f *fakeBackend) PollTurn(ctx workflow.Context, handle TurnHandle, cursor i
 	return res, nil
 }
 
-// fakeOutbound is a minimal OutboundDriver test double that records calls in order.
+// fakeOutbound is a minimal OutboundDriver+Streamer test double that records calls in
+// order. pollInterval is 0 by default (unpaced); set it to test the paced path.
 type fakeOutbound struct {
 	calls             []string
 	supportsStreaming *bool
@@ -47,6 +49,13 @@ type fakeOutbound struct {
 	finishInputs      []FinishStreamInput
 	postMessageInputs []TextMetadata
 	approvalInputs    []ApprovalAcknowledgementInput
+	pollInterval      time.Duration
+}
+
+var _ OutboundDriver = (*fakeOutbound)(nil)
+
+func (f *fakeOutbound) StreamPollInterval(Input) time.Duration {
+	return f.pollInterval
 }
 
 func (f *fakeOutbound) SupportsStreaming(Input) bool {
@@ -127,6 +136,28 @@ func teamsMessageInput(conversationType string) Input {
 func nonStreamingOutbound() *fakeOutbound {
 	supportsStreaming := false
 	return &fakeOutbound{supportsStreaming: &supportsStreaming}
+}
+
+// minimalOutbound is how a driver that never streams looks in practice: embed
+// NoStreaming, then implement only the three OutboundDriver methods that matter.
+type minimalOutbound struct {
+	NoStreaming
+	postMessageInputs []TextMetadata
+}
+
+var _ OutboundDriver = (*minimalOutbound)(nil)
+
+func (m *minimalOutbound) PostMessage(ctx workflow.Context, input TextMetadata) error {
+	m.postMessageInputs = append(m.postMessageInputs, input)
+	return nil
+}
+
+func (m *minimalOutbound) PostApprovalPrompt(ctx workflow.Context, input ApprovalPromptInput) error {
+	return nil
+}
+
+func (m *minimalOutbound) AcknowledgeApproval(ctx workflow.Context, input ApprovalAcknowledgementInput) error {
+	return nil
 }
 
 func newTestEnv(t *testing.T, w *RouterWorkflow) *testsuite.TestWorkflowEnvironment {
@@ -303,6 +334,26 @@ func TestRouterWorkflow_ApprovalBoundary_ResetsSegmentCitations(t *testing.T) {
 	for _, seg := range in.finishInputs[1].Segments {
 		assert.NotEqual(t, "before", seg.Text)
 	}
+}
+
+func TestRouterWorkflow_NoStreamingEmbed_PostsCompleteResponse(t *testing.T) {
+	handle := TurnHandle{}
+	out := &fakeBackend{
+		startResult: StartResult{Handle: &handle},
+		pollResults: []PollResult{
+			{Deltas: []Delta{{Text: "partial "}, {Text: "answer", IsFinal: true}}},
+		},
+	}
+	in := &minimalOutbound{}
+
+	w := NewRouterWorkflow(in, out)
+	env := newTestEnv(t, w)
+	env.ExecuteWorkflow(w.Run, defaultInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Len(t, in.postMessageInputs, 1)
+	assert.Equal(t, "partial answer", in.postMessageInputs[0].Text)
 }
 
 func TestRouterWorkflow_TeamsSharedConversationPostsCompleteResponse(t *testing.T) {
@@ -657,6 +708,105 @@ func TestRouterWorkflow_ContinuesLiveUpdatesAfterFailureAndFinishes(t *testing.T
 	assert.Equal(t, []string{"Start", "Append:first ", "Append:second ", "Append:third", "End"}, in.calls)
 	require.Len(t, in.updateInputs, 3)
 	require.Len(t, in.finishInputs, 1)
+}
+
+// --- Streamer pacing tests. These cover the paced path (fakeOutbound.pollInterval > 0).
+
+func TestRouterWorkflow_PacedDriver_CoalescesTextDeltasWithinABatch(t *testing.T) {
+	handle := TurnHandle{TurnNumber: 1}
+	out := &fakeBackend{
+		startResult: StartResult{Handle: &handle},
+		pollResults: []PollResult{
+			{Deltas: []Delta{{Text: "a"}, {Text: "b"}, {Text: "c", IsFinal: true}}},
+		},
+	}
+	in := &fakeOutbound{pollInterval: 300 * time.Millisecond}
+
+	w := NewRouterWorkflow(in, out)
+	env := newTestEnv(t, w)
+	env.ExecuteWorkflow(w.Run, defaultInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	// Three deltas in one batch become one Append call.
+	assert.Equal(t, []string{"Start", "Append:abc", "End"}, in.calls)
+	// FinishStream still gets all three raw deltas. Citation math needs them separate.
+	require.Len(t, in.finishInputs, 1)
+	require.Len(t, in.finishInputs[0].Segments, 3)
+	assert.Equal(t, "a", in.finishInputs[0].Segments[0].Text)
+	assert.Equal(t, "b", in.finishInputs[0].Segments[1].Text)
+	assert.Equal(t, "c", in.finishInputs[0].Segments[2].Text)
+}
+
+func TestRouterWorkflow_PacedDriver_FlushesPendingTextBeforeToolStatus(t *testing.T) {
+	handle := TurnHandle{TurnNumber: 1}
+	toolStatus := &ToolStatus{ToolID: "t1", ToolName: "search", Status: ToolStarted}
+	out := &fakeBackend{
+		startResult: StartResult{Handle: &handle},
+		pollResults: []PollResult{
+			{Deltas: []Delta{
+				{Text: "partial "},
+				{ToolStatus: toolStatus},
+				{Text: "answer", IsFinal: true},
+			}},
+		},
+	}
+	in := &fakeOutbound{pollInterval: 300 * time.Millisecond}
+
+	w := NewRouterWorkflow(in, out)
+	env := newTestEnv(t, w)
+	env.ExecuteWorkflow(w.Run, defaultInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	// ToolStatus is never merged with text. It keeps its place in order.
+	require.Len(t, in.updateInputs, 3)
+	assert.Equal(t, "partial ", in.updateInputs[0].Delta)
+	assert.Same(t, toolStatus, in.updateInputs[1].ToolStatus)
+	assert.Empty(t, in.updateInputs[1].Delta)
+	assert.Equal(t, "answer", in.updateInputs[2].Delta)
+}
+
+func TestRouterWorkflow_PacedDriver_FlushesAtEndOfEachPollBatch(t *testing.T) {
+	handle := TurnHandle{TurnNumber: 1}
+	out := &fakeBackend{
+		startResult: StartResult{Handle: &handle},
+		pollResults: []PollResult{
+			{Deltas: []Delta{{Text: "he"}, {Text: "llo "}}},
+			{Deltas: []Delta{{Text: "world", IsFinal: true}}},
+		},
+	}
+	in := &fakeOutbound{pollInterval: 300 * time.Millisecond}
+
+	w := NewRouterWorkflow(in, out)
+	env := newTestEnv(t, w)
+	env.ExecuteWorkflow(w.Run, defaultInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	// Each poll batch sends its own merged update. The user sees it right away.
+	assert.Equal(t, []string{"Start", "Append:hello ", "Append:world", "End"}, in.calls)
+	assert.Equal(t, 2, out.pollCalls)
+}
+
+func TestRouterWorkflow_UnpacedDriver_StillForwardsPerDelta(t *testing.T) {
+	// A driver without StreamPacer is unaffected. Compare to the paced tests above.
+	handle := TurnHandle{TurnNumber: 1}
+	out := &fakeBackend{
+		startResult: StartResult{Handle: &handle},
+		pollResults: []PollResult{
+			{Deltas: []Delta{{Text: "a"}, {Text: "b"}, {Text: "c", IsFinal: true}}},
+		},
+	}
+	in := &fakeOutbound{}
+
+	w := NewRouterWorkflow(in, out)
+	env := newTestEnv(t, w)
+	env.ExecuteWorkflow(w.Run, defaultInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	assert.Equal(t, []string{"Start", "Append:a", "Append:b", "Append:c", "End"}, in.calls)
 }
 
 func TestRouterWorkflow_TeamsClosesStreamAtApprovalBoundary(t *testing.T) {

--- a/nexus/ui_connector/slack/outbound/driver.go
+++ b/nexus/ui_connector/slack/outbound/driver.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	slackapi "github.com/slack-go/slack"
 
@@ -34,11 +35,18 @@ const (
 // I/O.
 type Driver struct {
 	ActivityOptions workflow.ActivityOptions
+
+	// PollInterval sets the wait between poll calls (see router.Streamer). Zero
+	// (default) means no wait: one chat.appendStream call per delta, as today. Set a
+	// few hundred milliseconds to merge deltas into fewer calls. Tune against Slack's
+	// rate limit for chat.appendStream.
+	PollInterval time.Duration
 }
 
 var _ router.OutboundDriver = (*Driver)(nil)
 
 // NewDriver returns a Driver that calls the Slack activities with the given options.
+// PollInterval defaults to zero. Set it on the returned Driver to enable batching.
 func NewDriver(opts workflow.ActivityOptions) Driver {
 	return Driver{ActivityOptions: opts}
 }
@@ -46,6 +54,11 @@ func NewDriver(opts workflow.ActivityOptions) Driver {
 // SupportsStreaming reports that Slack supports incremental response updates.
 func (Driver) SupportsStreaming(router.Input) bool {
 	return true
+}
+
+// StreamPollInterval implements router.Streamer.
+func (d Driver) StreamPollInterval(router.Input) time.Duration {
+	return d.PollInterval
 }
 
 func (d Driver) BeginStream(ctx workflow.Context, input router.BeginStreamInput) (router.StreamHandle, error) {

--- a/nexus/ui_connector/teams/outbound/driver.go
+++ b/nexus/ui_connector/teams/outbound/driver.go
@@ -56,6 +56,12 @@ func (Driver) SupportsStreaming(input router.Input) bool {
 	}
 }
 
+// StreamPollInterval implements router.Streamer. Teams doesn't batch updates yet:
+// always forward each delta right away.
+func (Driver) StreamPollInterval(router.Input) time.Duration {
+	return 0
+}
+
 func (d Driver) streamActivityContext(ctx workflow.Context, handle router.StreamHandle) workflow.Context {
 	if handle.TaskQueue == "" {
 		return d.activityContext(ctx)


### PR DESCRIPTION
## What changed

Allow waiting and accumulating agent's delta between stream calls back to the platform.

## Why

Batching is more efficient use of activities, also this will help smooth out the stream from polling side.