### PR TITLE
Add allowslist to allow some bots to use Slack-to-agent connector

### DIFF
--- a/nexus/ui_connector/slack/cmd/webhook/main.go
+++ b/nexus/ui_connector/slack/cmd/webhook/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/temporal-community/temporal-agent-harness/nexus/ui_connector/slack"
 	"github.com/temporal-community/temporal-agent-harness/nexus/ui_connector/slack/inbound"
@@ -19,6 +20,19 @@ type flags struct {
 	identity           string
 	webhookPort        string
 	slashCommandPrefix string
+	allowedBotIDs      []string
+}
+
+// splitCommaList splits a comma-separated env var into trimmed, non-empty
+// values. Returns nil for an empty or blank input.
+func splitCommaList(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func ensureFlags() *flags {
@@ -55,6 +69,9 @@ func ensureFlags() *flags {
 	// Prefix for slash commands. Set this when other bots share the same
 	// Slack workspace. Leave empty if not.
 	slashCommandPrefix := os.Getenv("SLASH_CMD_PREFIX")
+	// Other bot IDs allowed to trigger this server (e.g. a load-test bot),
+	// comma-separated. Leave empty to allow none.
+	allowedBotIDs := splitCommaList(os.Getenv("ALLOWED_INBOUND_BOT_IDS"))
 	return &flags{
 		slackBotToken:      slackBotToken,
 		slackSigningSecret: slackSigningSecret,
@@ -64,6 +81,7 @@ func ensureFlags() *flags {
 		identity:           identity,
 		webhookPort:        webhookPort,
 		slashCommandPrefix: slashCommandPrefix,
+		allowedBotIDs:      allowedBotIDs,
 	}
 }
 
@@ -87,7 +105,7 @@ func main() {
 		log.Printf("Slack bot user ID: %s (forwarding mentions, plus replies in threads the bot was mentioned in)", bot.UserID)
 	}
 
-	handler := slackinbound.NewServer(tc, flags.taskQueue, flags.identity, flags.slackSigningSecret, bot.UserID, flags.slashCommandPrefix)
+	handler := slackinbound.NewServer(tc, flags.taskQueue, flags.identity, flags.slackSigningSecret, bot.UserID, flags.slashCommandPrefix, flags.allowedBotIDs)
 	addr := ":" + flags.webhookPort
 	log.Printf("Slack webhook server listening on %s", addr)
 	if err := http.ListenAndServe(addr, handler); err != nil {

--- a/nexus/ui_connector/slack/inbound/server.go
+++ b/nexus/ui_connector/slack/inbound/server.go
@@ -32,6 +32,7 @@ type webhookServer struct {
 	signingSecret      string
 	botUserID          string
 	slashCommandPrefix string
+	allowedBotIDs      map[string]struct{}
 	mux                *http.ServeMux
 }
 
@@ -47,9 +48,17 @@ type webhookServer struct {
 // prefixed commands, like "/bot-dev-cmd". This strips the prefix so the
 // command matches a known name, like "cmd". Pass "" if this bot has no
 // prefix.
-func NewServer(tc client.Client, taskQueue, identity, signingSecret, botUserID, slashCommandPrefix string) *webhookServer {
+//
+// allowedBotIDs are other bots allowed to trigger this server. Every other
+// bot message is still ignored, including this bot's own echoes. Pass nil
+// or empty to allow none (today's behavior).
+func NewServer(tc client.Client, taskQueue, identity, signingSecret, botUserID, slashCommandPrefix string, allowedBotIDs []string) *webhookServer {
 	if identity == "" {
 		identity = defaultIdentity
+	}
+	allowedBotIDSet := make(map[string]struct{}, len(allowedBotIDs))
+	for _, id := range allowedBotIDs {
+		allowedBotIDSet[id] = struct{}{}
 	}
 	s := &webhookServer{
 		tc:                 tc,
@@ -58,6 +67,7 @@ func NewServer(tc client.Client, taskQueue, identity, signingSecret, botUserID, 
 		signingSecret:      signingSecret,
 		botUserID:          botUserID,
 		slashCommandPrefix: slashCommandPrefix,
+		allowedBotIDs:      allowedBotIDSet,
 		mux:                http.NewServeMux(),
 	}
 	s.mux.HandleFunc(routeEvents, s.handleEvents)
@@ -121,10 +131,10 @@ func (s *webhookServer) handleEvents(w http.ResponseWriter, r *http.Request) {
 
 	case slackevents.CallbackEvent:
 		if ev, ok := evt.InnerEvent.Data.(*slackevents.MessageEvent); ok {
-			// Ignore the bot's own messages (including its streamed replies, which
-			// Slack echoes back as events). Always fall through to WriteHeader(200)
-			// below - a bare return reads as a 5xx to the Lambda proxy and Slack retries.
-			if ev.BotID == "" {
+			// Ignore bot messages, including this bot's own echoes, except
+			// allowedBotIDs. Always fall through to WriteHeader(200) below -
+			// a bare return reads as a 5xx to the Lambda proxy and Slack retries.
+			if ev.BotID == "" || s.isAllowedBot(ev.BotID) {
 				mentioned := s.isMentioned(ev)
 				switch {
 				case mentioned:
@@ -140,6 +150,11 @@ func (s *webhookServer) handleEvents(w http.ResponseWriter, r *http.Request) {
 
 func (s *webhookServer) isMentioned(ev *slackevents.MessageEvent) bool {
 	return s.botUserID == "" || strings.Contains(ev.Text, "<@"+s.botUserID+">")
+}
+
+func (s *webhookServer) isAllowedBot(botID string) bool {
+	_, ok := s.allowedBotIDs[botID]
+	return ok
 }
 
 // threadSessionID scopes an agent session to one Slack thread: the channel plus

--- a/nexus/ui_connector/slack/inbound/server_test.go
+++ b/nexus/ui_connector/slack/inbound/server_test.go
@@ -105,7 +105,7 @@ func TestHandleEventsForwardsMention(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := mocks.NewClient(t)
 			expectRouterWorkflowStart(t, mockClient, tc.wfID, false)
-			server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "")
+			server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "", nil)
 
 			postEvent(t, server, `{
 				"type":"event_callback",
@@ -126,7 +126,7 @@ func TestHandleEventsForwardsUnmentionedReplyWhenThreadWasEverMentioned(t *testi
 	mockClient := mocks.NewClient(t)
 	expectThreadSessionLookup(t, mockClient, "connector-default-slack:C1:100.000-", true)
 	expectRouterWorkflowStart(t, mockClient, "connector-default-slack:C1:100.000-300.000", true)
-	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "")
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "", nil)
 
 	postEvent(t, server, `{
 		"type":"event_callback",
@@ -137,7 +137,7 @@ func TestHandleEventsForwardsUnmentionedReplyWhenThreadWasEverMentioned(t *testi
 func TestHandleEventsDropsUnmentionedReplyWhenThreadWasNeverMentioned(t *testing.T) {
 	mockClient := mocks.NewClient(t)
 	expectThreadSessionLookup(t, mockClient, "connector-default-slack:C1:100.000-", false)
-	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "")
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "", nil)
 
 	postEvent(t, server, `{
 		"type":"event_callback",
@@ -149,7 +149,7 @@ func TestHandleEventsDropsUnmentionedReplyWhenThreadWasNeverMentioned(t *testing
 
 func TestHandleEventsDropsUnmentionedTopLevelMessage(t *testing.T) {
 	mockClient := mocks.NewClient(t)
-	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "")
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "", nil)
 
 	postEvent(t, server, `{
 		"type":"event_callback",
@@ -160,12 +160,44 @@ func TestHandleEventsDropsUnmentionedTopLevelMessage(t *testing.T) {
 	mockClient.AssertNotCalled(t, "ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
+// TestHandleEventsForwardsAllowedBotMention checks that a mention from any
+// bot in allowedBotIDs is forwarded, same as a human mention - covers both
+// entries in a multi-bot allowlist, not just a single configured ID.
+func TestHandleEventsForwardsAllowedBotMention(t *testing.T) {
+	for _, botID := range []string{"HCBOT1", "HCBOT2"} {
+		t.Run(botID, func(t *testing.T) {
+			mockClient := mocks.NewClient(t)
+			expectRouterWorkflowStart(t, mockClient, "connector-default-slack:C1:100.000-100.000", false)
+			server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "", []string{"HCBOT1", "HCBOT2"})
+
+			postEvent(t, server, `{
+				"type":"event_callback",
+				"event":{"type":"message","channel":"C1","user":"U1","bot_id":"`+botID+`","ts":"100.000","text":"<@BOT123> hi"}
+			}`)
+		})
+	}
+}
+
+// TestHandleEventsDropsOtherBotMentionEvenWhenSomeBotsAreAllowed checks the
+// allowlist doesn't open the door to every bot, only the configured ones.
+func TestHandleEventsDropsOtherBotMentionEvenWhenSomeBotsAreAllowed(t *testing.T) {
+	mockClient := mocks.NewClient(t)
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "", []string{"HCBOT1", "HCBOT2"})
+
+	postEvent(t, server, `{
+		"type":"event_callback",
+		"event":{"type":"message","channel":"C1","user":"U1","bot_id":"OTHERBOT","ts":"100.000","text":"<@BOT123> hi"}
+	}`)
+
+	mockClient.AssertNotCalled(t, "ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
 // TestHandleSlashCommandsStripsConfiguredPrefix checks that a prefixed
 // command, like "/bot-build-name-cmd", resolves to "cmd".
 func TestHandleSlashCommandsStripsConfiguredPrefix(t *testing.T) {
 	mockClient := mocks.NewClient(t)
 	expectSlashWorkflowStart(t, mockClient, "scope", "docs")
-	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "bot-build-name")
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "bot-build-name", nil)
 
 	postSlashCommand(t, server, url.Values{
 		"command":    {"/bot-build-name-scope"},
@@ -180,7 +212,7 @@ func TestHandleSlashCommandsStripsConfiguredPrefix(t *testing.T) {
 func TestHandleSlashCommandsLeavesCommandUnchangedWhenNoPrefixConfigured(t *testing.T) {
 	mockClient := mocks.NewClient(t)
 	expectSlashWorkflowStart(t, mockClient, "scope", "docs")
-	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "")
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "", nil)
 
 	postSlashCommand(t, server, url.Values{
 		"command":    {"/scope"},
@@ -195,7 +227,7 @@ func TestHandleSlashCommandsLeavesCommandUnchangedWhenNoPrefixConfigured(t *test
 func TestHandleSlashCommandsLeavesMismatchedPrefixUnstripped(t *testing.T) {
 	mockClient := mocks.NewClient(t)
 	expectSlashWorkflowStart(t, mockClient, "scope", "docs")
-	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "bot-build-id")
+	server := NewServer(mockClient, "task-queue", "", "", testBotUserID, "bot-build-id", nil)
 
 	postSlashCommand(t, server, url.Values{
 		"command":    {"/scope"},


### PR DESCRIPTION
## What changed

Add an allowlist of bot IDs that can message our bot.

## Why

This allows us to do programmatic health checks easily to exercise slack connector + agent.