### PR TITLE
Thread streaming_batch_interval into the OpenAI stream observer

### DIFF
--- a/docs/internal/agentevent-workflow-stream.md
+++ b/docs/internal/agentevent-workflow-stream.md
@@ -117,6 +117,13 @@ stream, not the resurrected entries.
     and activity-tool `tool_start`/`tool_end`. Raw provider tokens are folded into semantic
     `AgentEvent`s *inside* the model-call activity — the lowest-level thing that ever crosses the
     activity→workflow→client boundary is already an `AgentEvent`, never raw bytes.
+- **Flush cadence is the out-of-workflow cost knob.** Activity-side publishes buffer and flush on
+  an interval; each flush is *one* Signal, so a longer interval means fewer history events for the
+  same stream content (it does not reduce the number of events published). Default is
+  `DEFAULT_PUBLISH_BATCH_INTERVAL` (50ms) in `publisher_from_activity`; an SDK plugin passes its own
+  configured value instead — for OpenAI that is `ModelActivityParameters.streaming_batch_interval`
+  (100ms), threaded to `harness_observer_factory` by `select_observer` and on into the observer's
+  publisher. In-workflow publishes are unbuffered (they ride the workflow's own history).
 - **Consumers** subscribe by `workflow_id` (`WorkflowStreamClient.create(...).subscribe(...)`); the
   UI-facing "stream" is a client-side merge of the whole agent tree — see
   [`event-stream-and-storage.md`](event-stream-and-storage.md).

--- a/examples/react_agent/worker.py
+++ b/examples/react_agent/worker.py
@@ -93,6 +93,12 @@ async def main() -> None:
             heartbeat_timeout=timedelta(seconds=30),
             # The harness streaming seam: route streamed events to the in-flight turn.
             stream_to_provider=stream_to_provider,
+            # Streaming granularity. Each flush is one publish Signal, so a longer interval
+            # means fewer workflow-history events for the same stream content (it does not
+            # change how many events are published). The field's default is 100ms; 50ms here
+            # buys the richest stream at the highest history cost — raise it (250-500ms) if
+            # history volume matters more than token-by-token smoothness.
+            streaming_batch_interval=timedelta(milliseconds=50),
         ),
         mcp_server_providers=[
             StatelessMCPServerProvider(

--- a/examples/react_agent/workflow.py
+++ b/examples/react_agent/workflow.py
@@ -53,7 +53,7 @@ with workflow.unsafe.imports_passed_through():
 
 
 TASK_QUEUE = "react-agent"
-DEFAULT_MODEL = "gpt-5.1"
+DEFAULT_MODEL = "gpt-5.6-luna"
 MCP_SERVER_NAME = "f1-data"
 
 # Streaming vs non-streaming is chosen here, at the SDK call site (see `ask`). Toggle it with the

--- a/temporal_agent_harness/ai_sdks/integration_helpers/_stream_observer.py
+++ b/temporal_agent_harness/ai_sdks/integration_helpers/_stream_observer.py
@@ -8,7 +8,7 @@ see the output live.
 This contract is deliberately SDK-agnostic: ``RawEvent`` is a type variable and
 the per-call routing token is opaque (``Any``).  An SDK plugin's streamed
 activity never type-switches on the token — it always hands the token to a
-configured :data:`ObserverFactory`, which returns a fresh observer per call.
+configured :class:`ObserverFactory`, which returns a fresh observer per call.
 The same contract serves the Gemini, OpenAI-agents, and any future plugin, so
 each plugin's "publish raw events to a workflow stream" path is one shared
 abstraction rather than N divergent re-implementations.
@@ -22,7 +22,7 @@ from contextlib import (
     asynccontextmanager,
 )
 from datetime import timedelta
-from typing import Any, AsyncIterator, Callable, Optional, Protocol, TypeVar
+from typing import Any, AsyncIterator, Optional, Protocol, TypeVar
 
 from temporalio.contrib.workflow_streams import WorkflowStreamClient
 
@@ -34,6 +34,12 @@ __all__ = [
 ]
 
 RawEvent = TypeVar("RawEvent", contravariant=True)
+
+# Fallback publish-flush cadence, used only when a caller does not pass one. Every
+# plugin-driven call DOES pass one (the OpenAI plugin threads
+# ``ModelActivityParameters.streaming_batch_interval``), so this governs only direct
+# construction; it mirrors that field's own default so the two never disagree.
+_DEFAULT_BATCH_INTERVAL = timedelta(milliseconds=100)
 
 
 class StreamObserver(Protocol[RawEvent]):
@@ -52,11 +58,24 @@ class StreamObserver(Protocol[RawEvent]):
     async def on_event(self, event: RawEvent) -> None: ...
 
 
-# Per-call factory: an opaque routing token -> a fresh observer context manager.
-# Per-call state (arg buffers, tool brackets, the WorkflowStream publisher) lives
-# inside the returned observer, so concurrent streamed calls on a shared worker
-# never bleed state into one another.
-ObserverFactory = Callable[[Any], AbstractAsyncContextManager["StreamObserver[Any]"]]
+class ObserverFactory(Protocol):
+    """Per-call factory: an opaque routing token -> a fresh observer context manager.
+
+    Per-call state (arg buffers, tool brackets, the WorkflowStream publisher) lives
+    inside the returned observer, so concurrent streamed calls on a shared worker
+    never bleed state into one another.
+
+    ``batch_interval`` is the publish-flush cadence the *plugin* was configured with
+    (``ModelActivityParameters.streaming_batch_interval``), handed to every factory so
+    a custom observer's own publisher honors the same setting as the built-in
+    :class:`RawTopicObserver` — the alternative being a configured interval that
+    silently does nothing whenever a factory is wired. Keyword-only, so a factory
+    that ignores cadence can still declare it as ``**_kw``.
+    """
+
+    def __call__(
+        self, token: Any, *, batch_interval: timedelta
+    ) -> AbstractAsyncContextManager["StreamObserver[Any]"]: ...
 
 
 class RawTopicObserver:
@@ -75,18 +94,18 @@ class RawTopicObserver:
         topic_name: str,
         *,
         event_type: type | None = None,
-        batch_ms: int = 100,
+        batch_interval: timedelta = _DEFAULT_BATCH_INTERVAL,
     ) -> None:
         self._topic_name = topic_name
         self._event_type = event_type
-        self._batch_ms = batch_ms
+        self._batch_interval = batch_interval
         self._stack: AsyncExitStack | None = None
         self._topic: Any = None
 
     async def __aenter__(self) -> RawTopicObserver:
         self._stack = AsyncExitStack()
         publisher = WorkflowStreamClient.from_within_activity(
-            batch_interval=timedelta(milliseconds=self._batch_ms),
+            batch_interval=self._batch_interval,
         )
         await self._stack.enter_async_context(publisher)
         self._topic = publisher.topic(self._topic_name, type=self._event_type)
@@ -127,13 +146,14 @@ def select_observer(
     factory: Optional[ObserverFactory],
     token: Any,
     event_type: type | None = None,
-    batch_ms: int = 100,
+    batch_interval: timedelta = _DEFAULT_BATCH_INTERVAL,
 ) -> AbstractAsyncContextManager[Optional[StreamObserver[Any]]]:
     """Resolve the per-call live observer from the routing token.
 
     - ``token is None`` → no observer (the factory is never called).
-    - a ``factory`` is configured → ``factory(token)`` (the plugin hands the
-      opaque token straight through; it never type-switches on it).
+    - a ``factory`` is configured → ``factory(token, batch_interval=...)`` (the plugin
+      hands the opaque token straight through; it never type-switches on it, and passes
+      the configured flush cadence so a custom observer's publisher can honor it).
     - no factory but a ``str`` token → the default :class:`RawTopicObserver`,
       treating the token as a ``WorkflowStream`` topic name.
     - no factory and a non-``str`` token → no observer (a non-default token with
@@ -142,7 +162,9 @@ def select_observer(
     if token is None:
         return _null_observer()
     if factory is not None:
-        return factory(token)
+        return factory(token, batch_interval=batch_interval)
     if isinstance(token, str):
-        return RawTopicObserver(token, event_type=event_type, batch_ms=batch_ms)
+        return RawTopicObserver(
+            token, event_type=event_type, batch_interval=batch_interval
+        )
     return _null_observer()

--- a/temporal_agent_harness/ai_sdks/openai_agents/_invoke_model_activity.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_invoke_model_activity.py
@@ -400,6 +400,8 @@ class ModelActivity:
         runtime's own vocabulary, while the default (no factory, ``str``
         token) republishes raw events to a ``WorkflowStream`` topic so
         external consumers (UIs, tracing, etc.) observe them as they arrive.
+        Either way the request's ``streaming_batch_interval`` is handed to the
+        observer, so the configured publish-flush cadence applies on both paths.
         The collected-and-returned list is unaffected either way.
 
         Heartbeats run on a background task via ``auto_heartbeater`` so
@@ -421,7 +423,7 @@ class ModelActivity:
         observer_cm = select_observer(
             factory=self._observer_factory,
             token=input["stream_to"],
-            batch_ms=int(batch_interval / timedelta(milliseconds=1)),
+            batch_interval=batch_interval,
         )
         async with observer_cm as obs:
             try:

--- a/temporal_agent_harness/ai_sdks/openai_agents/_model_parameters.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_model_parameters.py
@@ -92,6 +92,13 @@ class ModelActivityParameters:
     """Interval between automatic flushes for the stream publisher used
     by the streaming activity.
 
+    Each flush is one Signal to the workflow, so this trades how promptly
+    consumers see events against how many workflow-history events a streamed
+    turn costs; it does not change how many events are published. Applies on
+    both streaming paths: the built-in raw-topic publisher, and any observer
+    built by the plugin's ``observer_factory`` (the interval is handed to that
+    factory as ``batch_interval``).
+
     .. warning::
         Streaming support is experimental and may change in future
         versions."""

--- a/temporal_agent_harness/ai_sdks/openai_agents/_temporal_openai_agents.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_temporal_openai_agents.py
@@ -251,6 +251,10 @@ class OpenAIAgentsPlugin(SimplePlugin):
                 Use with caution in production environments.
             observer_factory: Optional factory turning each streamed model call's
                 opaque routing token into a fresh live :class:`StreamObserver`.
+                Called as ``factory(token, batch_interval=...)``, where the interval
+                is ``model_params.streaming_batch_interval`` — so the configured
+                flush cadence applies to a custom observer's publisher too, not just
+                to the built-in raw-topic one.
                 Pair with ``model_params.stream_to_provider`` to route streamed
                 events into an embedding runtime (e.g. the agent harness turn
                 stream). If ``None``, streaming publishes raw events to

--- a/temporal_agent_harness/ai_sdks/openai_agents_harness.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents_harness.py
@@ -40,7 +40,8 @@ import json
 import uuid
 from collections.abc import Awaitable, Callable, Mapping
 from contextlib import AsyncExitStack
-from typing import TYPE_CHECKING, Any
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Self
 
 from pydantic import BaseModel
 
@@ -134,7 +135,13 @@ class OpenAIStreamObserver:
     off the terminal ``response.completed``.
     """
 
