### PR TITLE
Use standalone executions for one-shot agent controls

### DIFF
--- a/examples/nexus_hello/README.md
+++ b/examples/nexus_hello/README.md
@@ -272,7 +272,7 @@ and session drawer show live and historical session counts from the registry.
 
 ```text
 Mount/send Nexus Hello:
-  browser -> gateway API -> BrokeredAgentAction
+  browser -> gateway API -> standalone Nexus operation
           -> nexus-hello-agent-endpoint -> AgentServiceHandler -> NexusHelloAgent
 
 Stream Nexus Hello:
@@ -292,7 +292,7 @@ Nexus Hello's Whimsical Agent child:
           -> AgentServiceHandler -> WhimsicalAgent in nexus-subagent-server
 
 Mount/send Whimsical Agent directly:
-  browser -> gateway API -> BrokeredAgentAction
+  browser -> gateway API -> standalone Nexus operation
           -> nexus-hello-whimsical-agent-endpoint -> AgentServiceHandler -> WhimsicalAgent
 
 Whimsical Agent's MCP calls:
@@ -304,9 +304,14 @@ Replay a Writer spawned by Nexus Hello:
           <- subagent-dispatch-{gateway_instance_id}-{turn_number}
 
 Mount/send Writer HTTP:
-  browser -> gateway API -> BrokeredAgentAction
-          -> standalone start/turn/stop activities -> subagent_server.py
+  browser -> gateway API -> standalone start/turn/stop activity -> subagent_server.py
 ```
+
+The one-shot send, status, interface, approval, callback, command, and close requests do
+not need proxy workflows: the gateway starts them as standalone Nexus operations. The
+third-party HTTP equivalents are standalone activities. Only operations that actually
+orchestrate repeated calls remain workflows: `BrokeredAgentAttach` long-polls the stream,
+and `BrokeredAgentDiscovery` drains lifecycle pages before reconciling child sessions.
 
 Nexus Hello and Whimsical use the same generic per-turn resolver:
 

--- a/nexus/mcp/durable_tools_gateway/README.md
+++ b/nexus/mcp/durable_tools_gateway/README.md
@@ -53,3 +53,9 @@ The Nexus operation uses the harness's stream-poll update while the target workf
 running. If Temporal reports that the workflow has already completed, `pollMessages` reads
 the same bounded page through the harness's replay query instead. Both paths return identical
 stream items and cursors, so stopped native subagents retain their mountable UI history.
+
+One-shot UI controls do not create proxy workflows. The gateway executes native agent
+send, status, interface, approval, callback, command, and close requests as standalone
+Nexus operations. Third-party HTTP start, turn, and close requests run as standalone
+activities. `BrokeredAgentDiscovery` remains a workflow because it drains multiple retained
+pages and then reconciles the resulting child-session snapshot.

--- a/nexus/mcp/durable_tools_gateway/agent_broker.py
+++ b/nexus/mcp/durable_tools_gateway/agent_broker.py
@@ -12,9 +12,10 @@ from typing import Any
 
 from temporalio import activity, workflow
 from temporalio.api.common.v1 import Payload
+from temporalio.client import Client
 from temporalio.common import RetryPolicy
 
-from .registry import SpawnedAgentObservation
+from .registry import REGISTRY_TASK_QUEUE, SpawnedAgentObservation
 
 with workflow.unsafe.imports_passed_through():
     from temporal_agent_harness.nexus_agent_adapter.generated import (
@@ -38,7 +39,7 @@ with workflow.unsafe.imports_passed_through():
         subagent_stop_activity,
     )
 
-AGENT_ACTION_WORKFLOW_NAME = "BrokeredAgentAction"
+AGENT_DISCOVERY_WORKFLOW_NAME = "BrokeredAgentDiscovery"
 AGENT_ATTACH_WORKFLOW_NAME = "BrokeredAgentAttach"
 MAX_ATTACH_POLLS = 500
 POLL_TIMEOUT_SECONDS = 30.0
@@ -56,6 +57,13 @@ class AgentActionInput:
     nexus_endpoint: str | None = None
     provider_url: str | None = None
     values: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class AgentDiscoveryInput:
+    session_id: str
+    nexus_endpoint: str
+    cursor: int = 0
 
 
 @dataclass(frozen=True)
@@ -238,184 +246,208 @@ def _values(input: AgentActionInput) -> dict[str, Any]:
     return input.values or {}
 
 