-    def __init__(self, context: TurnStreamContext, *, model: str | None = None) -> None:
+    def __init__(
+        self,
+        context: TurnStreamContext,
+        *,
+        model: str | None = None,
+        batch_interval: timedelta | None = None,
+    ) -> None:
         self._context = context
         # The requested model id, known at dispatch (from the streaming activity input),
         # so BOTH brackets name it — matching how the Gemini plugin reads the model from
@@ -150,11 +157,18 @@ class OpenAIStreamObserver:
         self._arg_buffers: dict[str, str] = {}
         # Token usage, captured off the terminal response.completed for the ended bracket.
         self._usage: TokenUsage | None = None
+        # Publish-flush cadence for this call's publisher — the plugin's configured
+        # ``ModelActivityParameters.streaming_batch_interval``, threaded in by
+        # ``harness_observer_factory``. ``None`` defers to the harness default in
+        # ``publisher_from_activity``.
+        self._batch_interval = batch_interval
 
-    async def __aenter__(self) -> OpenAIStreamObserver:
+    async def __aenter__(self) -> Self:
         self._stack = AsyncExitStack()
         self._publisher = await self._stack.enter_async_context(
-            AgentWorkflowRunner.publisher_from_activity(self._context)
+            AgentWorkflowRunner.publisher_from_activity(
+                self._context, batch_interval=self._batch_interval
+            )
         )
         # Open the model-interaction span at dispatch, before awaiting any event, so the
         # span duration is the real call latency.
@@ -304,20 +318,29 @@ def stream_to_provider(model: str | None, run_context: Any) -> _HarnessStreamTok
     return _HarnessStreamToken(context=context, model=model)
 
 
-def harness_observer_factory(token: Any) -> StreamObserver[Any]:
+def harness_observer_factory(
+    token: Any, *, batch_interval: timedelta | None = None
+) -> StreamObserver[Any]:
     """Turn a streamed call's opaque routing token into a fresh observer.
 
     The token is the :class:`_HarnessStreamToken` produced by :func:`stream_to_provider`;
     it arrives here rehydrated as a plain dict (it rides the activity input as an untyped
     ``Any`` field), so we validate it back into the model. Wired onto the plugin as
     ``observer_factory=...``.
+
+    ``batch_interval`` is the plugin's configured
+    ``ModelActivityParameters.streaming_batch_interval``, handed to every factory by
+    ``select_observer`` and forwarded to the observer's publisher — so raising that one
+    field genuinely coarsens this path's flush cadence (one Signal per flush) instead of
+    being ignored the moment a factory is wired. Defaulted so the factory stays callable
+    by hand (e.g. in tests), where ``None`` means "use the harness default".
     """
     tok = (
         token
         if isinstance(token, _HarnessStreamToken)
         else _HarnessStreamToken.model_validate(token)
     )