-@workflow.defn(sandboxed=False, name=AGENT_ACTION_WORKFLOW_NAME)
-class AgentActionWorkflow:
-    """One durable control request to a native Nexus or minimal HTTP agent."""
+async def execute_agent_action(
+    client: Client,
+    input: AgentActionInput,
+    *,
+    execution_id: str,
+) -> dict[str, Any]:
+    """Execute one control request without creating a proxy workflow."""
+    values = _values(input)
+    if input.provider_url:
+        return await _execute_external_action(
+            client, input, values, execution_id=execution_id
+        )
+    if not input.nexus_endpoint:
+        raise ValueError("nexus_endpoint is required for a native agent action")
+
+    nexus_client = client.create_nexus_client(
+        service=AgentService, endpoint=input.nexus_endpoint
+    )
+    session = QuerySessionInput(session_id=input.session_id)
+    match input.action:
+        case "send":
+            context = {
+                name: values[name]
+                for name in (
+                    "account_id",
+                    "registered_agent_id",
+                    "delegation_lineage",
+                    "delegation_depth",
+                    "max_delegation_depth",
+                )
+                if values.get(name) is not None
+            }
+            operation = AgentService.send_agent_message
+            operation_input = SendAgentMessageInput(
+                session_id=input.session_id,
+                msg_type=str(values["msg_type"]),
+                payload=json.dumps(values.get("payload") or {}),
+                expected_turn=(
+                    int(values["expected_turn"])
+                    if values.get("expected_turn") is not None
+                    else None
+                ),
+                **context,
+            )
+        case "status":
+            operation = AgentService.query_agent_status
+            operation_input = session
+        case "agent_interface":
+            operation = AgentService.query_agent_interface
+            operation_input = session
+        case "operator_interface":
+            operation = AgentService.query_operator_interface
+            operation_input = session
+        case "operator_command":
+            kwargs: dict[str, Any] = {
+                "session_id": input.session_id,
+                "name": str(values["name"]),
+            }
+            if values.get("arg") is not None:
+                kwargs["arg"] = str(values["arg"])
+            operation = AgentService.execute_operator_command
+            operation_input = ExecuteOperatorCommandInput(**kwargs)
+        case "approve":
+            kwargs = {
+                "session_id": input.session_id,
+                "tool_id": str(values["tool_id"]),
+                "approved": bool(values["approved"]),
+                "remember": bool(values.get("remember", False)),
+            }
+            if values.get("reason") is not None:
+                kwargs["reason"] = str(values["reason"])
+            operation = AgentService.approve_tool_call
+            operation_input = ApproveToolCallInput(**kwargs)
+        case "callback":
+            kwargs = {
+                "session_id": input.session_id,
+                "tool_id": str(values["tool_id"]),
+            }
+            if values.get("result") is not None:
+                kwargs["result"] = ProvideCallbackResultInputResult(
+                    additional_properties=values["result"]
+                )
+            if values.get("error") is not None:
+                kwargs["error"] = str(values["error"])
+            operation = AgentService.provide_callback_result
+            operation_input = ProvideCallbackResultInput(**kwargs)
+        case "close":
+            operation = AgentService.close_session
+            operation_input = session
+        case _:
+            raise ValueError(f"unsupported native agent action {input.action!r}")
+
+    result = await nexus_client.execute_operation(
+        operation,
+        operation_input,
+        id=execution_id,
+        schedule_to_close_timeout=timedelta(seconds=90),
+        summary=f"{input.action} agent session {input.session_id}",
+    )
+    return asdict(result)
+
+
+async def _execute_external_action(
+    client: Client,
+    input: AgentActionInput,
+    values: dict[str, Any],
+    *,
+    execution_id: str,
+) -> dict[str, Any]:
+    assert input.provider_url is not None
+    if input.action == "start":
+        result = await client.execute_activity(
+            subagent_start_activity,
+            SubagentStartInput(
+                url=input.provider_url,
+                idempotency_key=str(values["idempotency_key"]),
+            ),
+            id=execution_id,
+            task_queue=REGISTRY_TASK_QUEUE,
+            start_to_close_timeout=timedelta(seconds=15),
+            retry_policy=RetryPolicy(maximum_attempts=5),
+            summary=f"start external agent at {input.provider_url}",
+        )
+        return result.model_dump(mode="json")
+    if input.action == "send":
+        result = await client.execute_activity(
+            subagent_proxy_activity,
+            SubagentDispatchInput(
+                url=input.provider_url,
+                instance_id=input.session_id,
+                msg_type=str(values["msg_type"]),
+                payload=json.dumps(values.get("payload") or {}),
+                expected_turn=int(values["expected_turn"]),
+                idempotency_key=str(values["idempotency_key"]),
+            ),
+            id=execution_id,
+            task_queue=REGISTRY_TASK_QUEUE,
+            start_to_close_timeout=timedelta(seconds=75),
+            heartbeat_timeout=timedelta(seconds=30),
+            retry_policy=RetryPolicy(maximum_attempts=5),
+            summary=f"send turn to external agent session {input.session_id}",
+        )
+        return result.model_dump(mode="json")
+    if input.action == "close":
+        await client.execute_activity(
+            subagent_stop_activity,
+            SubagentStopInput(
+                url=input.provider_url,
+                instance_id=input.session_id,
+            ),
+            id=execution_id,
+            task_queue=REGISTRY_TASK_QUEUE,
+            start_to_close_timeout=timedelta(seconds=15),
+            retry_policy=RetryPolicy(maximum_attempts=5),
+            summary=f"close external agent session {input.session_id}",
+        )
+        return {"closed": True}
+    raise ValueError(f"external agents do not support {input.action!r}")
+
+
+@workflow.defn(sandboxed=False, name=AGENT_DISCOVERY_WORKFLOW_NAME)
+class AgentDiscoveryWorkflow:
+    """Drain retained lifecycle events and reconcile a native agent's children."""
 
     @workflow.run
-    async def run(self, input: AgentActionInput) -> dict[str, Any]:
-        values = _values(input)
-        if input.provider_url:
-            return await self._run_external(input, values)
-        if not input.nexus_endpoint:
-            raise ValueError("nexus_endpoint is required for a native agent action")
-
+    async def run(self, input: AgentDiscoveryInput) -> dict[str, Any]:
         client = workflow.create_nexus_client(
             service=AgentService, endpoint=input.nexus_endpoint
         )
-        session = QuerySessionInput(session_id=input.session_id)
-        if input.action == "discover_subagents":
-            cursor = int(values.get("cursor", 0))
-            spawned: list[SpawnedAgentObservation] = []
-            stopped: list[str] = []
-            closed = False
-            for _ in range(100):
-                poll = await client.execute_operation(
-                    AgentService.poll_messages,
-                    PollMessagesInput(
-                        session_id=input.session_id,
-                        cursor=cursor,
-                        timeout_seconds=0.1,
-                    ),
-                )
-                batch_spawned, batch_stopped = _spawned_lifecycle(poll.items)
-                spawned.extend(batch_spawned)
-                stopped.extend(batch_stopped)
-                cursor = poll.next_offset
-                closed = poll.closed
-                if poll.closed or not poll.more_ready:
-                    break
-            active = []
-            if not closed:
-                status = await client.execute_operation(
-                    AgentService.query_agent_status, session
-                )
-                active = [asdict(item) for item in status.subagents]
-            return {
-                "spawned": [_observation_dict(item) for item in spawned],
-                "stopped_source_session_ids": stopped,
-                "next_offset": cursor,
-                "active": active,
-            }
-        match input.action:
-            case "send":
-                context = {
-                    name: values[name]
-                    for name in (
-                        "account_id",
-                        "registered_agent_id",
-                        "delegation_lineage",
-                        "delegation_depth",
-                        "max_delegation_depth",
-                    )
-                    if values.get(name) is not None
-                }
-                result = await client.execute_operation(
-                    AgentService.send_agent_message,
-                    SendAgentMessageInput(
-                        session_id=input.session_id,
-                        msg_type=str(values["msg_type"]),
-                        payload=json.dumps(values.get("payload") or {}),
-                        expected_turn=(
-                            int(values["expected_turn"])
-                            if values.get("expected_turn") is not None
-                            else None
-                        ),
-                        **context,
-                    ),
-                )
-            case "status":
-                result = await client.execute_operation(
-                    AgentService.query_agent_status, session
-                )
-            case "agent_interface":
-                result = await client.execute_operation(
-                    AgentService.query_agent_interface, session
-                )
-            case "operator_interface":
-                result = await client.execute_operation(
-                    AgentService.query_operator_interface, session
-                )
-            case "operator_command":
-                kwargs: dict[str, Any] = {
-                    "session_id": input.session_id,
-                    "name": str(values["name"]),
-                }
-                if values.get("arg") is not None:
-                    kwargs["arg"] = str(values["arg"])
-                result = await client.execute_operation(
-                    AgentService.execute_operator_command,
-                    ExecuteOperatorCommandInput(**kwargs),
-                )
-            case "approve":
-                kwargs = {
-                    "session_id": input.session_id,
-                    "tool_id": str(values["tool_id"]),
-                    "approved": bool(values["approved"]),
-                    "remember": bool(values.get("remember", False)),
-                }
-                if values.get("reason") is not None:
-                    kwargs["reason"] = str(values["reason"])
-                result = await client.execute_operation(
-                    AgentService.approve_tool_call,
-                    ApproveToolCallInput(**kwargs),
-                )
-            case "callback":
-                kwargs = {
-                    "session_id": input.session_id,
-                    "tool_id": str(values["tool_id"]),
-                }
-                if values.get("result") is not None:
-                    kwargs["result"] = ProvideCallbackResultInputResult(
-                        additional_properties=values["result"]
-                    )
-                if values.get("error") is not None:
-                    kwargs["error"] = str(values["error"])
-                result = await client.execute_operation(
-                    AgentService.provide_callback_result,
-                    ProvideCallbackResultInput(**kwargs),
-                )
-            case "close":
-                result = await client.execute_operation(
-                    AgentService.close_session, session
-                )
-            case _:
-                raise ValueError(f"unsupported agent action {input.action!r}")
-        return asdict(result)
-
-    async def _run_external(
-        self, input: AgentActionInput, values: dict[str, Any]
-    ) -> dict[str, Any]:
-        assert input.provider_url is not None
-        if input.action == "start":
-            result = await workflow.execute_activity(
-                subagent_start_activity,
-                SubagentStartInput(
-                    url=input.provider_url,
-                    idempotency_key=str(values["idempotency_key"]),
+        cursor = input.cursor
+        spawned: list[SpawnedAgentObservation] = []
+        stopped: list[str] = []
+        closed = False
+        for _ in range(100):
+            poll = await client.execute_operation(
+                AgentService.poll_messages,
+                PollMessagesInput(
+                    session_id=input.session_id,
+                    cursor=cursor,
+                    timeout_seconds=0.1,
                 ),
-                start_to_close_timeout=timedelta(seconds=15),
-                retry_policy=RetryPolicy(maximum_attempts=5),
             )
-            return result.model_dump(mode="json")
-        if input.action == "send":
-            result = await workflow.execute_activity(
-                subagent_proxy_activity,
-                SubagentDispatchInput(
-                    url=input.provider_url,
-                    instance_id=input.session_id,
-                    msg_type=str(values["msg_type"]),
-                    payload=json.dumps(values.get("payload") or {}),
-                    expected_turn=int(values["expected_turn"]),
-                    idempotency_key=str(values["idempotency_key"]),
-                ),
-                start_to_close_timeout=timedelta(seconds=75),
-                heartbeat_timeout=timedelta(seconds=30),
-                retry_policy=RetryPolicy(maximum_attempts=5),
+            batch_spawned, batch_stopped = _spawned_lifecycle(poll.items)
+            spawned.extend(batch_spawned)
+            stopped.extend(batch_stopped)
+            cursor = poll.next_offset
+            closed = poll.closed
+            if poll.closed or not poll.more_ready:
+                break
+        active = []
+        if not closed:
+            status = await client.execute_operation(
+                AgentService.query_agent_status,
+                QuerySessionInput(session_id=input.session_id),
             )
-            return result.model_dump(mode="json")
-        if input.action == "close":
-            await workflow.execute_activity(
-                subagent_stop_activity,
-                SubagentStopInput(
-                    url=input.provider_url,
-                    instance_id=input.session_id,
-                ),
-                start_to_close_timeout=timedelta(seconds=15),
-                retry_policy=RetryPolicy(maximum_attempts=5),
-            )
-            return {"closed": True}
-        raise ValueError(f"external agents do not support {input.action!r}")
+            active = [asdict(item) for item in status.subagents]
+        return {
+            "spawned": [_observation_dict(item) for item in spawned],
+            "stopped_source_session_ids": stopped,
+            "next_offset": cursor,
+            "active": active,
+        }
 
 
 @workflow.defn(sandboxed=False, name=AGENT_ATTACH_WORKFLOW_NAME)

--- a/nexus/mcp/durable_tools_gateway/web.py
+++ b/nexus/mcp/durable_tools_gateway/web.py
@@ -28,13 +28,14 @@ from temporal_agent_harness.ui import packaged_ui_dist
 from temporal_agent_harness.utils.large_payload import with_large_payload_offload
 
 from .agent_broker import (
-    AGENT_ACTION_WORKFLOW_NAME,
     AGENT_ATTACH_WORKFLOW_NAME,
     AgentActionInput,
-    AgentActionWorkflow,
     AgentAttachInput,
     AgentAttachWorkflow,
+    AgentDiscoveryInput,
+    AgentDiscoveryWorkflow,
     event_broker,
+    execute_agent_action,
 )
 from .registry import (
     GLOBAL_CATALOG_WORKFLOW_ID,
@@ -48,15 +49,15 @@ from .registry import (
     ToolRegistryWorkflow,
     account_registry_workflow_id,
 )
-from .resources import (
-    AccountResourceRegistration,
-    ResourceDescriptor,
-    TEXT_AGENT_HANDLER,
-)
 from .registry_service_handler import (
     SubagentDispatchInput,
     SubagentDispatchOutput,
     subagent_dispatch_activity_id,
+)
+from .resources import (
+    TEXT_AGENT_HANDLER,
+    AccountResourceRegistration,
+    ResourceDescriptor,
 )
 from .tool_history import scan_external_tool_calls, scan_native_tool_calls
 
@@ -427,12 +428,10 @@ def create_account_agent_app(
     async def execute_action(
         input: AgentActionInput,
     ) -> dict[str, Any]:
-        return await app.state.temporal.execute_workflow(
-            AgentActionWorkflow.run,
+        return await execute_agent_action(
+            app.state.temporal,
             input,
-            id=f"broker-action-{uuid.uuid4()}",
-            task_queue=REGISTRY_TASK_QUEUE,
-            result_type=dict[str, Any],
+            execution_id=f"ui-agent-{input.action}-{uuid.uuid4()}",
         )
 
     async def submit(req: MessageRequest) -> dict[str, Any]:
@@ -775,13 +774,16 @@ def create_account_agent_app(
                 return
             try:
                 async with refresh_limit:
-                    result = await execute_action(
-                        AgentActionInput(
-                            action="discover_subagents",
+                    result = await app.state.temporal.execute_workflow(
+                        AgentDiscoveryWorkflow.run,
+                        AgentDiscoveryInput(
                             session_id=session.provider_session_id,
-                            nexus_endpoint=agent.nexus_endpoint,
-                            values={"cursor": session.discovery_offset},
-                        )
+                            nexus_endpoint=str(agent.nexus_endpoint),
+                            cursor=session.discovery_offset,
+                        ),
+                        id=f"broker-discovery-{uuid.uuid4()}",
+                        task_queue=REGISTRY_TASK_QUEUE,
+                        result_type=dict[str, Any],
                     )
                 await handle.execute_update(
                     ToolRegistryWorkflow.reconcile_spawned_agents,
@@ -1204,7 +1206,6 @@ def create_account_agent_app(
 
 
 __all__ = [
-    "AGENT_ACTION_WORKFLOW_NAME",
     "AGENT_ATTACH_WORKFLOW_NAME",
     "create_account_agent_app",
 ]

--- a/nexus/mcp/durable_tools_gateway/worker.py
+++ b/nexus/mcp/durable_tools_gateway/worker.py
@@ -35,8 +35,8 @@ from temporalio.worker import Worker
 from temporal_agent_harness.utils.large_payload import with_large_payload_offload
 
 from .agent_broker import (
-    AgentActionWorkflow,
     AgentAttachWorkflow,
+    AgentDiscoveryWorkflow,
     publish_agent_events,
 )
 from .registry import (
@@ -48,7 +48,6 @@ from .registry import (
     account_registry_workflow_id,
     fetch_external_tools,
 )
-from .resources import ResourceDescriptor, descriptor_from_dict
 from .registry_service_handler import (
     RegistryServiceHandler,
     mcp_proxy_activity,
@@ -56,6 +55,7 @@ from .registry_service_handler import (
     subagent_start_activity,
     subagent_stop_activity,
 )
+from .resources import ResourceDescriptor, descriptor_from_dict
 
 logger = logging.getLogger(__name__)
 
@@ -158,7 +158,7 @@ async def main(
         workflows=[
             GlobalCatalogWorkflow,
             ToolRegistryWorkflow,
-            AgentActionWorkflow,
+            AgentDiscoveryWorkflow,
             AgentAttachWorkflow,
         ],
         activities=[

--- a/tests/nexus_mcp/test_agent_broker.py
+++ b/tests/nexus_mcp/test_agent_broker.py
@@ -6,12 +6,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from durable_tools_gateway.agent_broker import (
     AgentActionInput,
-    AgentActionWorkflow,
     AgentAttachInput,
     AgentAttachWorkflow,
+    AgentDiscoveryInput,
+    AgentDiscoveryWorkflow,
     PublishBatchInput,
     PublishBatchResult,
     event_broker,
+    execute_agent_action,
     publish_agent_events,
 )
 from durable_tools_gateway.registry import SpawnedAgentObservation
@@ -148,8 +150,8 @@ async def test_attach_records_one_registry_batch_with_its_discovery_cursor(
     )
 
 
-@patch("durable_tools_gateway.agent_broker.workflow.create_nexus_client")
-async def test_native_send_is_one_nexus_action(mock_create_client: MagicMock) -> None:
+async def test_native_send_is_one_standalone_nexus_operation() -> None:
+    temporal = MagicMock()
     nexus = MagicMock()
     nexus.execute_operation = AsyncMock(
         return_value=SendMessageOutput(
@@ -159,9 +161,10 @@ async def test_native_send_is_one_nexus_action(mock_create_client: MagicMock) ->
             pending=False,
         )
     )
-    mock_create_client.return_value = nexus
+    temporal.create_nexus_client.return_value = nexus
 
-    result = await AgentActionWorkflow().run(
+    result = await execute_agent_action(
+        temporal,
         AgentActionInput(
             action="send",
             session_id="provider-session",
@@ -171,12 +174,14 @@ async def test_native_send_is_one_nexus_action(mock_create_client: MagicMock) ->
                 "payload": {"text": "hello"},
                 "expected_turn": 2,
             },
-        )
+        ),
+        execution_id="broker-action-1",
     )
 
     sent = nexus.execute_operation.await_args.args[1]
     assert sent.session_id == "provider-session"
     assert sent.expected_turn == 2
+    assert nexus.execute_operation.await_args.kwargs["id"] == "broker-action-1"
     assert result == {
         "turn_number": 2,
         "turn_id": "turn-2",
@@ -185,10 +190,8 @@ async def test_native_send_is_one_nexus_action(mock_create_client: MagicMock) ->
     }
 
 
-@patch("durable_tools_gateway.agent_broker.workflow.create_nexus_client")
-async def test_native_send_can_defer_turn_reconciliation_to_agent_service(
-    mock_create_client: MagicMock,
-) -> None:
+async def test_native_send_can_defer_turn_reconciliation_to_agent_service() -> None:
+    temporal = MagicMock()
     nexus = MagicMock()
     nexus.execute_operation = AsyncMock(
         return_value=SendMessageOutput(
@@ -198,15 +201,17 @@ async def test_native_send_can_defer_turn_reconciliation_to_agent_service(
             pending=False,
         )
     )
-    mock_create_client.return_value = nexus
+    temporal.create_nexus_client.return_value = nexus
 
-    await AgentActionWorkflow().run(
+    await execute_agent_action(
+        temporal,
         AgentActionInput(
             action="send",
             session_id="provider-session",
             nexus_endpoint="agent-endpoint",
             values={"msg_type": "ask", "payload": {"text": "hello"}},
-        )
+        ),
+        execution_id="broker-action-2",
     )
 
     sent = nexus.execute_operation.await_args.args[1]
@@ -241,12 +246,11 @@ async def test_subagent_discovery_reads_missed_lifecycle_and_live_status(
     )
     mock_create_client.return_value = nexus
 
-    result = await AgentActionWorkflow().run(
-        AgentActionInput(
-            action="discover_subagents",
+    result = await AgentDiscoveryWorkflow().run(
+        AgentDiscoveryInput(
             session_id="provider-session",
             nexus_endpoint="agent-endpoint",
-            values={"cursor": 2},
+            cursor=2,
         )
     )
 
@@ -255,27 +259,29 @@ async def test_subagent_discovery_reads_missed_lifecycle_and_live_status(
     assert result["active"][0]["next_expected_turn"] == 3
 
 
-@patch("durable_tools_gateway.agent_broker.workflow.execute_activity")
-async def test_external_agent_uses_the_minimal_http_provider_protocol(
-    mock_execute_activity: AsyncMock,
-) -> None:
-    mock_execute_activity.side_effect = [
-        SubagentStartResult(instance_id="provider-1"),
-        SubagentDispatchOutput(
-            output='{"text":"hello"}', turn_id="turn-1", turn_number=1
-        ),
-    ]
-    action = AgentActionWorkflow()
+async def test_external_agent_uses_standalone_activities() -> None:
+    temporal = MagicMock()
+    temporal.execute_activity = AsyncMock(
+        side_effect=[
+            SubagentStartResult(instance_id="provider-1"),
+            SubagentDispatchOutput(
+                output='{"text":"hello"}', turn_id="turn-1", turn_number=1
+            ),
+        ]
+    )
 
-    started = await action.run(
+    started = await execute_agent_action(
+        temporal,
         AgentActionInput(
             action="start",
             session_id="",
             provider_url="http://provider",
             values={"idempotency_key": "start-1"},
-        )
+        ),
+        execution_id="broker-external-start",
     )
-    sent = await action.run(
+    sent = await execute_agent_action(
+        temporal,
         AgentActionInput(
             action="send",
             session_id="provider-1",
@@ -286,12 +292,16 @@ async def test_external_agent_uses_the_minimal_http_provider_protocol(
                 "expected_turn": 1,
                 "idempotency_key": "turn-1",
             },
-        )
+        ),
+        execution_id="broker-external-send",
     )
 
     assert started == {"instance_id": "provider-1"}
     assert sent["turn_number"] == 1
-    assert mock_execute_activity.await_count == 2
+    assert temporal.execute_activity.await_count == 2
+    assert temporal.execute_activity.await_args_list[0].kwargs["id"] == (
+        "broker-external-start"
+    )
 
 
 @patch("durable_tools_gateway.agent_broker.workflow.execute_activity")

--- a/tests/nexus_mcp/test_brokered_web.py
+++ b/tests/nexus_mcp/test_brokered_web.py
@@ -13,14 +13,14 @@ from durable_tools_gateway.registry import (
     SessionRecord,
     ToolRegistryWorkflow,
 )
-from durable_tools_gateway.resources import (
-    AccountResourceRegistration,
-    ResourceDescriptor,
-    TEXT_AGENT_HANDLER,
-)
 from durable_tools_gateway.registry_service_handler import (
     SubagentDispatchInput,
     SubagentDispatchOutput,
+)
+from durable_tools_gateway.resources import (
+    TEXT_AGENT_HANDLER,
+    AccountResourceRegistration,
+    ResourceDescriptor,
 )
 from durable_tools_gateway.tool_history import ToolCallRecord
 from durable_tools_gateway.web import (
@@ -30,6 +30,11 @@ from durable_tools_gateway.web import (
 from fastapi.testclient import TestClient
 from temporalio.api.workflowservice.v1 import DescribeActivityExecutionResponse
 from temporalio.contrib.pydantic import pydantic_data_converter
+
+from temporal_agent_harness.nexus_agent_adapter.generated import (
+    AgentInterfaceOutput,
+    SendMessageOutput,
+)
 
 
 def _app_client(
@@ -113,6 +118,10 @@ def _app_client(
     temporal = MagicMock()
     temporal.start_workflow = AsyncMock(return_value=handle)
     temporal.execute_workflow = AsyncMock()
+    nexus = MagicMock()
+    nexus.execute_operation = AsyncMock(return_value=AgentInterfaceOutput(handlers=[]))
+    temporal.create_nexus_client.return_value = nexus
+    temporal.execute_activity = AsyncMock()
     app = create_account_agent_app(
         "account-1", temporal_client=temporal, static_dir=None
     )
@@ -361,10 +370,9 @@ def test_refresh_reconciles_registered_children_from_native_status() -> None:
         response = client.post("/api/sessions/refresh")
 
     assert response.status_code == 200
-    action = temporal.execute_workflow.await_args.args[1]
-    assert action.action == "discover_subagents"
-    assert action.session_id == "provider-parent"
-    assert action.values == {"cursor": 0}
+    discovery = temporal.execute_workflow.await_args.args[1]
+    assert discovery.session_id == "provider-parent"
+    assert discovery.cursor == 0
     sync = next(
         call
         for call in handle.execute_update.await_args_list
@@ -378,12 +386,14 @@ def test_refresh_reconciles_registered_children_from_native_status() -> None:
 
 def test_native_send_defers_stale_turn_reconciliation_to_agent_service() -> None:
     client, handle, temporal = _app_client()
-    temporal.execute_workflow.return_value = {
-        "turn_number": 2,
-        "turn_id": "turn-2",
-        "stream_head_offset": 8,
-        "pending": False,
-    }
+    temporal.create_nexus_client.return_value.execute_operation.return_value = (
+        SendMessageOutput(
+            turn_number=2,
+            turn_id="turn-2",
+            stream_head_offset=8,
+            pending=False,
+        )
+    )
 
     with client:
         response = client.post(
@@ -396,9 +406,11 @@ def test_native_send_defers_stale_turn_reconciliation_to_agent_service() -> None
         )
 
     assert response.status_code == 200
-    action = temporal.execute_workflow.await_args.args[1]
-    assert action.values is not None
-    assert action.values["expected_turn"] is None
+    nexus = temporal.create_nexus_client.return_value
+    operation_input = nexus.execute_operation.await_args.args[1]
+    assert operation_input.expected_turn is None
+    assert nexus.execute_operation.await_args.kwargs["id"].startswith("ui-agent-send-")
+    temporal.execute_workflow.assert_not_awaited()
     assert any(
         call.args[0] is ToolRegistryWorkflow.mark_session_started
         for call in handle.execute_update.await_args_list
@@ -415,27 +427,29 @@ def test_close_requires_a_decision_when_active_subagents_are_running() -> None:
         label="Session 1",
         has_started=True,
     )
-    client, handle, temporal = _app_client(session_override=started)
-    temporal.execute_workflow.return_value = {
-        "subagent_close_policy": "ask-user",
-        "subagents": [
-            {
-                "subagent_id": "research-a1b2c3",
-                "agent_key": "research",
-                "workflow_id": "research-workflow",
-                "next_expected_turn": 2,
-            }
-        ],
-    }
+    client, handle, _ = _app_client(session_override=started)
+    execute = AsyncMock(
+        return_value={
+            "subagent_close_policy": "ask-user",
+            "subagents": [
+                {
+                    "subagent_id": "research-a1b2c3",
+                    "agent_key": "research",
+                    "workflow_id": "research-workflow",
+                    "next_expected_turn": 2,
+                }
+            ],
+        }
+    )
 
-    with client:
+    with patch("durable_tools_gateway.web.execute_agent_action", execute), client:
         response = client.post("/api/sessions/session-1/close", json={})
 
     assert response.status_code == 409
     assert response.json()["detail"]["code"] == "subagent_close_decision_required"
     assert response.json()["detail"]["subagents"][0]["agent_key"] == "research"
-    assert temporal.execute_workflow.await_count == 1
-    assert temporal.execute_workflow.await_args.args[1].action == "status"
+    execute.assert_awaited_once()
+    assert execute.await_args.args[1].action == "status"
     assert not any(
         call.args[0] is ToolRegistryWorkflow.close_session
         for call in handle.execute_update.await_args_list
@@ -452,17 +466,17 @@ def test_close_applies_the_users_subagent_decision_before_closing() -> None:
         label="Session 1",
         has_started=True,
     )
-    client, handle, temporal = _app_client(session_override=started)
-    temporal.execute_workflow.side_effect = [{"reply": "updated"}, {"closed": True}]
+    client, handle, _ = _app_client(session_override=started)
+    execute = AsyncMock(side_effect=[{"reply": "updated"}, {"closed": True}])
 
-    with client:
+    with patch("durable_tools_gateway.web.execute_agent_action", execute), client:
         response = client.post(
             "/api/sessions/session-1/close",
             json={"subagent_close_policy": "close"},
         )
 
     assert response.status_code == 200
-    actions = [call.args[1] for call in temporal.execute_workflow.await_args_list]
+    actions = [call.args[1] for call in execute.await_args_list]
     assert [action.action for action in actions] == ["operator_command", "close"]
     assert actions[0].values == {
         "name": "subagent-close-policy",


### PR DESCRIPTION
## Summary
- execute one-shot native UI controls as Standalone Nexus Operations
- execute one-shot third-party HTTP controls as Standalone Activities
- retain workflows only for attach polling and multi-page subagent discovery
- document the execution split in the gateway and Nexus Hello demo

## Validation
- `uv run pytest -q` (318 passed)
- standalone Nexus smoke call against local Temporal Server 1.31 through `nexus-hello-agent-endpoint`