-    return OpenAIStreamObserver(tok.context, model=tok.model)
+    return OpenAIStreamObserver(tok.context, model=tok.model, batch_interval=batch_interval)
 
 
 # ---------------------------------------------------------------------------

--- a/temporal_agent_harness/harness/agent_workflow.py
+++ b/temporal_agent_harness/harness/agent_workflow.py
@@ -147,6 +147,13 @@ CustomApprovalFallback = Callable[[ToolApprovalContext], bool]
 
 _SLASH_MESSAGE_TYPE = "slash"
 
+# Harness default publish-flush cadence for activity-side stream publishers (see
+# ``AgentWorkflowRunner.publisher_from_activity``). Each flush is one Signal into the
+# workflow, so this is the knob that trades UI snappiness against workflow-history
+# volume. It is only the fallback: a caller that has its own configured cadence — an SDK
+# plugin threading ``streaming_batch_interval``, say — passes that instead.
+DEFAULT_PUBLISH_BATCH_INTERVAL = timedelta(milliseconds=50)
+
 _InjectedT = TypeVar("_InjectedT")
 
 # Annotate a tool parameter ``x: Injected[Foo]`` to have the *workflow* supply it per
@@ -2260,7 +2267,7 @@ class AgentWorkflowRunner:
     async def publisher_from_activity(
         context: TurnStreamContext,
         *,
-        batch_interval: timedelta = timedelta(milliseconds=50),
+        batch_interval: timedelta | None = None,
     ) -> AsyncIterator[TurnEventPublisher]:
         """Open a :class:`TurnEventPublisher` from inside a Temporal activity.
 
@@ -2279,14 +2286,21 @@ class AgentWorkflowRunner:
                 :attr:`AgentWorkflowRunner.current_stream_context` and
                 forwarded opaquely through activity inputs.
             batch_interval: Background flush cadence on the underlying
-                stream client. Default 50ms keeps the UI feel snappy.
+                stream client — each flush is one Signal, so a longer interval
+                trades UI snappiness for fewer workflow-history events. ``None``
+                takes :data:`DEFAULT_PUBLISH_BATCH_INTERVAL` (50ms), which keeps
+                the UI feel snappy. An SDK integration should pass its own
+                configured cadence (e.g. the OpenAI plugin's
+                ``ModelActivityParameters.streaming_batch_interval``).
 
         Yields:
             A :class:`TurnEventPublisher` bound to the active workflow
             (resolved from the activity context) and the given turn.
         """
         client = WorkflowStreamClient.from_within_activity(
-            batch_interval=batch_interval,
+            batch_interval=(
+                DEFAULT_PUBLISH_BATCH_INTERVAL if batch_interval is None else batch_interval
+            ),
         )
         # ``from_within_activity`` targets the workflow that SCHEDULED this activity (always the
         # publishing agent), so events land on the right stream. The agent's SHORT id to stamp them

--- a/tests/ai_sdks/integration_helpers/test_select_observer.py
+++ b/tests/ai_sdks/integration_helpers/test_select_observer.py
@@ -1,0 +1,88 @@
+# ABOUTME: Unit-tests select_observer's routing and the flush cadence it threads — that a
+# configured ObserverFactory is called with (token, batch_interval=...) so a plugin's
+# streaming_batch_interval governs a custom observer's publisher too, and that the default
+# raw-topic path carries the same interval. No Temporal server, no provider keys.
+#
+# Run with: uv run pytest tests/ai_sdks/integration_helpers/test_select_observer.py -v
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from temporal_agent_harness.ai_sdks.integration_helpers import (
+    ObserverFactory,
+    RawTopicObserver,
+    StreamObserver,
+    select_observer,
+)
+
+
+class _StubObserver:
+    """The minimal StreamObserver a factory has to hand back."""
+
+    async def __aenter__(self) -> StreamObserver[Any]:
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool | None:
+        return None
+
+    async def on_event(self, event: Any) -> None:
+        pass
+
+
+class _RecordingFactory(ObserverFactory):
+    """An ObserverFactory that records how select_observer called it."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, timedelta]] = []
+
+    def __call__(
+        self, token: Any, *, batch_interval: timedelta
+    ) -> AbstractAsyncContextManager[StreamObserver[Any]]:
+        self.calls.append((token, batch_interval))
+
+        @asynccontextmanager
+        async def _cm() -> AsyncGenerator[StreamObserver[Any], None]:
+            yield _StubObserver()
+
+        return _cm()
+
+
+@pytest.mark.asyncio
+async def test_factory_receives_token_and_batch_interval():
+    factory = _RecordingFactory()
+    token = {"context": {"turn_id": "t-1"}}
+
+    async with select_observer(
+        factory=factory, token=token, batch_interval=timedelta(milliseconds=400)
+    ):
+        pass
+
+    assert factory.calls == [(token, timedelta(milliseconds=400))]
+
+
+def test_raw_topic_path_carries_the_batch_interval():
+    observer = select_observer(
+        factory=None, token="raw_events", batch_interval=timedelta(milliseconds=250)
+    )
+    assert isinstance(observer, RawTopicObserver)
+    assert observer._batch_interval == timedelta(milliseconds=250)
+
+
+@pytest.mark.asyncio
+async def test_no_token_means_no_observer_and_no_factory_call():
+    factory = _RecordingFactory()
+    async with select_observer(factory=factory, token=None) as obs:
+        assert obs is None
+    assert factory.calls == []
+
+
+@pytest.mark.asyncio
+async def test_non_str_token_without_factory_is_a_no_op():
+    async with select_observer(factory=None, token=object()) as obs:
+        assert obs is None

--- a/tests/ai_sdks/openai_agents/test_stream_observer.py
+++ b/tests/ai_sdks/openai_agents/test_stream_observer.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from typing import Any
 
 import pytest
@@ -46,10 +47,15 @@ from temporal_agent_harness.harness.stream_context import TurnStreamContext
 
 
 class _FakePublisher:
-    """Stands in for TurnEventPublisher: records every published payload."""
+    """Stands in for TurnEventPublisher: records every published payload.
+
+    Also records the kwargs each ``publisher_from_activity`` open was given, so a test
+    can assert the flush cadence the observer asked for (see ``opened_with``).
+    """
 
     def __init__(self) -> None:
         self.events: list[Any] = []
+        self.opened_with: list[dict[str, Any]] = []
 
     def publish(self, event: Any) -> None:
         self.events.append(event)
@@ -62,7 +68,8 @@ def fake_publisher(monkeypatch: pytest.MonkeyPatch) -> _FakePublisher:
     pub = _FakePublisher()
 
     @asynccontextmanager
-    async def _fake_publisher_from_activity(context: Any, **_kw: Any):
+    async def _fake_publisher_from_activity(context: Any, **kw: Any):
+        pub.opened_with.append(kw)
         yield pub
 
     monkeypatch.setattr(
@@ -247,3 +254,43 @@ async def test_bracket_closes_even_with_no_content(fake_publisher: _FakePublishe
     ended = fake_publisher.events[-1]
     # No response.completed seen -> usage stays None (e.g. stream errored early).
     assert ended.usage is None and ended.model is None
+
+
+# ---------------------------------------------------------------------------
+# Flush cadence: the plugin's streaming_batch_interval reaches the publisher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_factory_threads_batch_interval_to_the_publisher(
+    fake_publisher: _FakePublisher,
+):
+    # ModelActivityParameters.streaming_batch_interval is handed to the factory by
+    # select_observer; it must reach the turn publisher, or configuring the field would
+    # silently do nothing on the harness path (each flush is one Signal, so this is the
+    # knob that trades UI snappiness for workflow-history volume).
+    ctx = TurnStreamContext(turn_id="t-5", turn_number=1, agent_id="agent-abc")
+    token = h._HarnessStreamToken(context=ctx, model="gpt-5.1")
+
+    observer = h.harness_observer_factory(
+        token.model_dump(mode="json"), batch_interval=timedelta(milliseconds=750)
+    )
+    async with observer:
+        pass
+
+    assert fake_publisher.opened_with == [{"batch_interval": timedelta(milliseconds=750)}]
+
+
+@pytest.mark.asyncio
+async def test_factory_without_interval_defers_to_the_harness_default(
+    fake_publisher: _FakePublisher,
+):
+    # Called by hand (no cadence): pass None through, so publisher_from_activity applies
+    # DEFAULT_PUBLISH_BATCH_INTERVAL rather than the observer duplicating that value.
+    ctx = TurnStreamContext(turn_id="t-6", turn_number=1, agent_id="agent-abc")
+    token = h._HarnessStreamToken(context=ctx, model="gpt-5.1")
+
+    async with h.harness_observer_factory(token):
+        pass
+
+    assert fake_publisher.opened_with == [{"batch_interval": None}]


### PR DESCRIPTION
ModelActivityParameters.streaming_batch_interval was silently inert whenever an observer_factory was wired: select_observer only applied it to the built-in RawTopicObserver, so the harness streaming path ran on publisher_from_activity's hard-coded 50ms and configuring the field did nothing. Each flush is one publish Signal, so this was the knob for trading UI snappiness against workflow-history volume — and it was unreachable.

Now the configured cadence reaches the publisher on both paths:

- ObserverFactory becomes a Protocol taking (token, *, batch_interval), and select_observer/RawTopicObserver speak timedelta rather than an int batch_ms, dropping the lossy ms conversion in the activity.
- harness_observer_factory forwards it to OpenAIStreamObserver, which passes it to publisher_from_activity.
- publisher_from_activity accepts None for "harness default", now owned by the new DEFAULT_PUBLISH_BATCH_INTERVAL (50ms) so the value lives in one place. Tool-activity publishing is unchanged.

Behavior change: the OpenAI harness streaming path now flushes on the field's 100ms default instead of 50ms.

Tests cover the routing and the threading on both branches, plus the None-means-default case. Pydantic AI still takes the harness default and has no knob; its config would ride HarnessDeps.

Also sets the react_agent example's cadence explicitly (documenting the tradeoff at the call site) and bumps its DEFAULT_MODEL to gpt-5.6-luna.