### PR TITLE
Adopt A2A for agent discovery and transport

### DIFF
--- a/examples/nexus_hello/README.md
+++ b/examples/nexus_hello/README.md
@@ -1,319 +1,216 @@
-# Nexus Hello: account gateway and brokered agent UI
+# Nexus Hello: A2A agents behind one account gateway
 
-This is the end-to-end demo for the account-scoped Nexus gateway. It shows an account
-owner opening one UI, seeing the agents and toolbox registered to that account, and
-mounting either:
+This demo is a small pane of glass for an account's agents and tools. It demonstrates
+three ideas together:
 
-- a Temporal Agent Harness agent reached through a Nexus endpoint, even though the
-  gateway UI and agent live in different Temporal namespaces; or
-- a minimal third-party HTTP agent implementing the gateway's small session protocol.
+- a global catalog installs agents and MCP servers into an account registry;
+- registered agents discover the account toolbox dynamically, so installing another
+  agent makes it available as a child on the next turn; and
+- standard A2A is the agent protocol for both top-level UI sessions and subagents.
 
-The global catalog advertises resources that can be installed. The account registry owns
-the account's pinned resource registrations and UI session records. There is no
-`SessionManagerWorkflow` or `agents.toml`.
+Temporal Nexus is the transport seam for harness-native agents. A third-party A2A
+agent uses standard HTTP instead. The UI renders both in the same way.
 
-The account used by the demo is `NexusHelloAccount`. Authentication is deliberately out
-of scope for now, so matching `account_id` values are the trust boundary.
+The demo account is `NexusHelloAccount`. Authentication and OAuth are deliberately
+out of scope, so a matching `account_id` is the prototype trust boundary.
 
-## What the account owns
+## The high-level model
 
-The gateway publishes these resources to the global catalog. After selecting them from
-**Catalog** in the account sidebar at <http://localhost:8000>, the account contains:
-
-| Registration | Kind | Route |
-|---|---|---|
-| `Nexus Hello` | mountable harness agent | `nexus-hello-agent-endpoint` |
-| `Research` | mountable harness agent/subagent | `nexus-hello-subagent-endpoint` |
-| `Whimsical Agent` | mountable OpenAI Agents SDK agent/subagent | `nexus-hello-whimsical-agent-endpoint` |
-| `Writer HTTP` | mountable third-party agent | `http://127.0.0.1:8766` |
-| `demo-nexus` | directly invoked Nexus MCP service | `nexus-hello-demo-endpoint` |
-| `demo` | MCP server in the toolbox | `http://127.0.0.1:8765/mcp` |
-
-The `Research`, `Whimsical Agent`, and `Writer HTTP` resource IDs become their dynamic
-subagent tool keys. That lets the registry project a spawned child into the account's
-session list and route it through the same installed descriptor used for top-level mounts.
-
-The Nexus Hello agent itself can use five resources:
-
-- `demo_get_fun_fact`: the registered HTTP MCP server, proxied through the account
-  gateway.
-- `demo-nexus_get_lucky_number`: a Nexus-native tool reached directly.
-- `research`: a Nexus-native harness subagent reached directly.
-- `whimsical-agent`: an OpenAI Agents SDK harness subagent reached directly over Nexus.
-- `writer`: the registered HTTP subagent, proxied through the account gateway.
-
-Only installed agents become independently mountable sessions. Installed resources are
-resolved once at the start of every agent turn. A newly registered agent or MCP server is
-therefore available on the next turn without changing or restarting the agent worker.
-
-Whimsical Agent is intentionally both a child and a top-level agent. Nexus Hello can create
-it through the native subagent toolset, while an account owner can click **New** on its card
-to start the same workflow independently. In either role its inner harness uses the OpenAI
-Agents SDK and the same `demo` and `demo-nexus` MCP tools, but a playful system instruction
-makes its replies easy to distinguish from Nexus Hello.
-
-## Architecture
-
-The gateway is the account owner's pane of glass. The account registry says which agents
-and tools belong to the account; the broker uses those registrations to reach each agent.
-The browser only talks HTTP and SSE to the gateway.
+The browser does not hold a Temporal client and it does not speak directly to an agent.
+It uses HTTP and SSE with the gateway UI backend. That backend is the A2A client and
+selects the transport described by the agent's A2A `AgentCard`.
 
 ```mermaid
 flowchart LR
-    Owner[Account owner] --> UI[Account UI]
+    Browser[Browser UI] <-->|HTTP + SSE| Gateway[Account gateway<br/>A2A client + pane of glass]
 
-    subgraph Gateway[Account gateway]
-        Catalog[Global catalog]
-        Registry[Account registry]
-        Broker[Agent broker]
-        Catalog -->|register| Registry
-        UI <--> Registry
-        UI <--> Broker
+    Gateway <-->|A2A over Nexus| Native[Harness-native agents]
+    Gateway <-->|A2A over HTTP| External[Third-party agents]
+
+    Native -. approvals and<br/>operator controls .-> Gateway
+```
+
+One long-lived UI or subagent session maps to one A2A Task. After a turn completes,
+the Task is `INPUT_REQUIRED`; closing the session cancels it. The harness preserves its
+rich event stream in an A2A metadata extension, so existing chat, graph, latency, logs,
+approval, and replay views do not lose information.
+
+Nexus operations currently return one result rather than a server stream. The Nexus
+binding therefore represents A2A `SubscribeToTask` as a bounded cursor page.
+`BrokeredAgentAttach` repeats that operation and multicasts each page to attached UI
+drivers. Completed harness workflows serve the same pages from their retained stream.
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant G as Gateway attach workflow
+    participant N as A2A service over Nexus
+    participant A as Agent workflow
+
+    B->>G: attach to A2A Task
+    loop while attached
+        G->>N: SubscribeToTask(task, cursor)
+        N->>A: bounded long-poll update
+        A-->>N: A2A event page + next cursor
+        N-->>G: page
+        G-->>B: SSE events
     end
-
-    Registry -. routes .-> Broker
-    Broker <-->|Nexus| Native[Harness-native agents]
-    Broker <-->|HTTP| External[Third-party agents]
 ```
 
-Nexus is the seam between the gateway and every harness-native agent. A registered endpoint
-hides the agent's Temporal namespace, task queue, and workflow-ID convention. Third-party
-agents use the same UI and registry model, but the gateway reaches them through standalone
-HTTP activities instead.
+Approvals, callbacks, slash commands, and harness status are intentionally not part of
+the portable agent protocol. Harness-aware UIs reach those through the separate
+`HarnessControlService`; ordinary A2A clients can still send, inspect, subscribe to, and
+cancel Tasks without knowing that extension.
+
+## Catalog, account, and dynamic toolbox
+
+The global catalog and account registry share one resource descriptor. Agents carry an
+official A2A `AgentCard`; the card's interface declares `TEMPORAL_NEXUS` or standard
+HTTP+JSON. MCP entries declare their Nexus or HTTP transport in the same resource
+envelope.
 
 ```mermaid
-flowchart LR
-    Browser[Account UI] -->|send · status · close| Gateway[Gateway broker]
-    Gateway -->|AgentService over Nexus| Agent[Harness-native agent]
-    Agent -->|pollMessages pages| Gateway
-    Gateway -->|SSE stream| Browser
+flowchart TB
+    Catalog[Global catalog<br/>available AgentCards and MCP servers]
+    Registry[Account registry<br/>installed resources + session routes]
+    UI[Account sidebar]
+    Agent[Running account agent]
+
+    Catalog -->|Register| Registry
+    Registry --> UI
+    Registry -->|resolve at each turn| Agent
+    Agent -->|A2A over Nexus, direct| Native[Native child agent]
+    Agent -->|A2A over Nexus to gateway| Router[Account A2A router]
+    Router -->|A2A over HTTP| ThirdParty[Third-party child agent]
 ```
 
-`pollMessages` works for both live and completed workflows: it long-polls a live stream and
-replays the retained `WorkflowStream` after completion. The browser sees the same cursor-based
-SSE stream either way.
+The registry is the control plane, not a transcript store. It owns installations,
+routes, and session identity. Temporal workflow history and the provider remain the
+sources of truth for execution history. Delegation lineage prevents an agent from
+offering itself or an ancestor as a child, and the demo caps dynamic delegation at five
+levels.
 
-At the beginning of each turn, an agent resolves the account's installed toolbox. Native
-resources remain direct Nexus calls; external resources cross Nexus to the gateway, which
-invokes their HTTP provider. This keeps the normal native path direct while making account
-registrations dynamic.
+## Resources in the demo
 
-```mermaid
-flowchart LR
-    Agent[Agent] --> Toolbox[Account toolbox]
-    Toolbox -->|direct Nexus| Native[Native agents and MCP tools]
-    Toolbox -->|Nexus| Gateway[Gateway]
-    Gateway -->|HTTP activities| External[External agents and MCP tools]
+Register these from **Catalog** in the sidebar:
 
-    Agent -->|spawn| Child[Child agent]
-    Child --> Registry[Account sessions]
-    Registry --> UI[Account UI]
-    UI -->|mount| Child
-```
+| Registration | Protocol | Purpose |
+|---|---|---|
+| `Nexus Hello` | A2A over Nexus | Main OpenAI Agents SDK harness agent |
+| `Research` | A2A over Nexus | Canned native child or standalone agent |
+| `Whimsical Agent` | A2A over Nexus | OpenAI Agents SDK child or standalone agent with a playful voice |
+| `Writer HTTP` | A2A over HTTP | Minimal third-party child or standalone agent |
+| `demo-nexus` | MCP over Nexus | Native lucky-number tool |
+| `demo` | MCP over HTTP | Third-party fun-fact tool |
 
-The registry stores routing and session metadata, not a duplicate transcript. A spawned
-harness child is mounted through its registered Nexus endpoint. A spawned third-party child
-is reconstructed from its deterministically named standalone activity inputs and outcomes,
-subject to the account's Temporal retention policy. Neither path requires a Temporal
-Visibility scan.
-
-### Why the gateway UI is colocated
-
-Nexus has no native `attach()` operation. `BrokeredAgentAttach` therefore owns a bounded
-loop around `pollMessages` using 30-second long polls. It publishes each returned batch
-through an in-process event broker to the browser's SSE connection. Agent-service pages are
-capped at about 256 KiB so their Temporal update results, Nexus envelopes, and broker activity
-inputs stay below Temporal's 512 KiB payload warning threshold. Adjacent provider text deltas are
-also compacted in the completed model activity result and coalesced before SSE delivery; their
-token boundaries have no semantic meaning to the UI.
-
-While an agent is running, `pollMessages` uses a long-polling workflow update. Temporal
-rejects updates after workflow completion, so the same operation then falls back to a
-bounded replay query over the harness's final `WorkflowStream` state. The cursor and batch
-format do not change, which lets the UI replay a stopped child without knowing whether its
-workflow is live or closed.
-
-This design avoids starting one Temporal workflow per poll. Status is checked only after
-an empty poll or a terminal event, and a long attachment continues as new after 500
-polls. Because the event broker is in process, this prototype runs the gateway worker and
-UI server together. A multi-replica deployment would replace that broker with shared
-pub/sub. Closing or replacing a browser attachment cancels its broker workflow, which in turn
-cancels the outstanding Nexus long poll rather than leaving an orphan poller behind.
-
-### Historical MCP calls
-
-The left account sidebar lists both MCP transports without changing either execution path.
-Opening **Tool calls** performs a read-only retained-history scan:
-
-```mermaid
-flowchart LR
-    UI[Tool-call inspector] --> Reader[Gateway history reader]
-    Reader -->|native Nexus calls| AgentHistory[Known agent histories]
-    Reader -->|external HTTP calls| GatewayHistory[Gateway activity history]
-```
-
-Native MCP calls stay on the direct `agent → Nexus endpoint` path. The history reader resolves
-the namespaces behind registered harness endpoints, fetches only account-known workflow IDs,
-and matches scheduled/completed/failed Nexus events by endpoint and service. It does not scan
-Workflow Visibility across those namespaces.
-
-Third-party MCP calls already execute as standalone activities in the gateway namespace. New
-activity inputs include `account_id`, server alias, and caller agent workflow metadata; the
-inspector lists retained `mcp_proxy_activity` executions, point-reads their inputs/outcomes with
-at most eight concurrent describes, and filters them to the current account. The initial
-implementation considers the most recent 500 retained proxy activities. Neither reader persists
-another copy of tool inputs or results. Activity/workflow retention therefore defines how far
-back the inspector can see. Calls made by an older gateway worker do not contain the account
-metadata and are omitted; older calls without caller metadata remain visible but cannot name the
-caller agent workflow. Restart the updated gateway before generating calls for this demo.
+Nexus Hello resolves the installed account toolbox at the start of every turn. With all
+six resources installed, it can call both MCP servers and invoke Research, Whimsical,
+or Writer as children without those registrations being hard-coded into its worker.
+Whimsical does the same resolution and can therefore act as either a child or a parent.
 
 ## Run the complete demo
 
 Prerequisites:
 
-- Python 3.13 or newer for the `nexus-mcp` extra.
-- `temporal`, `just`, `curl`, `pnpm`, and `uv` on `PATH`.
-- From the repository root, copy `.env.example` to `.env.local` and set
-  `OPENAI_API_KEY`.
-- Install dependencies once with `uv sync --extra nexus-mcp` and, from this example
-  directory, `just app-install`.
+- Python 3.13 or newer
+- `temporal`, `just`, `pnpm`, and `uv` on `PATH`
+- a repo-root `.env.local` with `OPENAI_API_KEY`
 
-Run all `just` commands from the example directory:
+Install dependencies once:
 
 ```sh
+uv sync --extra nexus-mcp
 cd examples/nexus_hello
+just app-install
 ```
 
-Start Temporal in one terminal:
+Run the remaining commands from `examples/nexus_hello`. Start Temporal first:
 
 ```sh
 just temporal
 ```
 
-In another terminal, create the four namespaces and five Nexus endpoints. This is a
-one-shot command and is safe to rerun:
+In another terminal, create four namespaces and five Nexus endpoints. This is a
+one-shot setup command and is safe to rerun:
 
 ```sh
 just setup-nexus
 ```
 
-Start these long-running services, one per terminal:
+Start each long-running process in its own terminal:
 
 ```sh
 just third-party-mcp-server  # HTTP MCP server on :8765
-just third-party-subagent    # HTTP agent/subagent provider on :8766
-just nexus-tool-service      # native Nexus tool service
-just nexus-subagent          # native research agent + its Nexus front door
-just whimsical-agent         # OpenAI child/standalone agent + its Nexus front door
-just worker                  # Nexus Hello agent + its Nexus front door
-just gateway-ui              # registry, gateway, broker, API, and UI on :8000
+just third-party-subagent    # standard A2A HTTP agent on :8766
+just nexus-tool-service      # native Nexus MCP service
+just nexus-subagent          # native Research A2A agent
+just whimsical-agent         # native Whimsical A2A agent
+just worker                  # Nexus Hello A2A agent
+just gateway-ui              # catalog, registry, gateway, API, UI on :8000
 ```
 
-`just gateway-ui` builds the shared Svelte UI before starting the colocated gateway
-process. If the build reports missing JavaScript dependencies, run `just app-install`
-once.
+Open <http://localhost:8000>, expand **Catalog**, and register the resources you want.
+Register all six for the full demo. Registration updates the account sidebar; no
+`just register-*` command or worker restart is required.
 
-Now open <http://localhost:8000>, click **Catalog**, and register the desired agents and
-MCP servers. Register all six entries for the full demo. The account sidebar updates after
-each installation; no registration CLI command or worker restart is required.
-
-### Mount Nexus Hello
-
-Click **Mount** on **Nexus Hello**. This creates an account-owned session record but does
-not start the underlying agent workflow yet. Send the first message to start it lazily
-through `nexus-hello-agent-endpoint`.
-
-A prompt that makes the child and tool routes easy to observe is:
+Click **New** on an agent card to create an account session. This only records the A2A
+Task route; the underlying agent starts lazily on the first message. For Nexus Hello,
+try:
 
 ```text
 Get a fun fact and a lucky number, ask the research, whimsical-agent, and writer
-subagents about Temporal, then summarize the results and stop all three subagents.
+agents about Temporal, then summarize their answers.
 ```
 
-The model still decides which tools are relevant, so its exact call sequence can vary.
-The browser stream travels back through repeated Nexus `pollMessages` calls rather than
-directly attaching to the workflow.
+Spawned children appear under their agent card. Open its **Sessions** list and click
+**Mount** to view or continue that exact A2A Task. A top-level refresh reconciles
+children from all active harness sessions. Closed native Tasks remain mountable for
+retained-history replay.
 
-As soon as the attached stream observes a registered child, that child is added to the
-account session drawer with a **spawned** marker. Click it to mount the child's own stream.
-The refresh button explicitly reconciles active children from each live registered harness
-session; it does not scan Temporal visibility or create sessions. Stopped children remain as
-closed registry records and remain mountable: `pollMessages` serves their retained stream
-history through the completed-workflow replay query. Children whose `agent_key` is not registered
-to the account are intentionally ignored.
+## What each route does
 
-### Mount Whimsical Agent directly
-
-Click **New** on **Whimsical Agent** and send it a message to run the exact same workflow
-as a top-level account session. It uses the OpenAI Agents SDK inside the Temporal Agent
-Harness and can call both account MCP services. Its storybook tone distinguishes its stream
-from Nexus Hello's. If Nexus Hello spawns `whimsical-agent` instead, the resulting child
-appears under the same card and remains independently mountable through the same Nexus
-endpoint.
-
-### Mount the third-party agent
-
-Click **Mount** on **Writer HTTP** and send it any message. The gateway creates an HTTP
-provider session, dispatches the turn through a standalone Temporal activity, stores the
-UI-compatible replay events in the account registry, and renders the canned reply. This
-is the minimal third-party feasibility path; harness-native Nexus agents are the primary
-integration.
-
-If Nexus Hello spawns `writer`, refresh the account once discovery completes and mount the
-spawned Writer session from its session drawer. Its parent-originated turns are replayed from
-the deterministic standalone activity history instead of registry event storage. Sending a
-new message from that mounted view continues the provider session; those UI-originated events
-then occupy the next deterministic four-offset turn window.
-
-Mounting any card again creates another independent account session. The account sidebar
-and session drawer show live and historical session counts from the registry.
-
-## Routes exercised
+### Native send and mount
 
 ```text
-Mount/send Nexus Hello:
-  browser -> gateway API -> standalone Nexus operation
-          -> nexus-hello-agent-endpoint -> AgentServiceHandler -> NexusHelloAgent
-
-Stream Nexus Hello:
-  browser <- SSE <- in-process broker <- BrokeredAgentAttach
-          <- repeated AgentService.pollMessages over Nexus
-
-Nexus Hello's registered MCP call:
-  default -> RegistryService(account_id="NexusHelloAccount")
-          -> standalone MCP activity -> tool_server.py
-
-Nexus Hello's registered writer subagent:
-  default -> RegistryService(account_id="NexusHelloAccount")
-          -> standalone start/turn/stop activities -> subagent_server.py
-
-Nexus Hello's Whimsical Agent child:
-  default -> nexus-hello-whimsical-agent-endpoint
-          -> AgentServiceHandler -> WhimsicalAgent in nexus-subagent-server
-
-Mount/send Whimsical Agent directly:
-  browser -> gateway API -> standalone Nexus operation
-          -> nexus-hello-whimsical-agent-endpoint -> AgentServiceHandler -> WhimsicalAgent
-
-Whimsical Agent's MCP calls:
-  nexus-subagent-server -> mcp-registry-endpoint -> demo HTTP MCP
-  nexus-subagent-server -> nexus-hello-demo-endpoint -> native Nexus MCP
-
-Replay a Writer spawned by Nexus Hello:
-  browser <- SSE projection <- DescribeActivityExecution(input + outcome)
-          <- subagent-dispatch-{gateway_instance_id}-{turn_number}
-
-Mount/send Writer HTTP:
-  browser -> gateway API -> standalone start/turn/stop activity -> subagent_server.py
+browser -> gateway HTTP API -> A2A SendMessage over Nexus -> agent workflow
+browser <- gateway SSE      <- repeated A2A SubscribeToTask pages over Nexus
 ```
 
-The one-shot send, status, interface, approval, callback, command, and close requests do
-not need proxy workflows: the gateway starts them as standalone Nexus operations. The
-third-party HTTP equivalents are standalone activities. Only operations that actually
-orchestrate repeated calls remain workflows: `BrokeredAgentAttach` long-polls the stream,
-and `BrokeredAgentDiscovery` drains lifecycle pages before reconciling child sessions.
+One-shot A2A and harness-control calls use standalone Nexus operations. Only repeated
+orchestration remains a workflow: `BrokeredAgentAttach` polls the A2A subscription and
+`BrokeredAgentDiscovery` reconciles spawned Tasks.
 
-Nexus Hello and Whimsical use the same generic per-turn resolver:
+### Native subagent
+
+```text
+parent workflow -> account toolbox -> registered AgentCard
+                -> A2A SendMessage over the child's Nexus endpoint
+                <- A2A SubscribeToTask pages
+```
+
+The native route stays direct; it does not pay an extra gateway activity hop.
+
+### Third-party agent
+
+```text
+browser or parent -> account A2A router over Nexus
+                  -> standalone activity -> A2A HTTP agent
+```
+
+The gateway remembers the route from its deterministic account Task ID to the provider's
+A2A Task ID. It does not invent a second agent protocol or copy the provider transcript.
+
+### MCP and retained tool-call inspection
+
+Native MCP calls remain direct Nexus operations. External MCP calls remain standalone
+gateway activities. Opening **Tool calls** performs a read-only history lookup across
+the known native agent namespaces and the gateway namespace, then matches calls to the
+selected registered MCP server. It stores no duplicate input or output data, so the
+account's Temporal retention policy defines how far back the UI can inspect.
+
+## Dynamic toolbox in code
+
+Every account agent uses the same resolver:
 
 ```python
 toolbox = await nexus_gateway(account_id).resolve_toolbox(
@@ -329,51 +226,25 @@ sdk_agent = Agent(
 )
 ```
 
-The resolved manifest excludes the caller and its ancestors. The runner propagates lineage
-to native child sessions and rejects delegation past depth five, preventing dynamically
-wired agents from recursively bouncing between one another. An agent using a different
-`account_id` resolves a different registry workflow and cannot see these installations.
+The resolver turns installed A2A AgentCard skills into harness tools. It excludes the
+caller and its ancestors, then picks the card's native Nexus or external HTTP interface.
+A different `account_id` resolves a different registry workflow and toolbox.
 
-## Run without `just`
+## Troubleshooting
 
-The justfile is the canonical executable runbook and contains the raw namespace and
-endpoint creation commands. The two processes introduced for the brokered UI are
-equivalent to:
+- Empty sidebar: open **Catalog** and register at least one agent.
+- First native message fails: verify the matching worker is running and rerun
+  `just setup-nexus` to check endpoint creation.
+- Agent toolbox is empty: install agents and MCP servers from **Catalog**; changes are
+  visible on the next turn.
+- HTTP agent fails: verify `just third-party-subagent` serves its AgentCard at
+  <http://127.0.0.1:8766/.well-known/agent-card.json>.
+- UI build fails: run `just app-install`, then `just gateway-ui` again.
 
-```sh
-TEMPORAL_NAMESPACE=default \
-uv run --extra nexus-mcp --group examples python -m examples.nexus_hello.worker
+The justfile is the canonical command reference. Account state is durable across gateway
+restarts; use the Temporal UI or CLI to terminate the demo account-registry workflow if
+you want a completely fresh account.
 
-TEMPORAL_NAMESPACE=gateway \
-GATEWAY_SEED_ACCOUNT_ID=NexusHelloAccount \
-GATEWAY_UI_ACCOUNT_ID=NexusHelloAccount \
-GATEWAY_CATALOG_FILE=examples/nexus_hello/catalog.json \
-uv run --extra nexus-mcp --group examples python -m durable_tools_gateway.worker
-```
-
-The UI's registration action is also available directly through the catalog API:
-
-```sh
-curl --fail --request POST \
-  http://127.0.0.1:8000/api/catalog/nexus-hello/register
-```
-
-## Troubleshooting and reset
-
-- If the pane has no cards, open **Catalog** and register at least one agent.
-- If Nexus Hello mounts but the first send fails, confirm `just worker` is running and
-  `nexus-hello-agent-endpoint` targets namespace `default`, task queue `nexus-hello`.
-- If an agent's toolbox is empty, install MCP servers and other agents from **Catalog**.
-- Account state is durable. To get a completely fresh demo, stop `gateway-ui`, run the
-  command below, and restart `just gateway-ui` before registering resources.
-
-```sh
-temporal workflow terminate \
-  --namespace gateway \
-  --workflow-id account-registry-cf700a56bafc7c6f1417b0fda1135aedd0298c6266fb173b325d69db81b09a8f
-```
-
-The HTTP provider stores its sessions and idempotency keys in memory. A production
-provider must persist and expire them. Authentication, account authorization, and a
-shared event transport for multiple gateway replicas are also intentionally left for a
-production implementation.
+This remains a prototype. Production work would add authentication and authorization,
+OAuth-backed catalog installs, persistent external-provider storage, and shared pub/sub
+for multiple gateway replicas.

--- a/examples/nexus_hello/catalog.json
+++ b/examples/nexus_hello/catalog.json
@@ -7,16 +7,17 @@
     "label": "Nexus Hello",
     "description": "OpenAI Agents SDK demo using an account-resolved toolbox.",
     "endpoint": "nexus-hello-agent-endpoint",
-    "service": "AgentService",
-    "handlers": [
-      {
-        "name": "ask",
-        "description": "Ask Nexus Hello a question.",
-        "param_name": "message",
-        "input_schema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"], "additionalProperties": false},
-        "output_schema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"], "additionalProperties": false}
-      }
-    ]
+    "service": "A2AService",
+    "agent_card": {
+      "name": "Nexus Hello",
+      "description": "OpenAI Agents SDK demo using an account-resolved toolbox.",
+      "version": "1.0.0",
+      "supportedInterfaces": [{"url": "nexus-hello-agent-endpoint", "protocolBinding": "TEMPORAL_NEXUS", "protocolVersion": "1.0"}],
+      "capabilities": {"streaming": true},
+      "defaultInputModes": ["text/plain"],
+      "defaultOutputModes": ["text/plain"],
+      "skills": [{"id": "ask", "name": "ask", "description": "Ask Nexus Hello a question.", "tags": ["assistant"]}]
+    }
   },
   {
     "resource_id": "research",
@@ -26,16 +27,17 @@
     "label": "Research",
     "description": "Nexus-native research agent with a concise canned response.",
     "endpoint": "nexus-hello-subagent-endpoint",
-    "service": "AgentService",
-    "handlers": [
-      {
-        "name": "ask",
-        "description": "Ask the research agent a question.",
-        "param_name": "message",
-        "input_schema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"], "additionalProperties": false},
-        "output_schema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"], "additionalProperties": false}
-      }
-    ]
+    "service": "A2AService",
+    "agent_card": {
+      "name": "Research",
+      "description": "Nexus-native research agent with a concise canned response.",
+      "version": "1.0.0",
+      "supportedInterfaces": [{"url": "nexus-hello-subagent-endpoint", "protocolBinding": "TEMPORAL_NEXUS", "protocolVersion": "1.0"}],
+      "capabilities": {"streaming": true},
+      "defaultInputModes": ["text/plain"],
+      "defaultOutputModes": ["text/plain"],
+      "skills": [{"id": "ask", "name": "ask", "description": "Ask the research agent a question.", "tags": ["research"]}]
+    }
   },
   {
     "resource_id": "whimsical-agent",
@@ -45,16 +47,17 @@
     "label": "Whimsical Agent",
     "description": "OpenAI Agents SDK agent with a playful voice and the same account toolbox.",
     "endpoint": "nexus-hello-whimsical-agent-endpoint",
-    "service": "AgentService",
-    "handlers": [
-      {
-        "name": "ask",
-        "description": "Ask the whimsical agent a question.",
-        "param_name": "message",
-        "input_schema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"], "additionalProperties": false},
-        "output_schema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"], "additionalProperties": false}
-      }
-    ]
+    "service": "A2AService",
+    "agent_card": {
+      "name": "Whimsical Agent",
+      "description": "OpenAI Agents SDK agent with a playful voice and the same account toolbox.",
+      "version": "1.0.0",
+      "supportedInterfaces": [{"url": "nexus-hello-whimsical-agent-endpoint", "protocolBinding": "TEMPORAL_NEXUS", "protocolVersion": "1.0"}],
+      "capabilities": {"streaming": true},
+      "defaultInputModes": ["text/plain"],
+      "defaultOutputModes": ["text/plain"],
+      "skills": [{"id": "ask", "name": "ask", "description": "Ask the whimsical agent a question.", "tags": ["whimsical"]}]
+    }
   },
   {
     "resource_id": "writer",
@@ -64,15 +67,16 @@
     "label": "Writer HTTP",
     "description": "Minimal third-party HTTP agent available through the gateway.",
     "endpoint": "http://127.0.0.1:8766",
-    "handlers": [
-      {
-        "name": "ask",
-        "description": "Ask the writer agent for prose.",
-        "param_name": "message",
-        "input_schema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"], "additionalProperties": false},
-        "output_schema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"], "additionalProperties": false}
-      }
-    ]
+    "agent_card": {
+      "name": "Writer HTTP",
+      "description": "Minimal third-party A2A agent available through the gateway.",
+      "version": "1.0.0",
+      "supportedInterfaces": [{"url": "http://127.0.0.1:8766", "protocolBinding": "HTTP+JSON", "protocolVersion": "1.0"}],
+      "capabilities": {"streaming": true},
+      "defaultInputModes": ["text/plain"],
+      "defaultOutputModes": ["text/plain"],
+      "skills": [{"id": "ask", "name": "ask", "description": "Ask the writer agent for prose.", "tags": ["writing"]}]
+    }
   },
   {
     "resource_id": "demo-nexus",

--- a/examples/nexus_hello/native_subagent.py
+++ b/examples/nexus_hello/native_subagent.py
@@ -17,9 +17,14 @@ from temporalio.client import Client
 from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 
-from temporal_agent_harness.nexus_agent_adapter.handler import AgentServiceHandler, Config
-
 with workflow.unsafe.imports_passed_through():
+    from temporalio.contrib.workflow_streams import WorkflowStream
+
+    from temporal_agent_harness.a2a.adapter import (
+        A2AHandlerConfig,
+        A2AServiceHandler,
+        make_agent_card,
+    )
     from temporal_agent_harness.harness import agent
     from temporal_agent_harness.harness.agent_protocol import (
         AgentConfig,
@@ -28,7 +33,10 @@ with workflow.unsafe.imports_passed_through():
         ToolApprovalPolicy,
     )
     from temporal_agent_harness.harness.agent_workflow import AgentWorkflowRunner
-    from temporalio.contrib.workflow_streams import WorkflowStream
+    from temporal_agent_harness.nexus_agent_adapter.handler import (
+        HarnessControlConfig,
+        HarnessControlServiceHandler,
+    )
 
 TASK_QUEUE = "nexus-hello-subagent"
 
@@ -61,17 +69,28 @@ class NativeResearchSubagentWorkflow:
 async def _run_worker() -> None:
     connect_config = ClientConfig.load_client_connect_config()
     client = await Client.connect(**connect_config)
-    config = Config(
-        agent_task_queue=TASK_QUEUE,
-        workflow_name="NativeResearchSubagent",
-        workflow_id_prefix="",  # The Nexus session ID is the workflow ID.
-        is_message_queuing_enabled=True,
-    )
+    control_config = HarnessControlConfig()
     worker = Worker(
         client,
         task_queue=TASK_QUEUE,
         workflows=[NativeResearchSubagentWorkflow],
-        nexus_service_handlers=[AgentServiceHandler(client, config)],
+        nexus_service_handlers=[
+            A2AServiceHandler(
+                client,
+                A2AHandlerConfig(
+                    agent_task_queue=TASK_QUEUE,
+                    workflow_name="NativeResearchSubagent",
+                    workflow_id_prefix="",
+                    is_message_queuing_enabled=True,
+                    agent_card=make_agent_card(
+                        name="Research",
+                        description="A concise research agent.",
+                        endpoint="nexus-hello-subagent-endpoint",
+                    ),
+                ),
+            ),
+            HarnessControlServiceHandler(client, control_config),
+        ],
     )
     print(
         f"Native research subagent worker ready (workflow + Nexus front door): "

--- a/examples/nexus_hello/subagent_server.py
+++ b/examples/nexus_hello/subagent_server.py
@@ -1,114 +1,109 @@
-"""Run the HTTP subagent for the Nexus hello example.
-
-The Durable Tools Gateway sends turns to this server. The server has no Nexus or Temporal
-client.
-
-Wire protocol (see nexus/mcp/durable_tools_gateway/registry_service_handler.py):
-    POST /sessions {idempotency_key} -> {instance_id}
-    POST /sessions/{instance_id}/turns -> {output, turn_id, turn_number}
-    POST /sessions/{instance_id}/close -> {}
-
-The server deduplicates retried requests by idempotency key.
-
-Run with (from the repo root):
-    uv run --extra nexus-mcp --group examples python -m examples.nexus_hello.subagent_server
-"""
+"""Run the demo third-party writer as a standard A2A HTTP agent."""
 
 from __future__ import annotations
 
-import json
-import uuid
-from dataclasses import dataclass, field
-
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.routes.agent_card_routes import create_agent_card_routes
+from a2a.server.routes.rest_routes import create_rest_routes
+from a2a.server.tasks import InMemoryTaskStore, TaskUpdater
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    AgentSkill,
+    Part,
+    Task,
+    TaskState,
+    TaskStatus,
+)
+from fastapi import FastAPI
+from google.protobuf.timestamp_pb2 import Timestamp
 
 PORT = 8766
+BASE_URL = f"http://127.0.0.1:{PORT}"
 
-app = FastAPI()
-_start_keys: dict[str, str] = {}
-_sessions: dict[str, "SessionState"] = {}
-
-
-class StartRequest(BaseModel):
-    idempotency_key: str
-
-
-class StartResponse(BaseModel):
-    instance_id: str
-
-
-class TurnRequest(BaseModel):
-    idempotency_key: str
-    msg_type: str
-    payload: str
-    expected_turn: int
-
-
-class TurnResponse(BaseModel):
-    output: dict
-    turn_id: str
-    turn_number: int
-
-
-@dataclass
-class SessionState:
-    next_turn: int = 1
-    seen: dict[str, tuple[TurnRequest, TurnResponse]] = field(default_factory=dict)
-
-
-@app.post("/sessions")
-def start(req: StartRequest) -> StartResponse:
-    instance_id = _start_keys.get(req.idempotency_key)
-    if instance_id is None:
-        instance_id = uuid.uuid4().hex
-        _start_keys[req.idempotency_key] = instance_id
-        _sessions[instance_id] = SessionState()
-    return StartResponse(instance_id=instance_id)
-
-
-@app.post("/sessions/{instance_id}/turns")
-def turns(instance_id: str, req: TurnRequest) -> TurnResponse:
-    session = _sessions.get(instance_id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="unknown subagent instance")
-    prior = session.seen.get(req.idempotency_key)
-    if prior is not None:
-        prior_request, prior_response = prior
-        if prior_request != req:
-            raise HTTPException(status_code=409, detail="idempotency key reused")
-        return prior_response
-    if req.expected_turn != session.next_turn:
-        raise HTTPException(
-            status_code=409,
-            detail=f"expected turn {session.next_turn}, got {req.expected_turn}",
+AGENT_CARD = AgentCard(
+    name="Writer HTTP",
+    description="A minimal third-party writing agent served using standard A2A HTTP+JSON.",
+    version="1.0.0",
+    supported_interfaces=[
+        AgentInterface(
+            url=BASE_URL, protocol_binding="HTTP+JSON", protocol_version="1.0"
         )
-    if req.msg_type != "ask":
-        raise HTTPException(status_code=400, detail=f"unknown handler {req.msg_type!r}")
-    try:
-        payload = json.loads(req.payload)
-    except json.JSONDecodeError as exc:
-        raise HTTPException(status_code=400, detail="invalid payload JSON") from exc
-    text = payload.get("text", "")
-    turn_number = session.next_turn
-    resp = TurnResponse(
-        output={"text": f"[3rd-party subagent] you asked {text!r} -- here is a canned answer."},
-        turn_id=f"{instance_id}-turn-{turn_number}",
-        turn_number=turn_number,
-    )
-    session.seen[req.idempotency_key] = (req, resp)
-    session.next_turn += 1
-    return resp
+    ],
+    capabilities=AgentCapabilities(streaming=True),
+    default_input_modes=["text/plain"],
+    default_output_modes=["text/plain"],
+    skills=[
+        AgentSkill(
+            id="ask",
+            name="ask",
+            description="Ask the writer agent for prose.",
+            tags=["writing"],
+            input_modes=["text/plain"],
+            output_modes=["text/plain"],
+        )
+    ],
+)
 
 
-@app.post("/sessions/{instance_id}/close")
-def close(instance_id: str) -> dict:
-    _sessions.pop(instance_id, None)
-    return {}
+class WriterExecutor(AgentExecutor):
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        assert context.task_id is not None
+        assert context.context_id is not None
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        if context.current_task is None:
+            timestamp = Timestamp()
+            timestamp.GetCurrentTime()
+            await event_queue.enqueue_event(
+                Task(
+                    id=context.task_id,
+                    context_id=context.context_id,
+                    status=TaskStatus(
+                        state=TaskState.TASK_STATE_SUBMITTED,
+                        timestamp=timestamp,
+                    ),
+                    history=[context.message] if context.message is not None else [],
+                )
+            )
+        await updater.start_work()
+        text = context.get_user_input()
+        await updater.add_artifact(
+            [
+                Part(
+                    text=(
+                        f"[3rd-party A2A agent] you asked {text!r} -- "
+                        "here is a canned writing answer."
+                    )
+                )
+            ],
+            name="answer",
+            last_chunk=True,
+        )
+        # One long-lived A2A task is one UI/harness session. It waits for the
+        # next message rather than completing after each conversational turn.
+        await updater.requires_input()
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        assert context.task_id is not None
+        assert context.context_id is not None
+        await TaskUpdater(event_queue, context.task_id, context.context_id).cancel()
+
+
+handler = DefaultRequestHandler(
+    agent_executor=WriterExecutor(),
+    task_store=InMemoryTaskStore(),
+    agent_card=AGENT_CARD,
+)
+app = FastAPI()
+app.router.routes.extend(create_agent_card_routes(AGENT_CARD))
+app.router.routes.extend(create_rest_routes(handler))
 
 
 if __name__ == "__main__":
     import uvicorn
 
-    print(f"Demo 3rd-party subagent ready: http://127.0.0.1:{PORT}", flush=True)
+    print(f"Demo third-party A2A agent ready: {BASE_URL}", flush=True)
     uvicorn.run(app, host="127.0.0.1", port=PORT)

--- a/examples/nexus_hello/whimsical_agent.py
+++ b/examples/nexus_hello/whimsical_agent.py
@@ -21,6 +21,11 @@ from temporalio.client import Client
 from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 
+from temporal_agent_harness.a2a.adapter import (
+    A2AHandlerConfig,
+    A2AServiceHandler,
+    make_agent_card,
+)
 from temporal_agent_harness.ai_sdks.openai_agents import (
     ModelActivityParameters,
     OpenAIAgentsPlugin,
@@ -30,8 +35,8 @@ from temporal_agent_harness.ai_sdks.openai_agents_harness import (
     stream_to_provider,
 )
 from temporal_agent_harness.nexus_agent_adapter.handler import (
-    AgentServiceHandler,
-    Config,
+    HarnessControlConfig,
+    HarnessControlServiceHandler,
 )
 
 from .whimsical_workflow import WORKFLOW_NAME, WhimsicalAgentWorkflow
@@ -58,17 +63,28 @@ async def _run_worker() -> None:
     )
     connect_config = ClientConfig.load_client_connect_config()
     client = await Client.connect(**connect_config, plugins=[plugin])
-    config = Config(
-        agent_task_queue=TASK_QUEUE,
-        workflow_name=WORKFLOW_NAME,
-        workflow_id_prefix="",
-        is_message_queuing_enabled=True,
-    )
+    control_config = HarnessControlConfig()
     worker = Worker(
         client,
         task_queue=TASK_QUEUE,
         workflows=[WhimsicalAgentWorkflow],
-        nexus_service_handlers=[AgentServiceHandler(client, config)],
+        nexus_service_handlers=[
+            A2AServiceHandler(
+                client,
+                A2AHandlerConfig(
+                    agent_task_queue=TASK_QUEUE,
+                    workflow_name=WORKFLOW_NAME,
+                    workflow_id_prefix="",
+                    is_message_queuing_enabled=True,
+                    agent_card=make_agent_card(
+                        name="Whimsical Agent",
+                        description="An OpenAI Agents SDK agent with a playful voice.",
+                        endpoint="nexus-hello-whimsical-agent-endpoint",
+                    ),
+                ),
+            ),
+            HarnessControlServiceHandler(client, control_config),
+        ],
     )
     print(
         "Whimsical agent worker + Nexus front door ready: "

--- a/examples/nexus_hello/worker.py
+++ b/examples/nexus_hello/worker.py
@@ -3,7 +3,7 @@
 Run from the repo root with:
     uv run --extra nexus-mcp --group examples python -m examples.nexus_hello.worker
 
-The worker hosts the agent workflow and its ``AgentServiceHandler`` on the same task
+The worker hosts the agent workflow and its A2A and harness-control services on the same task
 queue. The account gateway UI reaches that front door through the registered Nexus
 endpoint; the agent itself wires its tools and subagents in ``workflow.py``.
 
@@ -26,6 +26,11 @@ from temporalio.client import Client
 from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 
+from temporal_agent_harness.a2a.adapter import (
+    A2AHandlerConfig,
+    A2AServiceHandler,
+    make_agent_card,
+)
 from temporal_agent_harness.ai_sdks.openai_agents import (
     ModelActivityParameters,
     OpenAIAgentsPlugin,
@@ -35,8 +40,8 @@ from temporal_agent_harness.ai_sdks.openai_agents_harness import (
     stream_to_provider,
 )
 from temporal_agent_harness.nexus_agent_adapter.handler import (
-    AgentServiceHandler,
-    Config,
+    HarnessControlConfig,
+    HarnessControlServiceHandler,
 )
 
 from .workflow import TASK_QUEUE, WORKFLOW_NAME, NexusHelloAgentWorkflow
@@ -64,18 +69,29 @@ async def main() -> None:
 
     connect_config = ClientConfig.load_client_connect_config()
     client = await Client.connect(**connect_config, plugins=[plugin])
-    nexus_config = Config(
-        agent_task_queue=task_queue,
-        workflow_name=WORKFLOW_NAME,
-        workflow_id_prefix="",
-        is_message_queuing_enabled=True,
-    )
+    control_config = HarnessControlConfig()
 
     worker = Worker(
         client,
         task_queue=task_queue,
         workflows=[NexusHelloAgentWorkflow],
-        nexus_service_handlers=[AgentServiceHandler(client, nexus_config)],
+        nexus_service_handlers=[
+            A2AServiceHandler(
+                client,
+                A2AHandlerConfig(
+                    agent_task_queue=task_queue,
+                    workflow_name=WORKFLOW_NAME,
+                    workflow_id_prefix="",
+                    is_message_queuing_enabled=True,
+                    agent_card=make_agent_card(
+                        name="Nexus Hello",
+                        description="OpenAI Agents SDK demo with an account toolbox.",
+                        endpoint="nexus-hello-agent-endpoint",
+                    ),
+                ),
+            ),
+            HarnessControlServiceHandler(client, control_config),
+        ],
     )
     print(
         f"Nexus hello agent worker + Nexus front door ready: "

--- a/nexus/devserver/dynamicconfig/development.yaml
+++ b/nexus/devserver/dynamicconfig/development.yaml
@@ -27,7 +27,7 @@ callback.allowedAddresses:
       - Pattern: "*"
         AllowInsecure: true
 
-# Required for update-with-callback (the mechanism pollMessages relies on).
+# Required for update-with-callback (the bounded A2A subscription relies on it).
 history.enableUpdateCallbacks:
   - value: true
 

--- a/nexus/mcp/durable_tools_gateway/README.md
+++ b/nexus/mcp/durable_tools_gateway/README.md
@@ -29,9 +29,9 @@ uv run --extra nexus-mcp python -m durable_tools_gateway.worker
 ```
 
 `GATEWAY_UI_PORT` defaults to `8000`. A registered native agent can live in any
-namespace reachable by its Nexus endpoint. `external_http` registrations use the small
-`/sessions`, `/sessions/{id}/turns`, and `/close` protocol as a feasibility proof; the
-harness-native Nexus path is the primary implementation.
+namespace reachable by its Nexus endpoint. Every agent registration carries a standard
+A2A `AgentCard`: native cards select the Temporal Nexus binding and external cards select
+standard A2A HTTP+JSON.
 
 The account bar is the owner-facing pane of glass: it shows registered agents, live and
 historical session counts, MCP servers, and subagent providers. Selecting **Mount** creates
@@ -40,7 +40,8 @@ endpoint; no session-manager workflow or agent-namespace visibility access is in
 
 ## Polling behavior
 
-Nexus has no native attach primitive, so `BrokeredAgentAttach` long-polls `pollMessages`.
+Nexus operations do not yet return a server stream, so `BrokeredAgentAttach` repeatedly
+invokes the bounded Nexus binding for A2A `SubscribeToTask`.
 One bounded workflow owns the loop for a browser attachment, publishes batches through a
 local activity, and stops as soon as the agent is idle and caught up. It checks status only
 after an empty poll or a terminal event, avoiding both per-event status calls and the race
@@ -50,12 +51,12 @@ crossing the Nexus and activity boundaries, and browser disconnects cancel their
 workflow so stale long polls cannot accumulate.
 
 The Nexus operation uses the harness's stream-poll update while the target workflow is
-running. If Temporal reports that the workflow has already completed, `pollMessages` reads
-the same bounded page through the harness's replay query instead. Both paths return identical
+running. If Temporal reports that the workflow has already completed, it reads the same
+bounded A2A page through the harness's replay query instead. Both paths return identical
 stream items and cursors, so stopped native subagents retain their mountable UI history.
 
-One-shot UI controls do not create proxy workflows. The gateway executes native agent
-send, status, interface, approval, callback, command, and close requests as standalone
-Nexus operations. Third-party HTTP start, turn, and close requests run as standalone
-activities. `BrokeredAgentDiscovery` remains a workflow because it drains multiple retained
-pages and then reconciles the resulting child-session snapshot.
+One-shot A2A calls and harness-only status, approval, callback, and operator controls do
+not create proxy workflows; the gateway executes them as standalone Nexus operations.
+Third-party A2A HTTP requests run in standalone activities. `BrokeredAgentDiscovery`
+remains a workflow because it drains multiple retained pages and then reconciles the
+resulting child-session snapshot.

--- a/nexus/mcp/durable_tools_gateway/__init__.py
+++ b/nexus/mcp/durable_tools_gateway/__init__.py
@@ -25,16 +25,15 @@ with workflow.unsafe.imports_passed_through():
         account_registry_workflow_id,
         fetch_external_tools,
     )
-    from .resources import (
-        AccountResourceRegistration,
-        AgentHandlerDescriptor,
-        ResourceDescriptor,
-    )
     from .registry_service_handler import (
         REGISTRY_NEXUS_ENDPOINT,
         ExternalMCPCallInput,
         RegistryServiceHandler,
         mcp_proxy_activity,
+    )
+    from .resources import (
+        AccountResourceRegistration,
+        ResourceDescriptor,
     )
 
 # The gateway's real Nexus service name -- callers reach it via this name + a Nexus
@@ -46,27 +45,26 @@ assert _registry_service_definition is not None, (
 REGISTRY_SERVICE_NAME = _registry_service_definition.name
 
 __all__ = [
+    "GLOBAL_CATALOG_WORKFLOW_ID",
     "REGISTRY_NEXUS_ENDPOINT",
     "REGISTRY_SERVICE_NAME",
     "REGISTRY_TASK_QUEUE",
     "REGISTRY_WORKFLOW_ID_PREFIX",
     "AccountEntries",
     "AccountResourceRegistration",
-    "AgentHandlerDescriptor",
     "AgentRegistration",
     "CallToolInput",
     "CallToolOutput",
     "DeregisterInput",
     "ExternalMCPCallInput",
-    "GLOBAL_CATALOG_WORKFLOW_ID",
     "GlobalCatalogWorkflow",
     "ListAccountEntriesInput",
     "ListAccountEntriesOutput",
     "PendingSessionEvent",
     "RegisterExternalInput",
-    "ResourceDescriptor",
     "RegistryService",
     "RegistryServiceHandler",
+    "ResourceDescriptor",
     "SessionEvent",
     "SessionRecord",
     "ToolRegistryWorkflow",

--- a/nexus/mcp/durable_tools_gateway/agent_broker.py
+++ b/nexus/mcp/durable_tools_gateway/agent_broker.py
@@ -6,10 +6,20 @@ import asyncio
 import base64
 import json
 import threading
+import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Any
 
+from a2a.types import (
+    CancelTaskRequest,
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    StreamResponse,
+)
+from google.protobuf.json_format import MessageToDict
 from temporalio import activity, workflow
 from temporalio.api.common.v1 import Payload
 from temporalio.client import Client
@@ -18,16 +28,19 @@ from temporalio.common import RetryPolicy
 from .registry import REGISTRY_TASK_QUEUE, SpawnedAgentObservation
 
 with workflow.unsafe.imports_passed_through():
+    from temporal_agent_harness.a2a.control import HarnessControlService
+    from temporal_agent_harness.a2a.nexus import (
+        HARNESS_EVENT_METADATA_KEY,
+        A2AService,
+        SubscribeToTaskInput,
+        SubscribeToTaskItem,
+    )
     from temporal_agent_harness.nexus_agent_adapter.generated import (
-        AgentService,
         ApproveToolCallInput,
         ExecuteOperatorCommandInput,
-        PollMessagesInput,
         ProvideCallbackResultInput,
         ProvideCallbackResultInputResult,
         QuerySessionInput,
-        SendAgentMessageInput,
-        StreamItem,
     )
 
     from .registry_service_handler import (
@@ -79,7 +92,7 @@ class AgentAttachInput:
 @dataclass(frozen=True)
 class PublishBatchInput:
     stream_id: str
-    items: list[StreamItem]
+    items: list[SubscribeToTaskItem]
     error: str | None = None
     close: bool = False
 
@@ -128,8 +141,16 @@ class EventBroker:
 event_broker = EventBroker()
 
 
-def _decode_stream_item(item: StreamItem) -> tuple[str, dict[str, Any]]:
-    raw = base64.b64decode(item.data)
+def _decode_stream_item(item: SubscribeToTaskItem) -> tuple[str, dict[str, Any]]:
+    response = StreamResponse()
+    response.ParseFromString(base64.b64decode(item.data))
+    body = response.WhichOneof("payload")
+    if body is None:
+        raise ValueError("A2A StreamResponse has no payload")
+    a2a_metadata = MessageToDict(
+        getattr(response, body).metadata, preserving_proto_field_name=True
+    )
+    raw = base64.b64decode(str(a2a_metadata[HARNESS_EVENT_METADATA_KEY]))
     payload = Payload()
     payload.ParseFromString(raw)
     envelope = json.loads(payload.data)
@@ -150,7 +171,7 @@ def _sse(event_type: str, data: dict[str, Any]) -> bytes:
 
 
 def _coalesced_ui_frames(
-    items: list[StreamItem],
+    items: list[SubscribeToTaskItem],
 ) -> list[tuple[str, dict[str, Any]]]:
     """Decode a poll page and join adjacent text deltas from the same turn.
 
@@ -184,7 +205,7 @@ def _coalesced_ui_frames(
 
 
 def _spawned_lifecycle(
-    items: list[StreamItem],
+    items: list[SubscribeToTaskItem],
 ) -> tuple[list[SpawnedAgentObservation], list[str]]:
     spawned_agents: list[SpawnedAgentObservation] = []
     stopped_source_session_ids: list[str] = []
@@ -205,6 +226,7 @@ def _spawned_lifecycle(
                     agent_key=str(data["agent_key"]),
                     provider_session_id=str(data["workflow_id"]),
                     next_expected_turn=int(data["subagent_turn"]) + 1,
+                    has_started=True,
                 )
             )
         elif event_type == "subagent_stopped":
@@ -218,6 +240,7 @@ def _observation_dict(observation: SpawnedAgentObservation) -> dict[str, Any]:
         "agent_key": observation.agent_key,
         "workflow_id": observation.provider_session_id,
         "next_expected_turn": observation.next_expected_turn,
+        "has_started": observation.has_started,
     }
 
 
@@ -261,8 +284,11 @@ async def execute_agent_action(
     if not input.nexus_endpoint:
         raise ValueError("nexus_endpoint is required for a native agent action")
 
-    nexus_client = client.create_nexus_client(
-        service=AgentService, endpoint=input.nexus_endpoint
+    control_client = client.create_nexus_client(
+        service=HarnessControlService, endpoint=input.nexus_endpoint
+    )
+    a2a_client = client.create_nexus_client(
+        service=A2AService, endpoint=input.nexus_endpoint
     )
     session = QuerySessionInput(session_id=input.session_id)
     match input.action:
@@ -278,27 +304,42 @@ async def execute_agent_action(
                 )
                 if values.get(name) is not None
             }
-            operation = AgentService.send_agent_message
-            operation_input = SendAgentMessageInput(
-                session_id=input.session_id,
-                msg_type=str(values["msg_type"]),
-                payload=json.dumps(values.get("payload") or {}),
-                expected_turn=(
-                    int(values["expected_turn"])
-                    if values.get("expected_turn") is not None
-                    else None
+            payload = values.get("payload") or {}
+            operation = A2AService.send_message
+            operation_input = SendMessageRequest(
+                message=Message(
+                    message_id=str(uuid.uuid4()),
+                    task_id=input.session_id,
+                    context_id=input.session_id,
+                    role=Role.ROLE_USER,
+                    parts=[Part(text=str(payload.get("text", "")))],
+                    metadata={
+                        "temporal.io/message-type": str(values["msg_type"]),
+                        "temporal.io/payload": payload,
+                    },
                 ),
-                **context,
+                metadata={
+                    **context,
+                    **(
+                        {"expected_turn": int(values["expected_turn"])}
+                        if values.get("expected_turn") is not None
+                        else {}
+                    ),
+                },
             )
+            operation_client = a2a_client
+        case "close":
+            operation = A2AService.cancel_task
+            operation_input = CancelTaskRequest(id=input.session_id)
+            operation_client = a2a_client
         case "status":
-            operation = AgentService.query_agent_status
+            operation = HarnessControlService.query_agent_status
             operation_input = session
-        case "agent_interface":
-            operation = AgentService.query_agent_interface
-            operation_input = session
+            operation_client = control_client
         case "operator_interface":
-            operation = AgentService.query_operator_interface
+            operation = HarnessControlService.query_operator_interface
             operation_input = session
+            operation_client = control_client
         case "operator_command":
             kwargs: dict[str, Any] = {
                 "session_id": input.session_id,
@@ -306,8 +347,9 @@ async def execute_agent_action(
             }
             if values.get("arg") is not None:
                 kwargs["arg"] = str(values["arg"])
-            operation = AgentService.execute_operator_command
+            operation = HarnessControlService.execute_operator_command
             operation_input = ExecuteOperatorCommandInput(**kwargs)
+            operation_client = control_client
         case "approve":
             kwargs = {
                 "session_id": input.session_id,
@@ -317,8 +359,9 @@ async def execute_agent_action(
             }
             if values.get("reason") is not None:
                 kwargs["reason"] = str(values["reason"])
-            operation = AgentService.approve_tool_call
+            operation = HarnessControlService.approve_tool_call
             operation_input = ApproveToolCallInput(**kwargs)
+            operation_client = control_client
         case "callback":
             kwargs = {
                 "session_id": input.session_id,
@@ -330,21 +373,29 @@ async def execute_agent_action(
                 )
             if values.get("error") is not None:
                 kwargs["error"] = str(values["error"])
-            operation = AgentService.provide_callback_result
+            operation = HarnessControlService.provide_callback_result
             operation_input = ProvideCallbackResultInput(**kwargs)
-        case "close":
-            operation = AgentService.close_session
-            operation_input = session
+            operation_client = control_client
         case _:
             raise ValueError(f"unsupported native agent action {input.action!r}")
 
-    result = await nexus_client.execute_operation(
+    result = await operation_client.execute_operation(
         operation,
         operation_input,
         id=execution_id,
         schedule_to_close_timeout=timedelta(seconds=90),
         summary=f"{input.action} agent session {input.session_id}",
     )
+    if input.action == "send":
+        metadata = MessageToDict(result.task.metadata, preserving_proto_field_name=True)
+        return {
+            "turn_number": int(metadata["temporal.io/turn-number"]),
+            "turn_id": str(metadata["temporal.io/turn-id"]),
+            "stream_head_offset": int(metadata["temporal.io/accepted-offset"]),
+            "pending": bool(metadata["temporal.io/pending"]),
+        }
+    if input.action == "close":
+        return {"closed": True}
     return asdict(result)
 
 
@@ -412,18 +463,21 @@ class AgentDiscoveryWorkflow:
 
     @workflow.run
     async def run(self, input: AgentDiscoveryInput) -> dict[str, Any]:
-        client = workflow.create_nexus_client(
-            service=AgentService, endpoint=input.nexus_endpoint
+        a2a_client = workflow.create_nexus_client(
+            service=A2AService, endpoint=input.nexus_endpoint
+        )
+        control_client = workflow.create_nexus_client(
+            service=HarnessControlService, endpoint=input.nexus_endpoint
         )
         cursor = input.cursor
         spawned: list[SpawnedAgentObservation] = []
         stopped: list[str] = []
         closed = False
         for _ in range(100):
-            poll = await client.execute_operation(
-                AgentService.poll_messages,
-                PollMessagesInput(
-                    session_id=input.session_id,
+            poll = await a2a_client.execute_operation(
+                A2AService.subscribe_to_task,
+                SubscribeToTaskInput(
+                    id=input.session_id,
                     cursor=cursor,
                     timeout_seconds=0.1,
                 ),
@@ -431,14 +485,14 @@ class AgentDiscoveryWorkflow:
             batch_spawned, batch_stopped = _spawned_lifecycle(poll.items)
             spawned.extend(batch_spawned)
             stopped.extend(batch_stopped)
-            cursor = poll.next_offset
+            cursor = poll.next_cursor
             closed = poll.closed
             if poll.closed or not poll.more_ready:
                 break
         active = []
         if not closed:
-            status = await client.execute_operation(
-                AgentService.query_agent_status,
+            status = await control_client.execute_operation(
+                HarnessControlService.query_agent_status,
                 QuerySessionInput(session_id=input.session_id),
             )
             active = [asdict(item) for item in status.subagents]
@@ -456,16 +510,19 @@ class AgentAttachWorkflow:
 
     @workflow.run
     async def run(self, input: AgentAttachInput) -> None:
-        client = workflow.create_nexus_client(
-            service=AgentService, endpoint=input.nexus_endpoint
+        a2a_client = workflow.create_nexus_client(
+            service=A2AService, endpoint=input.nexus_endpoint
+        )
+        control_client = workflow.create_nexus_client(
+            service=HarnessControlService, endpoint=input.nexus_endpoint
         )
         cursor = input.from_offset
         for _ in range(MAX_ATTACH_POLLS):
             try:
-                poll = await client.execute_operation(
-                    AgentService.poll_messages,
-                    PollMessagesInput(
-                        session_id=input.session_id,
+                poll = await a2a_client.execute_operation(
+                    A2AService.subscribe_to_task,
+                    SubscribeToTaskInput(
+                        id=input.session_id,
                         cursor=cursor,
                         timeout_seconds=POLL_TIMEOUT_SECONDS,
                     ),
@@ -481,7 +538,7 @@ class AgentAttachWorkflow:
                 )
                 return
 
-            cursor = poll.next_offset
+            cursor = poll.next_cursor
             published = await self._publish(
                 PublishBatchInput(
                     stream_id=input.stream_id,
@@ -493,8 +550,8 @@ class AgentAttachWorkflow:
             if poll.closed:
                 return
             if not poll.items or (published.saw_terminal_event and not poll.more_ready):
-                status = await client.execute_operation(
-                    AgentService.query_agent_status,
+                status = await control_client.execute_operation(
+                    HarnessControlService.query_agent_status,
                     QuerySessionInput(session_id=input.session_id),
                 )
                 if not (

--- a/nexus/mcp/durable_tools_gateway/registry.py
+++ b/nexus/mcp/durable_tools_gateway/registry.py
@@ -16,8 +16,8 @@ from temporalio.exceptions import ApplicationError
 from .resources import (
     AccountResourceRegistration,
     ResourceDescriptor,
-    TEXT_AGENT_HANDLER,
     descriptor_from_dict,
+    text_agent_card,
     validate_resource_descriptor,
 )
 
@@ -86,7 +86,12 @@ class AccountEntries:
                 name,
                 "",
                 endpoint,
-                handlers=(TEXT_AGENT_HANDLER,),
+                agent_card=text_agent_card(
+                    name=name,
+                    description="Externally hosted A2A agent.",
+                    endpoint=endpoint,
+                    transport="external_http",
+                ),
             )
 
     @property
@@ -156,13 +161,13 @@ class GlobalCatalogWorkflow:
         return self._resources.get(resource_id)
 
 
-def AgentRegistration(  # noqa: N802 - compatibility constructor
+def AgentRegistration(
     agent_id: str,
     kind: str,
     label: str,
     description: str,
     nexus_endpoint: str | None = None,
-    nexus_service: str = "AgentService",
+    nexus_service: str = "A2AService",
     provider_url: str | None = None,
 ) -> ResourceDescriptor:
     """Build the canonical descriptor from the former agent registration API."""
@@ -178,11 +183,16 @@ def AgentRegistration(  # noqa: N802 - compatibility constructor
         description=description,
         endpoint=(nexus_endpoint if native else provider_url) or "",
         service=nexus_service if native else None,
-        handlers=(TEXT_AGENT_HANDLER,),
+        agent_card=text_agent_card(
+            name=label,
+            description=description,
+            endpoint=(nexus_endpoint if native else provider_url) or "",
+            transport="nexus" if native else "external_http",
+        ),
     )
 
 
-def NexusMCPServerRegistration(  # noqa: N802 - compatibility constructor
+def NexusMCPServerRegistration(
     name: str, endpoint: str, service: str
 ) -> ResourceDescriptor:
     """Build the canonical descriptor from the former Nexus MCP API."""
@@ -212,7 +222,7 @@ def _agent_descriptor(value: Any) -> ResourceDescriptor:
         label=str(value.get("label", "")),
         description=str(value.get("description", "")),
         nexus_endpoint=value.get("nexus_endpoint"),
-        nexus_service=str(value.get("nexus_service", "AgentService")),
+        nexus_service=str(value.get("nexus_service", "A2AService")),
         provider_url=value.get("provider_url"),
     )
 
@@ -276,6 +286,7 @@ class SpawnedAgentObservation:
     agent_key: str
     provider_session_id: str
     next_expected_turn: int = 1
+    has_started: bool = False
 
 
 @dataclass(frozen=True)
@@ -373,7 +384,12 @@ class ToolRegistryWorkflow:
                 label=alias,
                 description="Externally hosted HTTP agent.",
                 endpoint=url,
-                handlers=(TEXT_AGENT_HANDLER,),
+                agent_card=text_agent_card(
+                    name=alias,
+                    description="Externally hosted A2A agent.",
+                    endpoint=url,
+                    transport="external_http",
+                ),
             )
         )
         workflow.logger.info("[registry] registered subagent %r at %s", alias, url)
@@ -385,9 +401,7 @@ class ToolRegistryWorkflow:
             workflow.logger.info("[registry] deregistered subagent %r", alias)
 
     @workflow.update
-    def register_nexus_mcp_server(
-        self, registration: Any
-    ) -> ResourceDescriptor:
+    def register_nexus_mcp_server(self, registration: Any) -> ResourceDescriptor:
         """Register metadata without changing the service's direct Nexus route."""
         try:
             descriptor = _nexus_mcp_descriptor(registration)
@@ -502,6 +516,8 @@ class ToolRegistryWorkflow:
         self,
         parent_session_id: str,
         observation: SpawnedAgentObservation,
+        *,
+        authoritative_started: bool = False,
     ) -> SessionRecord | None:
         parent = self._require_session(parent_session_id)
         registration = self._resource(observation.agent_key)
@@ -526,12 +542,18 @@ class ToolRegistryWorkflow:
             provider_session_id = route.provider_instance_id
 
         current_turn = max(0, observation.next_expected_turn - 1)
+        has_started = observation.has_started or current_turn > 0
         existing = self._spawned_session(
             parent_session_id, observation.provider_session_id
         )
         if existing is not None:
             updated = replace(
                 existing,
+                has_started=(
+                    has_started
+                    if authoritative_started
+                    else existing.has_started or has_started
+                ),
                 current_turn=max(existing.current_turn, current_turn),
                 closed=False,
             )
@@ -551,7 +573,7 @@ class ToolRegistryWorkflow:
             source_session_id=observation.provider_session_id,
             is_spawned=True,
             is_message_queuing_enabled=parent.is_message_queuing_enabled,
-            has_started=True,
+            has_started=has_started,
             current_turn=current_turn,
         )
         self._sessions[session_id] = session
@@ -597,7 +619,11 @@ class ToolRegistryWorkflow:
             observation.provider_session_id for observation in observations
         }
         for observation in observations:
-            session = self._observe_spawned_agent(parent_session_id, observation)
+            session = self._observe_spawned_agent(
+                parent_session_id,
+                observation,
+                authoritative_started=True,
+            )
             if session is not None:
                 synced.append(session)
         for session_id, session in tuple(self._sessions.items()):
@@ -645,6 +671,18 @@ class ToolRegistryWorkflow:
         return updated
 
     @workflow.update
+    def bind_session_provider(
+        self, session_id: str, provider_session_id: str
+    ) -> SessionRecord:
+        """Record the A2A Task ID assigned by an external agent on first send."""
+        if not provider_session_id:
+            raise ValueError("provider_session_id is required")
+        session = self._require_session(session_id)
+        updated = replace(session, provider_session_id=provider_session_id)
+        self._sessions[session_id] = updated
+        return updated
+
+    @workflow.update
     def append_session_events(
         self, session_id: str, events: list[PendingSessionEvent]
     ) -> int:
@@ -688,12 +726,20 @@ class ToolRegistryWorkflow:
     ) -> None:
         """Bind a gateway instance ID to its provider session."""
         existing = self._subagent_instances.get(instance_id)
-        if existing is not None and existing != route:
-            raise ApplicationError(
-                f"subagent instance {instance_id!r} has a different route",
-                type="SubagentInstanceConflict",
-                non_retryable=True,
-            )
+        if existing is not None:
+            if existing == route:
+                return
+            if (
+                existing.alias != route.alias
+                or existing.url != route.url
+                or existing.provider_instance_id
+                or not route.provider_instance_id
+            ):
+                raise ApplicationError(
+                    f"subagent instance {instance_id!r} has a different route",
+                    type="SubagentInstanceConflict",
+                    non_retryable=True,
+                )
         self._subagent_instances[instance_id] = route
 
     @workflow.update
@@ -763,19 +809,29 @@ class ToolRegistryWorkflow:
 
     @workflow.query
     def list_sessions(self) -> list[SessionRecord]:
-        return list(self._sessions.values())
+        return [
+            self._normalized_session(session) for session in self._sessions.values()
+        ]
 
     @workflow.query
     def get_session(self, session_id: str) -> SessionRecord | None:
-        return self._sessions.get(session_id)
+        session = self._sessions.get(session_id)
+        return self._normalized_session(session) if session is not None else None
+
+    @staticmethod
+    def _normalized_session(session: SessionRecord) -> SessionRecord:
+        # A lazy spawned A2A route has no task before its first accepted turn.
+        if session.is_spawned and session.has_started and session.current_turn == 0:
+            return replace(session, has_started=False)
+        return session
 
     @workflow.query
     def resolve_session(self, session_id: str) -> SessionRecord | None:
         """Resolve an account session by its public ID or registered provider alias."""
         session = self._sessions.get(session_id)
         if session is not None:
-            return session
-        return next(
+            return self._normalized_session(session)
+        resolved = next(
             (
                 candidate
                 for candidate in self._sessions.values()
@@ -784,6 +840,7 @@ class ToolRegistryWorkflow:
             ),
             None,
         )
+        return self._normalized_session(resolved) if resolved is not None else None
 
     @workflow.query
     def poll_session_events(

--- a/nexus/mcp/durable_tools_gateway/registry_service_handler.py
+++ b/nexus/mcp/durable_tools_gateway/registry_service_handler.py
@@ -19,7 +19,30 @@ import httpx
 import nexusrpc
 import nexusrpc.handler
 import temporalio.nexus
+from a2a.client import ClientConfig, ClientFactory
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    AgentSkill,
+    Artifact,
+    CancelTaskRequest,
+    GetExtendedAgentCardRequest,
+    GetTaskRequest,
+    ListTasksRequest,
+    ListTasksResponse,
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    SendMessageResponse,
+    Task,
+    TaskState,
+    TaskStatus,
+)
 from authoring import validate_service_name
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.timestamp_pb2 import Timestamp
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 from mcp.types import CallToolResult
@@ -33,6 +56,12 @@ from temporalio.common import (
     WorkflowIDConflictPolicy,
 )
 from temporalio.exceptions import ApplicationError
+
+from temporal_agent_harness.a2a.nexus import (
+    A2AService,
+    SubscribeToTaskInput,
+    SubscribeToTaskOutput,
+)
 
 from .generated import (
     CallToolInput,
@@ -48,9 +77,9 @@ from .generated import (
     ListAccountEntriesOutputRemoteToolsValueItem,
     RegisterExternalInput,
     RegisterSubagentInput,
+    RegistryService,
     ResolveAccountToolboxInput,
     ResolveAccountToolboxOutput,
-    RegistryService,
     StartSubagentInput,
     StartSubagentOutput,
     StopSubagentInput,
@@ -101,7 +130,9 @@ async def mcp_proxy_activity(input: ExternalMCPCallInput) -> CallToolResult:
     Returns CallToolResult as-is: a tool-level error (isError=True) is data, not
     raised. Only a real RPC/transport failure raises.
     """
-    activity.logger.info("[proxy-activity] calling %r on %s", input.tool_name, input.server_url)
+    activity.logger.info(
+        "[proxy-activity] calling %r on %s", input.tool_name, input.server_url
+    )
     heartbeat_task = asyncio.create_task(_heartbeat_every(15))
     try:
         async with streamable_http_client(input.server_url) as (read, write, _):
@@ -114,7 +145,9 @@ async def mcp_proxy_activity(input: ExternalMCPCallInput) -> CallToolResult:
             await heartbeat_task
         except asyncio.CancelledError:
             pass
-    activity.logger.info("[proxy-activity] %r completed  is_error=%s", input.tool_name, result.isError)
+    activity.logger.info(
+        "[proxy-activity] %r completed  is_error=%s", input.tool_name, result.isError
+    )
     return result
 
 
@@ -142,6 +175,7 @@ class SubagentDispatchOutput(BaseModel):
     output: str
     turn_id: str
     turn_number: int
+    provider_instance_id: str = ""
 
 
 class SubagentTurnResponse(BaseModel):
@@ -199,39 +233,74 @@ def _parse_subagent_response(
 
 @activity.defn
 async def subagent_start_activity(input: SubagentStartInput) -> SubagentStartResult:
-    """Start one instance from an HTTP subagent provider."""
-    async with httpx.AsyncClient(timeout=10.0) as http:
-        resp = await http.post(
-            f"{_provider_url(input.url)}/sessions",
-            json={"idempotency_key": input.idempotency_key},
-        )
-        _check_subagent_response(resp)
-    return _parse_subagent_response(SubagentStartResult, resp)
+    """Allocate the deterministic A2A task ID; the first message starts it lazily."""
+    return SubagentStartResult(
+        instance_id=uuid.uuid5(uuid.NAMESPACE_URL, input.idempotency_key).hex
+    )
 
 
 @activity.defn
-async def subagent_proxy_activity(input: SubagentDispatchInput) -> SubagentDispatchOutput:
-    """POST one turn to a non-Nexus subagent's HTTP endpoint.
-
-    The remote subagent must deduplicate requests by ``idempotency_key``.
-    """
+async def subagent_proxy_activity(
+    input: SubagentDispatchInput,
+) -> SubagentDispatchOutput:
+    """Send one turn to a third-party agent using standard A2A HTTP+JSON."""
     activity.logger.info(
         "[subagent-proxy] dispatching turn %d to %s", input.expected_turn, input.url
     )
     heartbeat_task = asyncio.create_task(_heartbeat_every(15))
     try:
         async with httpx.AsyncClient(timeout=60.0) as http:
-            resp = await http.post(
-                f"{_provider_url(input.url)}/sessions/{input.instance_id}/turns",
-                json={
-                    "idempotency_key": input.idempotency_key,
-                    "msg_type": input.msg_type,
-                    "payload": input.payload,
-                    "expected_turn": input.expected_turn,
-                },
+            factory = ClientFactory(
+                ClientConfig(
+                    streaming=True,
+                    httpx_client=http,
+                    supported_protocol_bindings=["HTTP+JSON"],
+                )
             )
-            _check_subagent_response(resp)
-            data = _parse_subagent_response(SubagentTurnResponse, resp)
+            a2a_client = await factory.create_from_url(_provider_url(input.url))
+            try:
+                payload = json.loads(input.payload)
+                text = str(payload.get("text", ""))
+                output_text = ""
+                message_kwargs: dict[str, Any] = {}
+                if input.instance_id:
+                    message_kwargs.update(
+                        task_id=input.instance_id, context_id=input.instance_id
+                    )
+                provider_task_id = input.instance_id
+                async for response in a2a_client.send_message(
+                    SendMessageRequest(
+                        message=Message(
+                            message_id=input.idempotency_key,
+                            role=Role.ROLE_USER,
+                            parts=[Part(text=text)],
+                            metadata={"temporal.io/message-type": input.msg_type},
+                            **message_kwargs,
+                        )
+                    )
+                ):
+                    if response.HasField("task"):
+                        provider_task_id = response.task.id
+                    elif response.HasField("artifact_update"):
+                        provider_task_id = response.artifact_update.task_id
+                    elif response.HasField("status_update"):
+                        provider_task_id = response.status_update.task_id
+                    elif response.HasField("message"):
+                        provider_task_id = response.message.task_id
+                    if response.HasField("artifact_update"):
+                        output_text += "".join(
+                            part.text
+                            for part in response.artifact_update.artifact.parts
+                            if part.HasField("text")
+                        )
+                    elif response.HasField("message"):
+                        output_text += "".join(
+                            part.text
+                            for part in response.message.parts
+                            if part.HasField("text")
+                        )
+            finally:
+                await a2a_client.close()
     finally:
         heartbeat_task.cancel()
         try:
@@ -240,23 +309,34 @@ async def subagent_proxy_activity(input: SubagentDispatchInput) -> SubagentDispa
             pass
     activity.logger.info("[subagent-proxy] turn %d completed", input.expected_turn)
     return SubagentDispatchOutput(
-        output=json.dumps(data.output),
-        turn_id=data.turn_id,
-        turn_number=data.turn_number,
+        output=json.dumps({"text": output_text}),
+        turn_id=f"{provider_task_id}-turn-{input.expected_turn}",
+        turn_number=input.expected_turn,
+        provider_instance_id=provider_task_id,
     )
 
 
 @activity.defn
 async def subagent_stop_activity(input: SubagentStopInput) -> None:
-    """Request that an HTTP subagent close its session."""
+    """Cancel the third-party agent's A2A task."""
     async with httpx.AsyncClient(timeout=10.0) as http:
-        resp = await http.post(
-            f"{_provider_url(input.url)}/sessions/{input.instance_id}/close"
+        factory = ClientFactory(
+            ClientConfig(
+                streaming=False,
+                httpx_client=http,
+                supported_protocol_bindings=["HTTP+JSON"],
+            )
         )
-        _check_subagent_response(resp)
+        a2a_client = await factory.create_from_url(_provider_url(input.url))
+        try:
+            await a2a_client.cancel_task(CancelTaskRequest(id=input.instance_id))
+        finally:
+            await a2a_client.close()
 
 
-async def _fetch_tools_grouped(client: Client, servers: dict[str, str]) -> dict[str, list[dict[str, Any]]]:
+async def _fetch_tools_grouped(
+    client: Client, servers: dict[str, str]
+) -> dict[str, list[dict[str, Any]]]:
     """Fetch each {alias: url}'s tool list live, grouped by alias. Unreachable servers
     are logged and skipped."""
     if not servers:
@@ -274,15 +354,241 @@ async def _fetch_tools_grouped(client: Client, servers: dict[str, str]) -> dict[
         )
 
     results = await asyncio.gather(
-        *(_fetch_one(name, url) for name, url in servers.items()), return_exceptions=True
+        *(_fetch_one(name, url) for name, url in servers.items()),
+        return_exceptions=True,
     )
     grouped: dict[str, list[dict[str, Any]]] = {}
     for (name, url), result in zip(servers.items(), results):
         if isinstance(result, BaseException):
-            logger.warning("[registry] could not fetch tools from %r (%s): %s", name, url, result)
+            logger.warning(
+                "[registry] could not fetch tools from %r (%s): %s", name, url, result
+            )
             continue
         grouped[name] = result
     return grouped
+
+
+def _a2a_timestamp() -> Timestamp:
+    value = Timestamp()
+    value.GetCurrentTime()
+    return value
+
+
+@nexusrpc.handler.service_handler(service=A2AService)
+class GatewayA2AServiceHandler:
+    """A2A-over-Nexus router for account-registered HTTP A2A agents."""
+
+    def __init__(self, client: Client) -> None:
+        self._client = client
+
+    async def _account_handle(self, account_id: str):
+        if not account_id:
+            raise nexusrpc.HandlerError(
+                "A2A request metadata requires account_id",
+                type=nexusrpc.HandlerErrorType.BAD_REQUEST,
+            )
+        return await self._client.start_workflow(
+            ToolRegistryWorkflow.run,
+            account_id,
+            id=account_registry_workflow_id(account_id),
+            task_queue=REGISTRY_TASK_QUEUE,
+            id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+        )
+
+    @nexusrpc.handler.sync_operation
+    async def send_message(
+        self, ctx: StartOperationContext, request: SendMessageRequest
+    ) -> SendMessageResponse:
+        metadata = MessageToDict(request.metadata, preserving_proto_field_name=True)
+        message_metadata = MessageToDict(
+            request.message.metadata, preserving_proto_field_name=True
+        )
+        account_id = str(metadata.get("account_id", ""))
+        alias = str(metadata.get("agent_id", ""))
+        task_id = request.message.task_id
+        expected_turn = int(metadata.get("expected_turn", 1))
+        if not alias or not task_id:
+            raise nexusrpc.HandlerError(
+                "A2A request requires agent_id metadata and Message.task_id",
+                type=nexusrpc.HandlerErrorType.BAD_REQUEST,
+            )
+        handle = await self._account_handle(account_id)
+        route: SubagentInstanceRoute | None = await handle.query(
+            ToolRegistryWorkflow.find_subagent_instance, task_id
+        )
+        if route is None:
+            url: str | None = await handle.query(
+                ToolRegistryWorkflow.find_subagent, alias
+            )
+            if url is None:
+                raise nexusrpc.HandlerError(
+                    f"A2A agent {alias!r} is not registered for {account_id!r}",
+                    type=nexusrpc.HandlerErrorType.NOT_FOUND,
+                )
+            route = SubagentInstanceRoute(alias=alias, url=url, provider_instance_id="")
+            await handle.execute_update(
+                ToolRegistryWorkflow.bind_subagent_instance,
+                args=[task_id, route],
+                id=f"a2a-bind-{task_id}",
+            )
+
+        text = "".join(
+            part.text for part in request.message.parts if part.HasField("text")
+        )
+        msg_type = str(message_metadata.get("temporal.io/message-type", "ask"))
+        try:
+            result = await self._client.execute_activity(
+                subagent_proxy_activity,
+                SubagentDispatchInput(
+                    url=route.url,
+                    instance_id=route.provider_instance_id,
+                    msg_type=msg_type,
+                    payload=json.dumps({"text": text}),
+                    expected_turn=expected_turn,
+                    idempotency_key=request.message.message_id,
+                ),
+                id=subagent_dispatch_activity_id(task_id, expected_turn),
+                id_conflict_policy=ActivityIDConflictPolicy.USE_EXISTING,
+                task_queue=temporalio.nexus.info().task_queue,
+                schedule_to_close_timeout=timedelta(minutes=5),
+                start_to_close_timeout=timedelta(seconds=75),
+                heartbeat_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(maximum_attempts=5),
+            )
+        except ActivityFailureError as exc:
+            raise nexusrpc.HandlerError(
+                str(exc.cause or exc),
+                type=nexusrpc.HandlerErrorType.INTERNAL,
+                retryable_override=False,
+            ) from exc
+        output = json.loads(result.output)
+        if result.provider_instance_id != route.provider_instance_id:
+            route = SubagentInstanceRoute(
+                alias=route.alias,
+                url=route.url,
+                provider_instance_id=result.provider_instance_id,
+            )
+            await handle.execute_update(
+                ToolRegistryWorkflow.bind_subagent_instance,
+                args=[task_id, route],
+                id=(
+                    f"a2a-provider-bind-{task_id}-"
+                    f"{result.provider_instance_id}"
+                ),
+            )
+        output_text = (
+            str(output.get("text", "")) if isinstance(output, dict) else str(output)
+        )
+        return SendMessageResponse(
+            task=Task(
+                id=task_id,
+                context_id=request.message.context_id or task_id,
+                status=TaskStatus(
+                    state=TaskState.TASK_STATE_INPUT_REQUIRED,
+                    timestamp=_a2a_timestamp(),
+                ),
+                artifacts=[
+                    Artifact(
+                        artifact_id=result.turn_id,
+                        name="answer",
+                        parts=[Part(text=output_text)],
+                    )
+                ],
+                history=[request.message],
+                metadata={
+                    "temporal.io/turn-number": result.turn_number,
+                    "temporal.io/turn-id": result.turn_id,
+                },
+            )
+        )
+
+    @nexusrpc.handler.sync_operation
+    async def cancel_task(
+        self, ctx: StartOperationContext, request: CancelTaskRequest
+    ) -> Task:
+        metadata = MessageToDict(request.metadata, preserving_proto_field_name=True)
+        account_id = str(metadata.get("account_id", ""))
+        handle = await self._account_handle(account_id)
+        route: SubagentInstanceRoute | None = await handle.query(
+            ToolRegistryWorkflow.find_subagent_instance, request.id
+        )
+        if route is not None:
+            await self._client.execute_activity(
+                subagent_stop_activity,
+                SubagentStopInput(
+                    url=route.url, instance_id=route.provider_instance_id
+                ),
+                id=f"a2a-stop-{ctx.request_id}",
+                task_queue=temporalio.nexus.info().task_queue,
+                start_to_close_timeout=timedelta(seconds=15),
+                retry_policy=RetryPolicy(maximum_attempts=5),
+            )
+            await handle.execute_update(
+                ToolRegistryWorkflow.unbind_subagent_instance,
+                request.id,
+                id=f"a2a-unbind-{ctx.request_id}",
+            )
+        return Task(
+            id=request.id,
+            context_id=request.id,
+            status=TaskStatus(
+                state=TaskState.TASK_STATE_CANCELED,
+                timestamp=_a2a_timestamp(),
+            ),
+        )
+
+    @nexusrpc.handler.sync_operation
+    async def get_task(
+        self, _ctx: StartOperationContext, request: GetTaskRequest
+    ) -> Task:
+        return Task(
+            id=request.id,
+            context_id=request.id,
+            status=TaskStatus(
+                state=TaskState.TASK_STATE_INPUT_REQUIRED,
+                timestamp=_a2a_timestamp(),
+            ),
+        )
+
+    @nexusrpc.handler.sync_operation
+    async def list_tasks(
+        self, _ctx: StartOperationContext, _request: ListTasksRequest
+    ) -> ListTasksResponse:
+        return ListTasksResponse(tasks=[])
+
+    @nexusrpc.handler.sync_operation
+    async def subscribe_to_task(
+        self, _ctx: StartOperationContext, request: SubscribeToTaskInput
+    ) -> SubscribeToTaskOutput:
+        return SubscribeToTaskOutput(items=[], next_cursor=request.cursor)
+
+    @nexusrpc.handler.sync_operation
+    async def get_extended_agent_card(
+        self, _ctx: StartOperationContext, _request: GetExtendedAgentCardRequest
+    ) -> AgentCard:
+        return AgentCard(
+            name="Account A2A router",
+            description="Routes A2A requests to account-registered HTTP agents.",
+            version="1.0.0",
+            supported_interfaces=[
+                AgentInterface(
+                    url=REGISTRY_NEXUS_ENDPOINT,
+                    protocol_binding="TEMPORAL_NEXUS",
+                    protocol_version="1.0",
+                )
+            ],
+            capabilities=AgentCapabilities(streaming=False),
+            default_input_modes=["text/plain"],
+            default_output_modes=["text/plain"],
+            skills=[
+                AgentSkill(
+                    id="route",
+                    name="route",
+                    description="Route to an account-installed A2A agent.",
+                    tags=["router"],
+                )
+            ],
+        )
 
 
 @nexusrpc.handler.service_handler(service=RegistryService)
@@ -315,16 +621,24 @@ class RegistryServiceHandler:
         account_id = input.account_id or ""
         name = input.name or ""
         if not account_id:
-            raise nexusrpc.HandlerError("account_id is required", type=nexusrpc.HandlerErrorType.BAD_REQUEST)
+            raise nexusrpc.HandlerError(
+                "account_id is required", type=nexusrpc.HandlerErrorType.BAD_REQUEST
+            )
         try:
             validate_service_name(name)
         except ValueError as exc:
-            raise nexusrpc.HandlerError(str(exc), type=nexusrpc.HandlerErrorType.BAD_REQUEST) from exc
+            raise nexusrpc.HandlerError(
+                str(exc), type=nexusrpc.HandlerErrorType.BAD_REQUEST
+            ) from exc
         if not input.url:
-            raise nexusrpc.HandlerError("url is required", type=nexusrpc.HandlerErrorType.BAD_REQUEST)
+            raise nexusrpc.HandlerError(
+                "url is required", type=nexusrpc.HandlerErrorType.BAD_REQUEST
+            )
 
         handle = await self._account_handle(account_id)
-        await handle.signal(ToolRegistryWorkflow.register_external, args=[name, input.url])
+        await handle.signal(
+            ToolRegistryWorkflow.register_external, args=[name, input.url]
+        )
 
     @nexusrpc.handler.sync_operation
     async def deregister(
@@ -342,7 +656,9 @@ class RegistryServiceHandler:
         fetched live, every call."""
         account_id = input.account_id or ""
         if not account_id:
-            raise nexusrpc.HandlerError("account_id is required", type=nexusrpc.HandlerErrorType.BAD_REQUEST)
+            raise nexusrpc.HandlerError(
+                "account_id is required", type=nexusrpc.HandlerErrorType.BAD_REQUEST
+            )
         handle = await self._account_handle(account_id)
         entries = await handle.query(ToolRegistryWorkflow.list_account_entries)
         remote_tools = await _fetch_tools_grouped(self._client, entries.remote_servers)
@@ -352,7 +668,9 @@ class RegistryServiceHandler:
             remote_tools=ListAccountEntriesOutputRemoteTools(
                 additional_properties={
                     alias: [
-                        ListAccountEntriesOutputRemoteToolsValueItem(additional_properties=tool)
+                        ListAccountEntriesOutputRemoteToolsValueItem(
+                            additional_properties=tool
+                        )
                         for tool in tools
                     ]
                     for alias, tools in remote_tools.items()
@@ -417,7 +735,8 @@ class RegistryServiceHandler:
         name = input.name or ""
         if not account_id or not alias:
             raise nexusrpc.HandlerError(
-                "account_id and alias are required", type=nexusrpc.HandlerErrorType.BAD_REQUEST
+                "account_id and alias are required",
+                type=nexusrpc.HandlerErrorType.BAD_REQUEST,
             )
         operation = name.removeprefix(f"{alias}_")
         if operation == name:
@@ -436,7 +755,9 @@ class RegistryServiceHandler:
 
         # nex-gen wraps map-shaped (additionalProperties) fields in a named type instead
         # of a plain dict.
-        arguments = input.arguments.additional_properties if input.arguments is not None else {}
+        arguments = (
+            input.arguments.additional_properties if input.arguments is not None else {}
+        )
         try:
             result = await self._client.execute_activity(
                 mcp_proxy_activity,
@@ -458,10 +779,14 @@ class RegistryServiceHandler:
         except ActivityFailureError as exc:
             # Real RPC/transport failure. A tool-level error is data on `result` instead.
             raise nexusrpc.HandlerError(
-                str(exc.cause or exc), type=nexusrpc.HandlerErrorType.INTERNAL, retryable_override=False
+                str(exc.cause or exc),
+                type=nexusrpc.HandlerErrorType.INTERNAL,
+                retryable_override=False,
             ) from exc
         return CallToolOutput(
-            result=CallToolOutputResult(additional_properties=result.model_dump(mode="json"))
+            result=CallToolOutputResult(
+                additional_properties=result.model_dump(mode="json")
+            )
         )
 
     @nexusrpc.handler.sync_operation
@@ -473,13 +798,18 @@ class RegistryServiceHandler:
         alias = input.alias or ""
         if not account_id or not alias:
             raise nexusrpc.HandlerError(
-                "account_id and alias are required", type=nexusrpc.HandlerErrorType.BAD_REQUEST
+                "account_id and alias are required",
+                type=nexusrpc.HandlerErrorType.BAD_REQUEST,
             )
         if not input.url:
-            raise nexusrpc.HandlerError("url is required", type=nexusrpc.HandlerErrorType.BAD_REQUEST)
+            raise nexusrpc.HandlerError(
+                "url is required", type=nexusrpc.HandlerErrorType.BAD_REQUEST
+            )
 
         handle = await self._account_handle(account_id)
-        await handle.signal(ToolRegistryWorkflow.register_subagent, args=[alias, input.url])
+        await handle.signal(
+            ToolRegistryWorkflow.register_subagent, args=[alias, input.url]
+        )
 
     @nexusrpc.handler.sync_operation
     async def deregister_subagent(
@@ -487,9 +817,7 @@ class RegistryServiceHandler:
     ) -> None:
         """Remove one subagent registration under one account_id."""
         handle = await self._account_handle(input.account_id)
-        await handle.signal(
-            ToolRegistryWorkflow.deregister_subagent, input.alias
-        )
+        await handle.signal(ToolRegistryWorkflow.deregister_subagent, input.alias)
 
     @nexusrpc.handler.sync_operation
     async def start_subagent(
@@ -500,13 +828,12 @@ class RegistryServiceHandler:
         alias = input.alias
         if not account_id or not alias:
             raise nexusrpc.HandlerError(
-                "account_id and alias are required", type=nexusrpc.HandlerErrorType.BAD_REQUEST
+                "account_id and alias are required",
+                type=nexusrpc.HandlerErrorType.BAD_REQUEST,
             )
 
         handle = await self._account_handle(account_id)
-        url: str | None = await handle.query(
-            ToolRegistryWorkflow.find_subagent, alias
-        )
+        url: str | None = await handle.query(ToolRegistryWorkflow.find_subagent, alias)
         if url is None:
             raise nexusrpc.HandlerError(
                 f"subagent {alias!r} is not registered for account {account_id!r}.",
@@ -591,7 +918,9 @@ class RegistryServiceHandler:
             )
         except ActivityFailureError as exc:
             raise nexusrpc.HandlerError(
-                str(exc.cause or exc), type=nexusrpc.HandlerErrorType.INTERNAL, retryable_override=False
+                str(exc.cause or exc),
+                type=nexusrpc.HandlerErrorType.INTERNAL,
+                retryable_override=False,
             ) from exc
         if result.turn_number != input.expected_turn:
             raise nexusrpc.HandlerError(

--- a/nexus/mcp/durable_tools_gateway/resources.py
+++ b/nexus/mcp/durable_tools_gateway/resources.py
@@ -2,41 +2,46 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from typing import Any, Literal
+
+from a2a.types import AgentCard
+from google.protobuf.json_format import ParseDict
 
 ResourceCategory = Literal["agent", "mcp"]
 ResourceTransport = Literal["nexus", "external_http"]
 
 
-@dataclass(frozen=True)
-class AgentHandlerDescriptor:
-    """Model-facing contract for one remotely callable agent handler."""
+def text_agent_card(
+    *, name: str, description: str, endpoint: str, transport: ResourceTransport
+) -> dict[str, Any]:
+    """Return the minimal standard A2A card used by manually registered agents."""
 
-    name: str
-    description: str
-    input_schema: dict[str, Any]
-    output_schema: dict[str, Any]
-    param_name: str = "input"
-
-
-TEXT_AGENT_HANDLER = AgentHandlerDescriptor(
-    name="ask",
-    description="Ask the agent a question.",
-    param_name="message",
-    input_schema={
-        "type": "object",
-        "properties": {"text": {"type": "string"}},
-        "required": ["text"],
-        "additionalProperties": False,
-    },
-    output_schema={
-        "type": "object",
-        "properties": {"text": {"type": "string"}},
-        "required": ["text"],
-        "additionalProperties": False,
-    },
-)
+    return {
+        "name": name,
+        "description": description,
+        "version": "1.0.0",
+        "supportedInterfaces": [
+            {
+                "url": endpoint,
+                "protocolBinding": (
+                    "TEMPORAL_NEXUS" if transport == "nexus" else "HTTP+JSON"
+                ),
+                "protocolVersion": "1.0",
+            }
+        ],
+        "capabilities": {"streaming": True},
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [
+            {
+                "id": "ask",
+                "name": "ask",
+                "description": "Ask the agent a question.",
+                "tags": ["agent"],
+            }
+        ],
+    }
 
 
 @dataclass(frozen=True)
@@ -55,13 +60,15 @@ class ResourceDescriptor:
     description: str
     endpoint: str
     service: str | None = None
-    handlers: tuple[AgentHandlerDescriptor, ...] = field(default_factory=tuple)
+    # Official A2A AgentCard JSON. This is the sole agent capability schema shared
+    # by the global catalog, account registry, native Nexus binding, and HTTP agents.
+    agent_card: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
-    # Compatibility views keep the broker/UI readable while the canonical stored
-    # shape remains transport-neutral and defined only once.
+    # Named projections keep routing code readable while the canonical stored shape
+    # remains transport-neutral and defined only once.
     @property
     def name(self) -> str:
         return self.resource_id
@@ -80,7 +87,7 @@ class ResourceDescriptor:
 
     @property
     def nexus_service(self) -> str:
-        return self.service or "AgentService"
+        return self.service or "A2AService"
 
     @property
     def provider_url(self) -> str | None:
@@ -115,25 +122,24 @@ def validate_resource_descriptor(descriptor: ResourceDescriptor) -> None:
         raise ValueError(f"unsupported resource transport {descriptor.transport!r}")
     if descriptor.transport == "nexus" and not (descriptor.service or "").strip():
         raise ValueError("Nexus resources require a service name")
-    if descriptor.category == "agent" and not descriptor.handlers:
-        raise ValueError("agent resources require at least one handler contract")
-    if descriptor.category == "mcp" and descriptor.handlers:
-        raise ValueError("MCP resources cannot declare agent handlers")
-    for handler in descriptor.handlers:
-        if not handler.name.strip() or not handler.param_name.strip():
-            raise ValueError("agent handler name and parameter name are required")
-        if handler.input_schema.get("type") != "object":
-            raise ValueError("agent handler input schemas must describe an object")
-        if handler.output_schema.get("type") != "object":
-            raise ValueError("agent handler output schemas must describe an object")
+    if descriptor.category == "agent" and not descriptor.agent_card:
+        raise ValueError("agent resources require an A2A agent_card")
+    if descriptor.category == "mcp" and descriptor.agent_card is not None:
+        raise ValueError("MCP resources cannot declare an A2A agent_card")
+    if descriptor.agent_card is not None:
+        try:
+            card = ParseDict(descriptor.agent_card, AgentCard())
+        except Exception as exc:
+            raise ValueError("agent_card must be valid A2A AgentCard JSON") from exc
+        if not card.name or not card.supported_interfaces or not card.skills:
+            raise ValueError(
+                "agent_card requires a name, supported interface, and skill"
+            )
 
 
 def descriptor_from_dict(value: dict[str, Any]) -> ResourceDescriptor:
     """Decode JSON-shaped catalog data into the canonical descriptor."""
 
-    handlers = tuple(
-        AgentHandlerDescriptor(**handler) for handler in value.get("handlers", [])
-    )
     descriptor = ResourceDescriptor(
         resource_id=str(value["resource_id"]),
         revision=int(value.get("revision", 1)),
@@ -143,7 +149,7 @@ def descriptor_from_dict(value: dict[str, Any]) -> ResourceDescriptor:
         description=str(value.get("description", "")),
         endpoint=str(value["endpoint"]),
         service=value.get("service"),
-        handlers=handlers,
+        agent_card=value.get("agent_card"),
     )
     validate_resource_descriptor(descriptor)
     return descriptor

--- a/nexus/mcp/durable_tools_gateway/web.py
+++ b/nexus/mcp/durable_tools_gateway/web.py
@@ -54,15 +54,13 @@ from .registry_service_handler import (
     SubagentDispatchOutput,
     subagent_dispatch_activity_id,
 )
-from .resources import (
-    TEXT_AGENT_HANDLER,
-    AccountResourceRegistration,
-    ResourceDescriptor,
-)
+from .resources import AccountResourceRegistration, ResourceDescriptor
 from .tool_history import scan_external_tool_calls, scan_native_tool_calls
 
 logger = logging.getLogger(__name__)
 _EXTERNAL_EVENTS_PER_TURN = 4
+_SESSION_PROJECTION_TIMEOUT_SECONDS = 1.0
+_SESSION_PROJECTION_RETRY_SECONDS = 0.025
 
 
 class ExternalTurnHistoryUnavailable(Exception):
@@ -407,11 +405,21 @@ def create_account_agent_app(
         session_id: str,
     ) -> tuple[SessionRecord, ResourceDescriptor]:
         handle = await registry_handle()
-        session: SessionRecord | None = await handle.query(
-            ToolRegistryWorkflow.resolve_session,
-            session_id,
-            result_type=SessionRecord | None,
-        )
+        session: SessionRecord | None = None
+        deadline = time.monotonic() + _SESSION_PROJECTION_TIMEOUT_SECONDS
+        while True:
+            session = await handle.query(
+                ToolRegistryWorkflow.resolve_session,
+                session_id,
+                result_type=SessionRecord | None,
+            )
+            if (
+                session is not None
+                or session_id.startswith("session-")
+                or time.monotonic() >= deadline
+            ):
+                break
+            await asyncio.sleep(_SESSION_PROJECTION_RETRY_SECONDS)
         if session is None:
             raise HTTPException(status_code=404, detail="unknown account session")
         agent: ResourceDescriptor | None = await handle.query(
@@ -450,14 +458,18 @@ def create_account_agent_app(
             "delegation_lineage": [],
             "delegation_depth": 0,
             "max_delegation_depth": 5,
-            # Native AgentService reconciles its live turn when this is omitted.
+            # The native A2A adapter reconciles its live turn when this is omitted.
             "expected_turn": expected_turn,
             "idempotency_key": (f"{account_id}:{session.session_id}:{expected_turn}"),
         }
         result = await execute_action(
             AgentActionInput(
                 action="send",
-                session_id=session.provider_session_id,
+                session_id=(
+                    ""
+                    if agent.kind == "external_http" and not session.has_started
+                    else session.provider_session_id
+                ),
                 nexus_endpoint=agent.nexus_endpoint,
                 provider_url=agent.provider_url,
                 values=values,
@@ -465,6 +477,16 @@ def create_account_agent_app(
         )
         handle = await registry_handle()
         if agent.kind == "external_http":
+            provider_session_id = str(result.get("provider_instance_id") or "")
+            if (
+                provider_session_id
+                and provider_session_id != session.provider_session_id
+            ):
+                session = await handle.execute_update(
+                    ToolRegistryWorkflow.bind_session_provider,
+                    args=[session.session_id, provider_session_id],
+                    result_type=SessionRecord,
+                )
             turn_number = int(result["turn_number"])
             turn_id = str(result["turn_id"])
             output = _json_value(str(result["output"]))
@@ -663,8 +685,34 @@ def create_account_agent_app(
             label=req.label,
             description=req.description,
             endpoint=req.nexus_endpoint or req.provider_url or "",
-            service="AgentService" if req.kind == "harness_nexus" else None,
-            handlers=(TEXT_AGENT_HANDLER,),
+            service="A2AService" if req.kind == "harness_nexus" else None,
+            agent_card={
+                "name": req.label,
+                "description": req.description,
+                "version": "1.0.0",
+                "supportedInterfaces": [
+                    {
+                        "url": req.nexus_endpoint or req.provider_url or "",
+                        "protocolBinding": (
+                            "TEMPORAL_NEXUS"
+                            if req.kind == "harness_nexus"
+                            else "HTTP+JSON"
+                        ),
+                        "protocolVersion": "1.0",
+                    }
+                ],
+                "capabilities": {"streaming": True},
+                "defaultInputModes": ["text/plain"],
+                "defaultOutputModes": ["text/plain"],
+                "skills": [
+                    {
+                        "id": "ask",
+                        "name": "ask",
+                        "description": "Send a text message to this agent.",
+                        "tags": ["agent"],
+                    }
+                ],
+            },
         )
         result: ResourceDescriptor = await app.state.registry.execute_update(
             ToolRegistryWorkflow.register_agent,
@@ -759,6 +807,8 @@ def create_account_agent_app(
                     agent_key=str(item["agent_key"]),
                     provider_session_id=str(item["workflow_id"]),
                     next_expected_turn=int(item.get("next_expected_turn", 1)),
+                    has_started=bool(item.get("has_started", False))
+                    or int(item.get("next_expected_turn", 1)) > 1,
                 )
                 for item in values
             ]
@@ -873,34 +923,20 @@ def create_account_agent_app(
 
     @app.get("/api/agent-interface/{session_id}")
     async def agent_interface(session_id: str):
-        session, agent = await resolve_session(session_id)
-        if agent.kind == "external_http" or not session.has_started:
-            return [
-                {
-                    "name": "ask",
-                    "description": "Send a text message to this agent.",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"text": {"type": "string"}},
-                        "required": ["text"],
-                    },
-                    "output": {"type": "object"},
-                }
-            ]
-        result = await execute_action(
-            AgentActionInput(
-                action="agent_interface",
-                session_id=session.provider_session_id,
-                nexus_endpoint=agent.nexus_endpoint,
-            )
-        )
+        _, agent = await resolve_session(session_id)
+        skills = (agent.agent_card or {}).get("skills", [])
         return [
             {
-                **handler,
-                "parameters": _json_value(handler["parameters"]),
-                "output": _json_value(handler["output"]),
+                "name": skill["id"],
+                "description": skill.get("description", skill.get("name", "")),
+                "parameters": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+                "output": {"type": "object"},
             }
-            for handler in result["handlers"]
+            for skill in skills
         ]
 
     @app.get("/api/operator-interface/{session_id}")
@@ -1160,9 +1196,8 @@ def create_account_agent_app(
                             )
                         )
                     )
-                    if (
-                        status.get("subagent_close_policy") == "ask-user"
-                        and status.get("subagents")
+                    if status.get("subagent_close_policy") == "ask-user" and status.get(
+                        "subagents"
                     ):
                         raise HTTPException(
                             status_code=409,

--- a/nexus/mcp/durable_tools_gateway/worker.py
+++ b/nexus/mcp/durable_tools_gateway/worker.py
@@ -49,6 +49,7 @@ from .registry import (
     fetch_external_tools,
 )
 from .registry_service_handler import (
+    GatewayA2AServiceHandler,
     RegistryServiceHandler,
     mcp_proxy_activity,
     subagent_proxy_activity,
@@ -169,7 +170,10 @@ async def main(
             subagent_stop_activity,
             publish_agent_events,
         ],
-        nexus_service_handlers=[RegistryServiceHandler(client)],
+        nexus_service_handlers=[
+            RegistryServiceHandler(client),
+            GatewayA2AServiceHandler(client),
+        ],
     )
     async with worker:
         logger.info(

--- a/nexus/mcp/pyproject.toml
+++ b/nexus/mcp/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Bridge MCP tools with Temporal's reliable workflow execution via Nexus RPC"
 requires-python = ">=3.13"
 dependencies = [
+    "a2a-sdk[http-server]>=1.1.2",
     "anyio>=4.0.0",
     "fastapi>=0.136.3",
     "httpx>=0.27.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.11"
 # pydantic. AI-SDK and external-storage needs are opt-in extras below, so installing the
 # harness doesn't drag in Gemini or boto3.
 dependencies = [
+    "a2a-sdk>=1.1.2",
     "temporalio>=1.31.0",  # provides temporalio.contrib.workflow_streams (experimental)
     "pydantic>=2.0",
 ]

--- a/temporal_agent_harness/a2a/__init__.py
+++ b/temporal_agent_harness/a2a/__init__.py
@@ -1,0 +1,17 @@
+"""A2A protocol bindings for Temporal Agent Harness agents."""
+
+from .control import HarnessControlService
+from .nexus import (
+    A2AService,
+    SubscribeToTaskInput,
+    SubscribeToTaskItem,
+    SubscribeToTaskOutput,
+)
+
+__all__ = [
+    "A2AService",
+    "HarnessControlService",
+    "SubscribeToTaskInput",
+    "SubscribeToTaskItem",
+    "SubscribeToTaskOutput",
+]

--- a/temporal_agent_harness/a2a/adapter.py
+++ b/temporal_agent_harness/a2a/adapter.py
@@ -1,0 +1,333 @@
+"""Expose a Temporal Agent Harness workflow as an A2A agent over Nexus."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    AgentSkill,
+    CancelTaskRequest,
+    GetExtendedAgentCardRequest,
+    GetTaskRequest,
+    ListTasksRequest,
+    ListTasksResponse,
+    Message,
+    SendMessageRequest,
+    SendMessageResponse,
+    Task,
+    TaskState,
+    TaskStatus,
+)
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.timestamp_pb2 import Timestamp
+from nexusrpc import HandlerError, HandlerErrorType
+from nexusrpc.handler import StartOperationContext, service_handler, sync_operation
+from temporalio import nexus
+from temporalio.client import Client
+from temporalio.service import RPCError
+
+from temporal_agent_harness.harness.agent_client import AgentClient, StaleTurnError
+from temporal_agent_harness.harness.agent_protocol import AgentConfig
+
+from .nexus import (
+    A2A_STREAM_POLL_UPDATE,
+    A2A_STREAM_REPLAY_QUERY,
+    A2AService,
+    SubscribeToTaskInput,
+    SubscribeToTaskOutput,
+)
+
+A2A_NEXUS_BINDING = "TEMPORAL_NEXUS"
+A2A_PROTOCOL_VERSION = "1.0"
+HARNESS_HANDLER_METADATA_KEY = "temporal.io/message-type"
+HARNESS_PAYLOAD_METADATA_KEY = "temporal.io/payload"
+_MAX_SEND_RETRIES = 5
+
+
+@dataclass(frozen=True)
+class A2AHandlerConfig:
+    agent_task_queue: str
+    workflow_name: str
+    workflow_id_prefix: str
+    is_message_queuing_enabled: bool
+    agent_card: AgentCard
+
+
+def make_agent_card(
+    *,
+    name: str,
+    description: str,
+    endpoint: str,
+    skills: tuple[tuple[str, str], ...] = (("ask", "Ask the agent a question."),),
+) -> AgentCard:
+    """Build the public A2A card for a harness-native Nexus endpoint."""
+
+    return AgentCard(
+        name=name,
+        description=description,
+        version="1.0.0",
+        supported_interfaces=[
+            AgentInterface(
+                url=endpoint,
+                protocol_binding=A2A_NEXUS_BINDING,
+                protocol_version=A2A_PROTOCOL_VERSION,
+            )
+        ],
+        capabilities=AgentCapabilities(streaming=True),
+        default_input_modes=["text/plain", "application/json"],
+        default_output_modes=["text/plain", "application/json"],
+        skills=[
+            AgentSkill(
+                id=skill_id,
+                name=skill_id,
+                description=skill_description,
+                tags=["temporal-agent-harness"],
+                input_modes=["text/plain", "application/json"],
+                output_modes=["text/plain", "application/json"],
+            )
+            for skill_id, skill_description in skills
+        ],
+    )
+
+
+def _timestamp(value: float | None = None) -> Timestamp:
+    timestamp = Timestamp()
+    timestamp.FromDatetime(
+        datetime.fromtimestamp(value, UTC)
+        if value is not None
+        else datetime.now(UTC)
+    )
+    return timestamp
+
+
+def _metadata(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    return MessageToDict(value, preserving_proto_field_name=True)
+
+
+def _message_text(message: Message) -> str:
+    return "".join(part.text for part in message.parts if part.HasField("text"))
+
+
+def _is_completed(exc: Exception) -> bool:
+    return "already completed" in str(exc).lower()
+
+
+def _is_not_found(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return "workflow not found" in message or "not found for id" in message
+
+
+@service_handler(service=A2AService)
+class A2AServiceHandler:
+    """A2A v1 adapter around the harness's durable workflow protocol."""
+
+    def __init__(self, client: Client, config: A2AHandlerConfig) -> None:
+        self._client = client
+        self._config = config
+
+    def _workflow_id(self, task_id: str) -> str:
+        return self._config.workflow_id_prefix + task_id
+
+    def _agent_client(self, task_id: str) -> AgentClient:
+        return AgentClient(self._client, self._workflow_id(task_id))
+
+    @sync_operation
+    async def send_message(
+        self, ctx: StartOperationContext, request: SendMessageRequest
+    ) -> SendMessageResponse:
+        message = request.message
+        task_id = message.task_id
+        if not task_id:
+            raise HandlerError(
+                "A2A Message.task_id is required by the Nexus binding",
+                type=HandlerErrorType.BAD_REQUEST,
+            )
+        metadata = _metadata(request.metadata)
+        message_metadata = _metadata(message.metadata)
+        msg_type = str(message_metadata.get(HARNESS_HANDLER_METADATA_KEY, "ask"))
+        payload = message_metadata.get(HARNESS_PAYLOAD_METADATA_KEY)
+        if not isinstance(payload, dict):
+            payload = {"text": _message_text(message)}
+
+        config = AgentConfig(
+            is_message_queuing_enabled=self._config.is_message_queuing_enabled,
+            account_id=metadata.get("account_id"),
+            registered_agent_id=metadata.get("registered_agent_id"),
+            delegation_lineage=(
+                tuple(metadata["delegation_lineage"])
+                if isinstance(metadata.get("delegation_lineage"), list)
+                else None
+            ),
+            delegation_depth=metadata.get("delegation_depth"),
+            max_delegation_depth=metadata.get("max_delegation_depth"),
+        )
+        expected = metadata.get("expected_turn")
+        expected_turn = int(expected) if expected is not None else 1
+        client = self._agent_client(task_id)
+        attempts = 1 if expected is not None else _MAX_SEND_RETRIES
+        for attempt in range(attempts):
+            if attempt:
+                status = await client.get_status()
+                expected_turn = status.current_turn + len(status.pending_turns) + 1
+            try:
+                reply = await client.start_and_submit_message(
+                    msg_type,
+                    payload,
+                    expected_turn,
+                    workflow_name=self._config.workflow_name,
+                    task_queue=self._config.agent_task_queue,
+                    start_config=config,
+                    update_id=f"a2a-send-{ctx.request_id}-{attempt}",
+                )
+                break
+            except StaleTurnError as exc:
+                if expected is not None:
+                    raise HandlerError(
+                        f"StaleTurn: {exc}", type=HandlerErrorType.BAD_REQUEST
+                    ) from exc
+                await asyncio.sleep((attempt + 1) * 0.05)
+        else:
+            raise HandlerError(
+                "SendMessage exhausted retries", type=HandlerErrorType.INTERNAL
+            )
+
+        task = Task(
+            id=task_id,
+            context_id=message.context_id or task_id,
+            status=TaskStatus(
+                state=TaskState.TASK_STATE_WORKING, timestamp=_timestamp()
+            ),
+            history=[message],
+            metadata={
+                "temporal.io/turn-number": reply.turn_number,
+                "temporal.io/turn-id": reply.turn_id,
+                "temporal.io/accepted-offset": reply.accepted_offset,
+                "temporal.io/pending": reply.pending,
+            },
+        )
+        return SendMessageResponse(task=task)
+
+    @sync_operation
+    async def get_task(
+        self, _ctx: StartOperationContext, request: GetTaskRequest
+    ) -> Task:
+        try:
+            status = await self._agent_client(request.id).get_status()
+        except RPCError as exc:
+            if _is_not_found(exc):
+                return Task(
+                    id=request.id,
+                    context_id=request.id,
+                    status=TaskStatus(
+                        state=TaskState.TASK_STATE_SUBMITTED,
+                        timestamp=_timestamp(),
+                    ),
+                )
+            if _is_completed(exc):
+                return Task(
+                    id=request.id,
+                    context_id=request.id,
+                    status=TaskStatus(
+                        state=TaskState.TASK_STATE_COMPLETED,
+                        timestamp=_timestamp(),
+                    ),
+                )
+            raise
+        state = (
+            TaskState.TASK_STATE_WORKING
+            if status.turn_active
+            or status.pending_turns
+            or status.pending_approvals
+            or status.pending_callbacks
+            else TaskState.TASK_STATE_INPUT_REQUIRED
+        )
+        return Task(
+            id=request.id,
+            context_id=request.id,
+            status=TaskStatus(state=state, timestamp=_timestamp()),
+            metadata={
+                "temporal.io/current-turn": status.current_turn,
+                "temporal.io/subagents": [
+                    {
+                        "subagent_id": item.subagent_id,
+                        "agent_key": item.agent_key,
+                        "workflow_id": item.workflow_id,
+                        "next_expected_turn": item.next_expected_turn,
+                    }
+                    for item in status.subagents
+                ],
+                "temporal.io/pending-approvals": len(status.pending_approvals),
+                "temporal.io/pending-callbacks": len(status.pending_callbacks),
+            },
+        )
+
+    @sync_operation
+    async def list_tasks(
+        self, _ctx: StartOperationContext, _request: ListTasksRequest
+    ) -> ListTasksResponse:
+        # Task enumeration belongs to the account registry. An agent endpoint has no
+        # account-wide visibility and must not leak workflows from another tenant.
+        return ListTasksResponse(tasks=[], page_size=0, total_size=0)
+
+    @sync_operation
+    async def cancel_task(
+        self, _ctx: StartOperationContext, request: CancelTaskRequest
+    ) -> Task:
+        await self._agent_client(request.id).close()
+        return Task(
+            id=request.id,
+            context_id=request.id,
+            status=TaskStatus(
+                state=TaskState.TASK_STATE_CANCELED, timestamp=_timestamp()
+            ),
+        )
+
+    @sync_operation
+    async def get_extended_agent_card(
+        self, _ctx: StartOperationContext, _request: GetExtendedAgentCardRequest
+    ) -> AgentCard:
+        result = AgentCard()
+        result.CopyFrom(self._config.agent_card)
+        return result
+
+    @nexus.temporal_operation
+    async def subscribe_to_task(
+        self,
+        _ctx: nexus.TemporalStartOperationContext,
+        client: nexus.TemporalNexusClient,
+        request: SubscribeToTaskInput,
+    ) -> nexus.TemporalOperationResult[SubscribeToTaskOutput]:
+        workflow_id = self._workflow_id(request.id)
+        try:
+            result = await client.start_workflow_update(
+                workflow_id,
+                A2A_STREAM_POLL_UPDATE,
+                request,
+                result_type=SubscribeToTaskOutput,
+            )
+        except RPCError as exc:
+            if _is_completed(exc):
+                replay = await self._client.get_workflow_handle(workflow_id).query(
+                    A2A_STREAM_REPLAY_QUERY,
+                    request,
+                    result_type=SubscribeToTaskOutput,
+                )
+                return nexus.TemporalOperationResult.sync(replay)
+            if _is_not_found(exc):
+                return nexus.TemporalOperationResult.sync(
+                    SubscribeToTaskOutput(
+                        items=[], next_cursor=request.cursor, closed=True
+                    )
+                )
+            raise
+        if result.token is not None:
+            return nexus.TemporalOperationResult.async_token(result.token)
+        return nexus.TemporalOperationResult.sync(result.value)

--- a/temporal_agent_harness/a2a/control.py
+++ b/temporal_agent_harness/a2a/control.py
@@ -1,0 +1,42 @@
+"""Harness-specific controls intentionally outside the A2A agent protocol."""
+
+from __future__ import annotations
+
+import nexusrpc
+
+from temporal_agent_harness.nexus_agent_adapter.generated import (
+    AgentStatusOutput,
+    ApproveToolCallInput,
+    ApproveToolCallOutput,
+    ExecuteOperatorCommandInput,
+    ExecuteOperatorCommandOutput,
+    ProvideCallbackResultInput,
+    ProvideCallbackResultOutput,
+    QueryOperatorInterfaceOutput,
+    QuerySessionInput,
+)
+
+
+@nexusrpc.service(name="HarnessControlService")
+class HarnessControlService:
+    """Approval, callback, status, and operator controls for harness-aware UIs."""
+
+    execute_operator_command = nexusrpc.Operation(
+        "ExecuteOperatorCommand",
+        ExecuteOperatorCommandInput,
+        ExecuteOperatorCommandOutput,
+    )
+    approve_tool_call = nexusrpc.Operation(
+        "ApproveToolCall", ApproveToolCallInput, ApproveToolCallOutput
+    )
+    query_operator_interface = nexusrpc.Operation(
+        "QueryOperatorInterface", QuerySessionInput, QueryOperatorInterfaceOutput
+    )
+    query_agent_status = nexusrpc.Operation(
+        "QueryAgentStatus", QuerySessionInput, AgentStatusOutput
+    )
+    provide_callback_result = nexusrpc.Operation(
+        "ProvideCallbackResult",
+        ProvideCallbackResultInput,
+        ProvideCallbackResultOutput,
+    )

--- a/temporal_agent_harness/a2a/nexus.py
+++ b/temporal_agent_harness/a2a/nexus.py
@@ -1,0 +1,175 @@
+"""A2A's request model bound to Temporal Nexus.
+
+A2A's HTTP and gRPC bindings expose server streams. Nexus operations currently have a
+single result, so ``SubscribeToTask`` returns one bounded cursor page. A durable caller
+repeats that operation and can multicast the resulting A2A events to any number of UI
+drivers. The semantic payloads remain the official A2A protobuf messages.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import nexusrpc
+from a2a.types import (
+    AgentCard,
+    Artifact,
+    CancelTaskRequest,
+    GetExtendedAgentCardRequest,
+    GetTaskRequest,
+    ListTasksRequest,
+    ListTasksResponse,
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    SendMessageResponse,
+    StreamResponse,
+    Task,
+    TaskArtifactUpdateEvent,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+)
+from google.protobuf.timestamp_pb2 import Timestamp
+from pydantic import BaseModel, Field
+from temporalio.api.common.v1 import Payload
+
+HARNESS_EVENT_METADATA_KEY = "temporal.io/agent-event-payload"
+A2A_STREAM_POLL_UPDATE = "__temporal_a2a_subscribe_to_task"
+A2A_STREAM_REPLAY_QUERY = "__temporal_a2a_replay_task"
+
+
+class SubscribeToTaskInput(BaseModel):
+    """A bounded A2A subscription request for the Nexus protocol binding."""
+
+    tenant: str = ""
+    id: str
+    cursor: int = Field(default=0, ge=0)
+    timeout_seconds: float = Field(default=30.0, gt=0, le=60)
+
+
+class SubscribeToTaskItem(BaseModel):
+    """One serialized ``lf.a2a.v1.StreamResponse`` and its durable cursor."""
+
+    offset: int = Field(ge=0)
+    data: str
+
+
+class SubscribeToTaskOutput(BaseModel):
+    items: list[SubscribeToTaskItem]
+    next_cursor: int = Field(ge=0)
+    more_ready: bool = False
+    closed: bool = False
+
+
+def _timestamp(value: float | None = None) -> Timestamp:
+    timestamp = Timestamp()
+    timestamp.FromDatetime(
+        datetime.fromtimestamp(value, UTC)
+        if value is not None
+        else datetime.now(UTC)
+    )
+    return timestamp
+
+
+def stream_response(encoded_payload: str) -> StreamResponse:
+    """Project one rich harness event into standard A2A plus an extension payload."""
+
+    raw = base64.b64decode(encoded_payload)
+    payload = Payload()
+    payload.ParseFromString(raw)
+    envelope = json.loads(payload.data)
+    event = envelope["event"]
+    event_type = event["type"]
+    task_id = str(envelope["agent_id"])
+    metadata = {HARNESS_EVENT_METADATA_KEY: encoded_payload}
+    if event_type == "reply_delta":
+        return StreamResponse(
+            artifact_update=TaskArtifactUpdateEvent(
+                task_id=task_id,
+                context_id=task_id,
+                artifact=Artifact(
+                    artifact_id=str(envelope["turn_id"]),
+                    parts=[Part(text=str(event.get("text", "")))],
+                ),
+                append=True,
+                metadata=metadata,
+            )
+        )
+    if event_type == "reply":
+        output = event.get("output", {})
+        text = (
+            output.get("text", json.dumps(output))
+            if isinstance(output, dict)
+            else str(output)
+        )
+        return StreamResponse(
+            message=Message(
+                message_id=str(uuid.uuid5(uuid.NAMESPACE_URL, encoded_payload)),
+                task_id=task_id,
+                context_id=task_id,
+                role=Role.ROLE_AGENT,
+                parts=[Part(text=text)],
+                metadata=metadata,
+            )
+        )
+    state = TaskState.TASK_STATE_WORKING
+    if event_type == "turn_end":
+        state = TaskState.TASK_STATE_INPUT_REQUIRED
+    elif event_type == "error":
+        state = TaskState.TASK_STATE_FAILED
+    return StreamResponse(
+        status_update=TaskStatusUpdateEvent(
+            task_id=task_id,
+            context_id=task_id,
+            status=TaskStatus(
+                state=state, timestamp=_timestamp(envelope.get("timestamp"))
+            ),
+            metadata=metadata,
+        )
+    )
+
+
+def subscription_page(
+    result: Any, *, closed: bool | None = None
+) -> SubscribeToTaskOutput:
+    """Convert an internal stream-poll result to the Nexus A2A binding page."""
+
+    source_closed = result.closed if closed is None else closed
+    return SubscribeToTaskOutput(
+        items=[
+            SubscribeToTaskItem(
+                offset=item.offset,
+                data=base64.b64encode(
+                    stream_response(item.data).SerializeToString()
+                ).decode(),
+            )
+            for item in result.items
+        ],
+        next_cursor=result.next_offset,
+        more_ready=result.more_ready,
+        closed=source_closed and not result.more_ready,
+    )
+
+
+@nexusrpc.service(name="A2AService")
+class A2AService:
+    """A2A v1 methods exposed through a Temporal Nexus endpoint."""
+
+    send_message = nexusrpc.Operation(
+        "SendMessage", SendMessageRequest, SendMessageResponse
+    )
+    get_task = nexusrpc.Operation("GetTask", GetTaskRequest, Task)
+    list_tasks = nexusrpc.Operation("ListTasks", ListTasksRequest, ListTasksResponse)
+    cancel_task = nexusrpc.Operation("CancelTask", CancelTaskRequest, Task)
+    subscribe_to_task = nexusrpc.Operation(
+        "SubscribeToTask", SubscribeToTaskInput, SubscribeToTaskOutput
+    )
+    get_extended_agent_card = nexusrpc.Operation(
+        "GetExtendedAgentCard", GetExtendedAgentCardRequest, AgentCard
+    )

--- a/temporal_agent_harness/ai_sdks/openai_agents/_nexus_mcp.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_nexus_mcp.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from agents.mcp import MCPServer
-from pydantic import BaseModel, create_model
 from temporalio import workflow
 
 if TYPE_CHECKING:
@@ -27,7 +26,7 @@ _INSTALL_MESSAGE = (
 
 try:
     with workflow.unsafe.imports_passed_through():
-        from transport.workflow_transport import WorkflowTransport, _coerce_call_tool_result
+        from a2a.types import AgentCard
         from durable_tools_gateway.generated import (
             CallToolInput,
             CallToolInputArguments,
@@ -35,7 +34,29 @@ try:
             RegistryService,
             ResolveAccountToolboxInput,
         )
-        from durable_tools_gateway.resources import ResourceDescriptor, descriptor_from_dict
+        from durable_tools_gateway.resources import (
+            ResourceDescriptor,
+            descriptor_from_dict,
+        )
+        from temporal_agent_harness.harness.agent_protocol import (
+            TextMessage,
+            TextReply,
+        )
+        from temporal_agent_harness.harness.subagent_gateway_transport import (
+            GatewayTransport,
+        )
+        from temporal_agent_harness.harness.subagent_nexus_transport import (
+            NexusTransport,
+        )
+        from temporal_agent_harness.harness.subagent_toolset import (
+            declared_handler,
+            subagent_toolset,
+        )
+        from google.protobuf.json_format import ParseDict
+        from transport.workflow_transport import (
+            WorkflowTransport,
+            _coerce_call_tool_result,
+        )
 except ModuleNotFoundError as exc:
     raise RuntimeError(_INSTALL_MESSAGE) from exc
 
@@ -44,7 +65,9 @@ def _error_result(exc: Exception) -> CallToolResult:
     """Wrap a caught exception as an isError=True CallToolResult."""
     from mcp import types
 
-    return types.CallToolResult(content=[types.TextContent(type="text", text=str(exc))], isError=True)
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=str(exc))], isError=True
+    )
 
 
 class _BaseNexusMCPServer(MCPServer):  # type: ignore[misc]
@@ -95,11 +118,16 @@ class _NexusTransportMCPServer(_BaseNexusMCPServer):
     def name(self) -> str:
         return self._transport.name
 
-    async def list_tools(self, run_context: Any = None, agent: Any = None) -> list[MCPTool]:
+    async def list_tools(
+        self, run_context: Any = None, agent: Any = None
+    ) -> list[MCPTool]:
         return await self._transport.list_tools()
 
     async def call_tool(
-        self, tool_name: str, arguments: dict[str, Any] | None, meta: dict[str, Any] | None = None
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
     ) -> CallToolResult:
         return await self._transport.call_tool(tool_name, arguments, meta)
 
@@ -124,7 +152,9 @@ class NexusGateway:
         single Nexus call. An alias that isn't actually registered is silently skipped
         for now (no error handling yet -- this is a prototype).
         """
-        display_name = f"{self._account_id}-{self._gateway_name}-{self._gateway_endpoint}"
+        display_name = (
+            f"{self._account_id}-{self._gateway_name}-{self._gateway_endpoint}"
+        )
         return _NexusGatewayMCPServer(
             self._account_id,
             frozenset(aliases),
@@ -176,66 +206,22 @@ class ResolvedAccountToolbox:
     subagent_tools: tuple[Any, ...]
 
 
-def _schema_type(schema: dict[str, Any], name: str) -> Any:
-    kind = schema.get("type")
-    if kind == "string":
-        return str
-    if kind == "integer":
-        return int
-    if kind == "number":
-        return float
-    if kind == "boolean":
-        return bool
-    if kind == "array":
-        return list[_schema_type(schema.get("items", {}), f"{name}Item")]
-    if kind == "object":
-        properties = schema.get("properties", {})
-        required = set(schema.get("required", []))
-        fields: dict[str, Any] = {}
-        for field_name, field_schema in properties.items():
-            annotation = _schema_type(field_schema, f"{name}{field_name.title()}")
-            fields[field_name] = (
-                (annotation, ...)
-                if field_name in required
-                else (annotation | None, None)
-            )
-        return create_model(name, **fields)
-    return Any
-
-
 def _declared_handlers(
     resource: ResourceDescriptor,
 ) -> list[Any]:
-    from temporal_agent_harness.harness.subagent_toolset import declared_handler
-
-    result = []
-    for handler in resource.handlers:
-        input_type = _schema_type(
-            handler.input_schema,
-            f"{resource.resource_id.title().replace('-', '')}{handler.name.title()}Input",
+    if resource.agent_card is None:
+        raise ValueError(f"agent {resource.resource_id!r} has no A2A AgentCard")
+    card = ParseDict(resource.agent_card, AgentCard())
+    return [
+        declared_handler(
+            skill.id,
+            skill.description,
+            TextMessage,
+            TextReply,
+            param_name="message",
         )
-        output_type = _schema_type(
-            handler.output_schema,
-            f"{resource.resource_id.title().replace('-', '')}{handler.name.title()}Output",
-        )
-        if not isinstance(input_type, type) or not issubclass(input_type, BaseModel):
-            raise TypeError(
-                f"{resource.resource_id}.{handler.name} input must be an object"
-            )
-        if not isinstance(output_type, type) or not issubclass(output_type, BaseModel):
-            raise TypeError(
-                f"{resource.resource_id}.{handler.name} output must be an object"
-            )
-        result.append(
-            declared_handler(
-                handler.name,
-                handler.description,
-                input_type,
-                output_type,
-                param_name=handler.param_name,
-            )
-        )
-    return result
+        for skill in card.skills
+    ]
 
 
 def _materialize_toolbox(
@@ -246,12 +232,6 @@ def _materialize_toolbox(
     gateway_endpoint: str,
     version: str,
 ) -> ResolvedAccountToolbox:
-    from temporal_agent_harness.harness.subagent_gateway_transport import (
-        GatewayTransport,
-    )
-    from temporal_agent_harness.harness.subagent_nexus_transport import NexusTransport
-    from temporal_agent_harness.harness.subagent_toolset import subagent_toolset
-
     mcp_servers: list[MCPServer] = []
     subagent_tools: list[Any] = []
     external_mcp_aliases: list[str] = []
@@ -332,14 +312,17 @@ class _NexusGatewayMCPServer(_BaseNexusMCPServer):
     def name(self) -> str:
         return self._display_name
 
-    async def list_tools(self, run_context: Any = None, agent: Any = None) -> list[MCPTool]:
+    async def list_tools(
+        self, run_context: Any = None, agent: Any = None
+    ) -> list[MCPTool]:
         from mcp import types
 
         gateway_client = workflow.create_nexus_client(
             service=self._gateway_name, endpoint=self._gateway_endpoint
         )
         entries = await gateway_client.execute_operation(
-            RegistryService.list_account_entries, ListAccountEntriesInput(account_id=self._account_id)
+            RegistryService.list_account_entries,
+            ListAccountEntriesInput(account_id=self._account_id),
         )
         # nex-gen wraps map-shaped (additionalProperties) fields in a named type instead
         # of a plain dict.
@@ -361,17 +344,22 @@ class _NexusGatewayMCPServer(_BaseNexusMCPServer):
         return [types.Tool(**d) for d in tool_dicts]
 
     async def call_tool(
-        self, tool_name: str, arguments: dict[str, Any] | None, meta: dict[str, Any] | None = None
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
     ) -> CallToolResult:
         from mcp import types
 
         alias = self._remote_routes.get(tool_name)
         if alias is None:
             return types.CallToolResult(
-                content=[types.TextContent(
-                    type="text",
-                    text=f"Unknown tool {tool_name!r} for account {self._account_id!r}.",
-                )],
+                content=[
+                    types.TextContent(
+                        type="text",
+                        text=f"Unknown tool {tool_name!r} for account {self._account_id!r}.",
+                    )
+                ],
                 isError=True,
             )
 
@@ -386,7 +374,9 @@ class _NexusGatewayMCPServer(_BaseNexusMCPServer):
                     alias=alias,
                     name=tool_name,
                     caller_workflow_id=workflow.info().workflow_id,
-                    arguments=CallToolInputArguments(additional_properties=arguments or {}),
+                    arguments=CallToolInputArguments(
+                        additional_properties=arguments or {}
+                    ),
                 ),
             )
             result = (

--- a/temporal_agent_harness/harness/agent_workflow.py
+++ b/temporal_agent_harness/harness/agent_workflow.py
@@ -120,6 +120,14 @@ from temporal_agent_harness.harness.stream_poll import (
     bounded_poll_result,
     replay_stream_state,
 )
+with workflow.unsafe.imports_passed_through():
+    from temporal_agent_harness.a2a.nexus import (
+        A2A_STREAM_POLL_UPDATE,
+        A2A_STREAM_REPLAY_QUERY,
+        SubscribeToTaskInput,
+        SubscribeToTaskOutput,
+        subscription_page,
+    )
 
 # ParamSpec/return-type vars for the tool decorators. They let each be typed as an
 # identity over the wrapped callable (``Callable[P, Awaitable[R]] -> Callable[P,
@@ -1434,9 +1442,17 @@ class AgentWorkflowRunner:
             AGENT_STREAM_POLL_UPDATE,
             self._handle_stream_poll,
         )
+        workflow.set_update_handler(
+            A2A_STREAM_POLL_UPDATE,
+            self._handle_a2a_stream_poll,
+        )
         workflow.set_query_handler(
             AGENT_STREAM_REPLAY_QUERY,
             self._handle_stream_replay,
+        )
+        workflow.set_query_handler(
+            A2A_STREAM_REPLAY_QUERY,
+            self._handle_a2a_stream_replay,
         )
         workflow.set_query_handler(AGENT_STATUS_QUERY, self._handle_agent_status)
         workflow.set_query_handler(AGENT_INTERFACE_QUERY, self._handle_agent_interface)
@@ -2069,6 +2085,30 @@ class AgentWorkflowRunner:
     def _handle_stream_replay(self, input: AgentStreamPollInput) -> AgentStreamPollResult:
         """Read a bounded stream page through a query, including after completion."""
         return replay_stream_state(self._stream.get_state(), input)
+
+    async def _handle_a2a_stream_poll(
+        self, input: SubscribeToTaskInput
+    ) -> SubscribeToTaskOutput:
+        result = await self._handle_stream_poll(
+            AgentStreamPollInput(
+                from_offset=input.cursor,
+                topics=[TURN_EVENTS_TOPIC],
+                timeout_seconds=input.timeout_seconds,
+            )
+        )
+        return subscription_page(result)
+
+    def _handle_a2a_stream_replay(
+        self, input: SubscribeToTaskInput
+    ) -> SubscribeToTaskOutput:
+        result = self._handle_stream_replay(
+            AgentStreamPollInput(
+                from_offset=input.cursor,
+                topics=[TURN_EVENTS_TOPIC],
+                timeout_seconds=input.timeout_seconds,
+            )
+        )
+        return subscription_page(result, closed=True)
 
     # -- Turn loop ----------------------------------------------------------
 

--- a/temporal_agent_harness/harness/subagent_gateway_transport.py
+++ b/temporal_agent_harness/harness/subagent_gateway_transport.py
@@ -1,4 +1,4 @@
-# ABOUTME: Transport for an HTTP subagent reached through the Durable Tools Gateway.
+# ABOUTME: A2A transport for an HTTP agent routed by the account gateway.
 
 from __future__ import annotations
 
@@ -8,6 +8,11 @@ from typing import Any
 
 from temporalio import workflow
 
+with workflow.unsafe.imports_passed_through():
+    from a2a.types import CancelTaskRequest, Message, Part, Role, SendMessageRequest
+    from google.protobuf.json_format import MessageToDict
+
+    from temporal_agent_harness.a2a.nexus import A2AService
 from temporal_agent_harness.harness.agent_protocol import (
     AgentConfig,
     SubagentMessageSent,
@@ -16,54 +21,29 @@ from temporal_agent_harness.harness.agent_protocol import (
 from temporal_agent_harness.harness.agent_workflow import _current_runner
 from temporal_agent_harness.harness.stream_context import TurnStreamContext
 
-_INSTALL_MESSAGE = (
-    "Gateway-brokered subagent support requires the optional `nexus-mcp` extra, which is "
-    "only resolvable from an editable checkout of this repo (it path-depends on nexus/mcp) "
-    "and requires Python >=3.13. Install it with `uv sync --extra nexus-mcp`."
-)
-
-try:
-    with workflow.unsafe.imports_passed_through():
-        from durable_tools_gateway.generated import (
-            DispatchSubagentTurnInput,
-            RegistryService,
-            StartSubagentInput,
-            StopSubagentInput,
-        )
-except ModuleNotFoundError as exc:
-    raise RuntimeError(_INSTALL_MESSAGE) from exc
-
 
 class GatewayTransport:
-    """Reach a registered HTTP subagent through the Durable Tools Gateway.
-
-    The alias identifies a provider. Each ``start`` call creates an instance.
-    """
+    """Route A2A over Nexus to an account-registered HTTP A2A agent."""
 
     def __init__(
         self,
         account_id: str,
         alias: str,
-        gateway_name: str = "RegistryService",
+        gateway_name: str = "A2AService",
         gateway_endpoint: str = "mcp-registry-endpoint",
     ) -> None:
         self._account_id = account_id
         self._alias = alias
-        self._gateway_name = gateway_name
         self._gateway_endpoint = gateway_endpoint
 
-    def _client(self) -> workflow.NexusClient[Any]:
+    def _client(self) -> workflow.NexusClient[A2AService]:
         return workflow.create_nexus_client(
-            service=self._gateway_name, endpoint=self._gateway_endpoint
+            service=A2AService, endpoint=self._gateway_endpoint
         )
 
     async def start(self, *, agent_key: str, config: AgentConfig) -> str:
-        out = await self._client().execute_operation(
-            RegistryService.start_subagent,
-            StartSubagentInput(account_id=self._account_id, alias=self._alias),
-            schedule_to_close_timeout=timedelta(minutes=1),
-        )
-        return out.instance_id
+        # A2A tasks are started lazily by their first Message.
+        return f"{agent_key}-subagent-{workflow.uuid4()}"
 
     async def dispatch(
         self,
@@ -78,41 +58,56 @@ class GatewayTransport:
         parent_stream_context: TurnStreamContext,
     ) -> SubagentTurnResult:
         out = await self._client().execute_operation(
-            RegistryService.dispatch_subagent_turn,
-            DispatchSubagentTurnInput(
-                account_id=self._account_id,
-                instance_id=target,
-                msg_type=msg_type,
-                payload=json.dumps(payload),
-                expected_turn=expected_turn,
+            A2AService.send_message,
+            SendMessageRequest(
+                message=Message(
+                    message_id=str(workflow.uuid4()),
+                    task_id=target,
+                    context_id=target,
+                    role=Role.ROLE_USER,
+                    parts=[Part(text=str(payload.get("text", "")))],
+                    metadata={"temporal.io/message-type": msg_type},
+                ),
+                metadata={
+                    "account_id": self._account_id,
+                    "agent_id": self._alias,
+                    "expected_turn": expected_turn,
+                },
             ),
             schedule_to_close_timeout=timedelta(minutes=6),
         )
-        # Publish only after the gateway returns a reply.
+        metadata = MessageToDict(out.task.metadata, preserving_proto_field_name=True)
+        turn_number = int(metadata["temporal.io/turn-number"])
+        turn_id = str(metadata["temporal.io/turn-id"])
+        text = "".join(
+            part.text
+            for artifact in out.task.artifacts
+            for part in artifact.parts
+            if part.HasField("text")
+        )
         _current_runner().publish(
             SubagentMessageSent(
                 subagent_id=handle,
                 agent_key=agent_key,
                 workflow_id=target,
                 function=msg_type,
-                subagent_turn=out.turn_number,
+                subagent_turn=turn_number,
                 from_offset=from_offset,
             )
         )
         return SubagentTurnResult(
-            output=json.loads(out.output),
-            turn_id=out.turn_id,
-            turn_number=out.turn_number,
-            # This transport has no remote stream cursor.
+            output={"text": text},
+            turn_id=turn_id,
+            turn_number=turn_number,
             consumed_offset=from_offset,
         )
 
     async def stop(self, *, target: str) -> None:
         await self._client().execute_operation(
-            RegistryService.stop_subagent,
-            StopSubagentInput(
-                account_id=self._account_id,
-                instance_id=target,
+            A2AService.cancel_task,
+            CancelTaskRequest(
+                id=target,
+                metadata={"account_id": self._account_id, "agent_id": self._alias},
             ),
             schedule_to_close_timeout=timedelta(minutes=1),
         )

--- a/temporal_agent_harness/harness/subagent_nexus_transport.py
+++ b/temporal_agent_harness/harness/subagent_nexus_transport.py
@@ -1,15 +1,31 @@
-# ABOUTME: Transport for a harness subagent reached directly through Nexus.
+# ABOUTME: A2A transport for a harness subagent reached directly through Nexus.
 
 from __future__ import annotations
 
 import base64
-import json
 from typing import Any
 
 from temporalio import workflow
 from temporalio.api.common.v1 import Payload
 from temporalio.exceptions import ApplicationError
 
+with workflow.unsafe.imports_passed_through():
+    from a2a.types import (
+        CancelTaskRequest,
+        Message,
+        Part,
+        Role,
+        SendMessageRequest,
+        StreamResponse,
+    )
+    from google.protobuf.json_format import MessageToDict
+
+    from temporal_agent_harness.a2a.nexus import (
+        A2AService,
+        HARNESS_EVENT_METADATA_KEY,
+        SubscribeToTaskInput,
+        SubscribeToTaskItem,
+    )
 from temporal_agent_harness.harness.agent_protocol import (
     AgentConfig,
     AgentEvent,
@@ -19,42 +35,38 @@ from temporal_agent_harness.harness.agent_protocol import (
 )
 from temporal_agent_harness.harness.agent_workflow import _current_runner
 from temporal_agent_harness.harness.stream_context import TurnStreamContext
-from temporal_agent_harness.nexus_agent_adapter.generated import (
-    AgentService,
-    PollMessagesInput,
-    QuerySessionInput,
-    SendAgentMessageInput,
-)
 
-# Requested wait for one poll request.
 POLL_TIMEOUT_SECONDS = 25.0
 
 
-def _decode_stream_item(data: str) -> AgentEvent:
-    """Decode an event from a base64-encoded Temporal payload."""
+def _decode_stream_item(item: SubscribeToTaskItem) -> AgentEvent:
+    """Recover the rich harness event carried as an A2A extension."""
+
+    response = StreamResponse()
+    response.ParseFromString(base64.b64decode(item.data))
+    body = response.WhichOneof("payload")
+    if body is None:
+        raise ValueError("A2A StreamResponse has no payload")
+    metadata = MessageToDict(
+        getattr(response, body).metadata, preserving_proto_field_name=True
+    )
+    encoded_payload = str(metadata[HARNESS_EVENT_METADATA_KEY])
     payload = Payload()
-    payload.ParseFromString(base64.b64decode(data))
+    payload.ParseFromString(base64.b64decode(encoded_payload))
     return workflow.payload_converter().from_payload(payload, AgentEvent)
 
 
 class NexusTransport:
-    """Reach a harness subagent through its Nexus AgentService endpoint.
-
-    The target service creates its own ``AgentConfig``. It cannot use the parent handle as
-    the remote agent ID. A client therefore cannot join the two streams by agent ID.
-    """
+    """Reach a harness subagent through the A2A Nexus protocol binding."""
 
     def __init__(self, endpoint: str) -> None:
         self._endpoint = endpoint
         self._start_configs: dict[str, AgentConfig] = {}
 
-    def _client(self) -> workflow.NexusClient[AgentService]:
-        return workflow.create_nexus_client(
-            service=AgentService, endpoint=self._endpoint
-        )
+    def _client(self) -> workflow.NexusClient[A2AService]:
+        return workflow.create_nexus_client(service=A2AService, endpoint=self._endpoint)
 
     async def start(self, *, agent_key: str, config: AgentConfig) -> str:
-        # The first message starts or reuses the target workflow.
         target = f"{agent_key}-subagent-{workflow.uuid4()}"
         self._start_configs[target] = config
         return target
@@ -71,40 +83,52 @@ class NexusTransport:
         agent_key: str,
         parent_stream_context: TurnStreamContext,
     ) -> SubagentTurnResult:
+        config = self._start_configs.get(target, AgentConfig())
+        context: dict[str, Any] = {"expected_turn": expected_turn}
+        if config.account_id is not None:
+            context["account_id"] = config.account_id
+        if config.registered_agent_id is not None:
+            context["registered_agent_id"] = config.registered_agent_id
+        if config.delegation_lineage is not None:
+            context["delegation_lineage"] = list(config.delegation_lineage)
+        if config.delegation_depth is not None:
+            context["delegation_depth"] = config.delegation_depth
+        if config.max_delegation_depth is not None:
+            context["max_delegation_depth"] = config.max_delegation_depth
+
         try:
-            config = self._start_configs.get(target, AgentConfig())
-            context: dict[str, Any] = {}
-            if config.account_id is not None:
-                context["account_id"] = config.account_id
-            if config.registered_agent_id is not None:
-                context["registered_agent_id"] = config.registered_agent_id
-            if config.delegation_lineage is not None:
-                context["delegation_lineage"] = list(config.delegation_lineage)
-            if config.delegation_depth is not None:
-                context["delegation_depth"] = config.delegation_depth
-            if config.max_delegation_depth is not None:
-                context["max_delegation_depth"] = config.max_delegation_depth
             sent = await self._client().execute_operation(
-                AgentService.send_agent_message,
-                SendAgentMessageInput(
-                    session_id=target,
-                    msg_type=msg_type,
-                    payload=json.dumps(payload),
-                    expected_turn=expected_turn,
-                    **context,
+                A2AService.send_message,
+                SendMessageRequest(
+                    message=Message(
+                        message_id=str(workflow.uuid4()),
+                        task_id=target,
+                        context_id=target,
+                        role=Role.ROLE_USER,
+                        parts=[Part(text=str(payload.get("text", "")))],
+                        metadata={
+                            "temporal.io/message-type": msg_type,
+                            "temporal.io/payload": payload,
+                        },
+                    ),
+                    metadata=context,
                 ),
             )
         except Exception as exc:
             raise _rejection_error(exc) from exc
 
-        # Publish after Nexus accepts the message.
+        sent_metadata = MessageToDict(
+            sent.task.metadata, preserving_proto_field_name=True
+        )
+        turn_number = int(sent_metadata["temporal.io/turn-number"])
+        turn_id = str(sent_metadata["temporal.io/turn-id"])
         _current_runner().publish(
             SubagentMessageSent(
                 subagent_id=handle,
                 agent_key=agent_key,
                 workflow_id=target,
                 function=msg_type,
-                subagent_turn=sent.turn_number,
+                subagent_turn=turn_number,
                 from_offset=from_offset,
             )
         )
@@ -113,30 +137,30 @@ class NexusTransport:
         output: dict[str, Any] = {}
         while True:
             poll = await self._client().execute_operation(
-                AgentService.poll_messages,
-                PollMessagesInput(
-                    session_id=target,
+                A2AService.subscribe_to_task,
+                SubscribeToTaskInput(
+                    id=target,
                     cursor=cursor,
                     timeout_seconds=POLL_TIMEOUT_SECONDS,
                 ),
             )
             if poll.closed:
                 raise ApplicationError(
-                    f"subagent {target!r} closed before turn {sent.turn_number} replied",
-                    {"subagent_turn": sent.turn_number},
+                    f"subagent {target!r} closed before turn {turn_number} replied",
+                    {"subagent_turn": turn_number},
                     type="SubagentNoReply",
                     non_retryable=True,
                 )
             for item in poll.items:
                 cursor = item.offset + 1
-                event = _decode_stream_item(item.data)
-                if event.turn_id != sent.turn_id:
+                event = _decode_stream_item(item)
+                if event.turn_id != turn_id:
                     continue
                 envelope = event.event
                 if envelope.type == AgentEventType.ERROR:
                     raise ApplicationError(
                         envelope.message or "subagent turn failed",
-                        {"subagent_turn": sent.turn_number},
+                        {"subagent_turn": turn_number},
                         type="SubagentTurnError",
                         non_retryable=True,
                     )
@@ -145,20 +169,19 @@ class NexusTransport:
                 if envelope.type == AgentEventType.TURN_END:
                     return SubagentTurnResult(
                         output=output,
-                        turn_id=sent.turn_id,
-                        turn_number=sent.turn_number,
+                        turn_id=turn_id,
+                        turn_number=turn_number,
                         consumed_offset=cursor,
                     )
 
     async def stop(self, *, target: str) -> None:
         await self._client().execute_operation(
-            AgentService.close_session, QuerySessionInput(session_id=target)
+            A2AService.cancel_task, CancelTaskRequest(id=target)
         )
         self._start_configs.pop(target, None)
 
 
 def _rejection_error(exc: Exception) -> ApplicationError:
-    """Map a Nexus rejection to the transport-independent error type."""
     message = str(exc)
     if message.startswith("StaleTurn: "):
         return ApplicationError(message, type="StaleTurn", non_retryable=True)

--- a/temporal_agent_harness/nexus_agent_adapter/handler.py
+++ b/temporal_agent_harness/nexus_agent_adapter/handler.py
@@ -1,67 +1,40 @@
-# ABOUTME: Python implementation of the AgentService Nexus handler.
-#
-# Replaces a Go handler (see git history) that only existed because pollMessages needs
-# update-with-callback, unsupported in Python until sdk-python#1631. All operations except
-# pollMessages just delegate to AgentClient (see _agent_client).
+"""Harness-specific Nexus controls that intentionally sit outside A2A."""
 
 from __future__ import annotations
 
-import asyncio
 import json
 from dataclasses import dataclass
 
 from nexusrpc import HandlerError, HandlerErrorType
 from nexusrpc.handler import StartOperationContext, service_handler, sync_operation
-from temporalio import nexus
 from temporalio.client import Client
 from temporalio.service import RPCError
 
+from temporal_agent_harness.a2a.control import HarnessControlService
 from temporal_agent_harness.harness.agent_client import (
     AgentClient,
     CallbackResultError,
-    StaleTurnError,
     ToolApprovalError,
 )
 from temporal_agent_harness.harness.agent_protocol import (
-    TURN_EVENTS_TOPIC,
-    AgentConfig,
     OperatorCommand,
     PendingCallback,
     PendingTurn,
     SubagentInfo,
     ToolApprovalPolicy,
 )
-from temporal_agent_harness.harness.stream_poll import (
-    AGENT_STREAM_POLL_UPDATE,
-    AGENT_STREAM_REPLAY_QUERY,
-    AgentStreamPollInput,
-    AgentStreamPollResult,
-)
 
-# Aliased with a Nexus* prefix where the name collides with an agent_protocol type of the
-# same name but a different (reshaped, wire-friendly) shape.
 from .generated import (
-    AcceptedFunction as NexusAcceptedFunction,
-)
-from .generated import (
-    AgentInterfaceOutput,
     AgentStatusOutput,
     ApproveToolCallInput,
     ApproveToolCallOutput,
-    CloseSessionOutput,
     ExecuteOperatorCommandInput,
     ExecuteOperatorCommandOutput,
-    PollMessagesInput,
-    PollMessagesOutput,
     ProvideCallbackResultInput,
     ProvideCallbackResultOutput,
     QueryOperatorInterfaceOutput,
     QuerySessionInput,
-    SendAgentMessageInput,
-    SendMessageOutput,
-    StreamItem,
 )
-from .generated import AgentService as AgentServiceDefinition
 from .generated import (
     ApprovalPolicy as NexusApprovalPolicy,
 )
@@ -84,31 +57,21 @@ from .generated import (
     SubagentInfo as NexusSubagentInfo,
 )
 
-DEFAULT_POLL_TIMEOUT_SECONDS = 30.0
-_MAX_SEND_RETRIES = 5
-
-
-def _is_workflow_already_completed(exc: Exception) -> bool:
-    """True when the target agent workflow has already finished (see poll_messages)."""
-    return "already completed" in str(exc).lower()
-
 
 def _is_workflow_not_found(exc: Exception) -> bool:
-    """True when a registry entry outlives its backing Temporal workflow."""
     message = str(exc).lower()
     return "workflow not found" in message or "not found for id" in message
 
 
 def _nexus_operator_command(cmd: OperatorCommand) -> NexusOperatorCommand:
-    # nex-gen models reject an optional field set to None — omit the kwarg instead.
     argument_kwargs: dict[str, object] = {}
     if cmd.argument is not None:
-        arg_kwargs: dict[str, object] = dict(
-            kind=cmd.argument.kind,
-            required=cmd.argument.required,
-            choices=list(cmd.argument.choices),
-            allow_multiple=cmd.argument.allow_multiple,
-        )
+        arg_kwargs: dict[str, object] = {
+            "kind": cmd.argument.kind,
+            "required": cmd.argument.required,
+            "choices": list(cmd.argument.choices),
+            "allow_multiple": cmd.argument.allow_multiple,
+        }
         if cmd.argument.placeholder is not None:
             arg_kwargs["placeholder"] = cmd.argument.placeholder
         argument_kwargs["argument"] = NexusOperatorCommandArgument(**arg_kwargs)
@@ -121,153 +84,54 @@ def _nexus_operator_command(cmd: OperatorCommand) -> NexusOperatorCommand:
     )
 
 
-def _nexus_pending_callback(pc: PendingCallback) -> NexusPendingCallback:
+def _nexus_pending_callback(value: PendingCallback) -> NexusPendingCallback:
     return NexusPendingCallback(
-        tool_id=pc.tool_id,
-        tool_name=pc.tool_name,
-        tool_input=json.dumps(pc.tool_input),
-        output_schema=json.dumps(pc.output_schema),
-        turn_number=pc.turn_number,
+        tool_id=value.tool_id,
+        tool_name=value.tool_name,
+        tool_input=json.dumps(value.tool_input),
+        output_schema=json.dumps(value.output_schema),
+        turn_number=value.turn_number,
     )
 
 
-def _nexus_pending_turn(pt: PendingTurn) -> NexusPendingTurn:
+def _nexus_pending_turn(value: PendingTurn) -> NexusPendingTurn:
     return NexusPendingTurn(
-        turn_number=pt.turn_number, turn_id=pt.turn_id, message=pt.message
+        turn_number=value.turn_number, turn_id=value.turn_id, message=value.message
     )
 
 
-def _nexus_subagent_info(info: SubagentInfo) -> NexusSubagentInfo:
+def _nexus_subagent_info(value: SubagentInfo) -> NexusSubagentInfo:
     return NexusSubagentInfo(
-        subagent_id=info.subagent_id,
-        agent_key=info.agent_key,
-        workflow_id=info.workflow_id,
-        next_expected_turn=info.next_expected_turn,
+        subagent_id=value.subagent_id,
+        agent_key=value.agent_key,
+        workflow_id=value.workflow_id,
+        next_expected_turn=value.next_expected_turn,
     )
 
 
-def _nexus_approval_policy(policy: ToolApprovalPolicy) -> NexusApprovalPolicy:
+def _nexus_approval_policy(value: ToolApprovalPolicy) -> NexusApprovalPolicy:
     return NexusApprovalPolicy(
-        dangerously_skip_all_approvals=policy.dangerously_skip_all_approvals,
-        auto_approve_inherently_safe=policy.auto_approve_inherently_safe,
-        auto_approve_tools=list(policy.auto_approve_tools),
+        dangerously_skip_all_approvals=value.dangerously_skip_all_approvals,
+        auto_approve_inherently_safe=value.auto_approve_inherently_safe,
+        auto_approve_tools=list(value.auto_approve_tools),
     )
 
 
 @dataclass(frozen=True)
-class Config:
-    """Per-deployment settings for AgentServiceHandler."""
-
-    agent_task_queue: str
-    workflow_name: str
-    workflow_id_prefix: str
-    is_message_queuing_enabled: bool
+class HarnessControlConfig:
+    workflow_id_prefix: str = ""
 
 
-@service_handler(service=AgentServiceDefinition)
-class AgentServiceHandler:
-    """Exposes an agent session to external callers (e.g. the Slack connector).
+@service_handler(service=HarnessControlService)
+class HarnessControlServiceHandler:
+    """Approval, callback, status, and operator controls for harness-aware UIs."""
 
-    The connector calls ``sendAgentMessage`` to deliver user input and ``pollMessages`` to
-    consume the agent's response stream.
-    """
-
-    def __init__(self, client: Client, config: Config) -> None:
+    def __init__(self, client: Client, config: HarnessControlConfig) -> None:
         self._client = client
         self._config = config
 
-    def _workflow_id(self, session_id: str) -> str:
-        return self._config.workflow_id_prefix + session_id
-
     def _agent_client(self, session_id: str) -> AgentClient:
-        """Cheap to construct per-call. Every operation but pollMessages delegates to it."""
-        return AgentClient(self._client, self._workflow_id(session_id))
-
-    # -----------------------------------------------------------------------
-    # sendAgentMessage — AgentClient.start_and_submit_message()'s guess-and-retry caller
-    # -----------------------------------------------------------------------
-
-    @sync_operation
-    async def send_agent_message(
-        self, ctx: StartOperationContext, input: SendAgentMessageInput
-    ) -> SendMessageOutput:
-        try:
-            payload = json.loads(input.payload)
-        except json.JSONDecodeError as e:
-            raise HandlerError(
-                f"invalid payload JSON: {e}", type=HandlerErrorType.BAD_REQUEST
-            ) from e
-
-        start_config = AgentConfig(
-            is_message_queuing_enabled=self._config.is_message_queuing_enabled,
-            account_id=input.account_id,
-            registered_agent_id=input.registered_agent_id,
-            delegation_lineage=(
-                tuple(input.delegation_lineage)
-                if input.delegation_lineage is not None
-                else None
-            ),
-            delegation_depth=input.delegation_depth,
-            max_delegation_depth=input.max_delegation_depth,
-        )
-        client = self._agent_client(input.session_id)
-
-        if input.expected_turn is not None:
-            # Use the caller's turn number. Reuse the update ID on a Nexus retry.
-            try:
-                reply = await client.start_and_submit_message(
-                    input.msg_type,
-                    payload,
-                    input.expected_turn,
-                    workflow_name=self._config.workflow_name,
-                    task_queue=self._config.agent_task_queue,
-                    start_config=start_config,
-                    update_id=f"send-{ctx.request_id}",
-                )
-            except StaleTurnError as e:
-                raise HandlerError(
-                    f"StaleTurn: {e}", type=HandlerErrorType.BAD_REQUEST
-                ) from e
-            return SendMessageOutput(
-                turn_number=reply.turn_number,
-                turn_id=reply.turn_id,
-                stream_head_offset=reply.accepted_offset,
-                pending=reply.pending,
-            )
-
-        # Nexus callers don't know expected_turn; guess 1, then re-derive from status on retry.
-        expected_turn = 1
-        for attempt in range(_MAX_SEND_RETRIES):
-            if attempt > 0:
-                status = await client.get_status()
-                expected_turn = status.current_turn + len(status.pending_turns) + 1
-
-            try:
-                reply = await client.start_and_submit_message(
-                    input.msg_type,
-                    payload,
-                    expected_turn,
-                    workflow_name=self._config.workflow_name,
-                    task_queue=self._config.agent_task_queue,
-                    start_config=start_config,
-                    update_id=f"send-{ctx.request_id}-{attempt}",
-                )
-            except StaleTurnError:
-                await asyncio.sleep((attempt + 1) * 0.05)
-                continue
-            return SendMessageOutput(
-                turn_number=reply.turn_number,
-                turn_id=reply.turn_id,
-                stream_head_offset=reply.accepted_offset,
-                pending=reply.pending,
-            )
-        raise HandlerError(
-            "send_agent_message: exhausted retries", type=HandlerErrorType.INTERNAL
-        )
-
-    # -----------------------------------------------------------------------
-    # executeOperatorCommand — harness-level operator commands (no turn)
-    # -----------------------------------------------------------------------
+        return AgentClient(self._client, self._config.workflow_id_prefix + session_id)
 
     @sync_operation
     async def execute_operator_command(
@@ -277,10 +141,6 @@ class AgentServiceHandler:
             input.name, arg=input.arg, update_id=f"op-{ctx.request_id}"
         )
         return ExecuteOperatorCommandOutput(reply=result.text)
-
-    # -----------------------------------------------------------------------
-    # approveToolCall — resolve a pending tool-approval gate
-    # -----------------------------------------------------------------------
 
     @sync_operation
     async def approve_tool_call(
@@ -294,65 +154,29 @@ class AgentServiceHandler:
                 remember=input.remember or False,
                 update_id=f"approve-{ctx.request_id}",
             )
-        except ToolApprovalError as e:
-            raise HandlerError(
-                str(e), type=HandlerErrorType.BAD_REQUEST
-            ) from e  # caller's fault
+        except ToolApprovalError as exc:
+            raise HandlerError(str(exc), type=HandlerErrorType.BAD_REQUEST) from exc
         return ApproveToolCallOutput(tool_id=result.tool_id, accepted=result.accepted)
-
-    # -----------------------------------------------------------------------
-    # queryOperatorInterface — discover available slash commands
-    # -----------------------------------------------------------------------
 
     @sync_operation
     async def query_operator_interface(
-        self, ctx: StartOperationContext, input: QuerySessionInput
+        self, _ctx: StartOperationContext, input: QuerySessionInput
     ) -> QueryOperatorInterfaceOutput:
         try:
             commands = await self._agent_client(
                 input.session_id
             ).get_operator_interface()
-        except RPCError as e:
-            if _is_workflow_not_found(e):
+        except RPCError as exc:
+            if _is_workflow_not_found(exc):
                 return QueryOperatorInterfaceOutput(commands=[])
             raise
         return QueryOperatorInterfaceOutput(
-            commands=[_nexus_operator_command(cmd) for cmd in commands]
+            commands=[_nexus_operator_command(command) for command in commands]
         )
-
-    # -----------------------------------------------------------------------
-    # queryAgentInterface — discover @agent.accepts handlers
-    # -----------------------------------------------------------------------
-
-    @sync_operation
-    async def query_agent_interface(
-        self, ctx: StartOperationContext, input: QuerySessionInput
-    ) -> AgentInterfaceOutput:
-        try:
-            functions = await self._agent_client(input.session_id).get_agent_interface()
-        except RPCError as e:
-            if _is_workflow_not_found(e):
-                return AgentInterfaceOutput(handlers=[])
-            raise
-        return AgentInterfaceOutput(
-            handlers=[
-                NexusAcceptedFunction(
-                    name=fn.name,
-                    description=fn.description,
-                    parameters=json.dumps(fn.parameters),
-                    output=json.dumps(fn.output),
-                )
-                for fn in functions
-            ]
-        )
-
-    # -----------------------------------------------------------------------
-    # queryAgentStatus — session state snapshot
-    # -----------------------------------------------------------------------
 
     @sync_operation
     async def query_agent_status(
-        self, ctx: StartOperationContext, input: QuerySessionInput
+        self, _ctx: StartOperationContext, input: QuerySessionInput
     ) -> AgentStatusOutput:
         status = await self._agent_client(input.session_id).get_status()
         return AgentStatusOutput(
@@ -360,35 +184,30 @@ class AgentServiceHandler:
             current_turn=status.current_turn,
             turn_active=status.turn_active,
             is_message_queuing_enabled=status.is_message_queuing_enabled,
-            pending_turns=[_nexus_pending_turn(pt) for pt in status.pending_turns],
+            pending_turns=[_nexus_pending_turn(item) for item in status.pending_turns],
             pending_approvals=[
                 NexusPendingApproval(
-                    tool_id=pa.tool_id,
-                    tool_name=pa.tool_name,
-                    tool_input=json.dumps(pa.tool_input),
-                    turn_number=pa.turn_number,
+                    tool_id=item.tool_id,
+                    tool_name=item.tool_name,
+                    tool_input=json.dumps(item.tool_input),
+                    turn_number=item.turn_number,
                 )
-                for pa in status.pending_approvals
+                for item in status.pending_approvals
             ],
             pending_callbacks=[
-                _nexus_pending_callback(pc) for pc in status.pending_callbacks
+                _nexus_pending_callback(item) for item in status.pending_callbacks
             ],
-            subagents=[_nexus_subagent_info(s) for s in status.subagents],
+            subagents=[_nexus_subagent_info(item) for item in status.subagents],
             approval_policy=_nexus_approval_policy(status.approval_policy),
             has_custom_approval_fallback=status.has_custom_approval_fallback,
             subagent_close_policy=status.subagent_close_policy.value,
             subagent_reuse_policy=status.subagent_reuse_policy.value,
         )
 
-    # -----------------------------------------------------------------------
-    # provideCallbackResult — fulfill a pending callback tool call
-    # -----------------------------------------------------------------------
-
     @sync_operation
     async def provide_callback_result(
         self, ctx: StartOperationContext, input: ProvideCallbackResultInput
     ) -> ProvideCallbackResultOutput:
-        # nex-gen wraps the object-shaped result in a named type instead of a plain dict.
         callback_result = (
             input.result.additional_properties if input.result is not None else None
         )
@@ -399,108 +218,8 @@ class AgentServiceHandler:
                 error=input.error,
                 update_id=f"callback-{ctx.request_id}",
             )
-        except CallbackResultError as e:
-            raise HandlerError(
-                str(e), type=HandlerErrorType.BAD_REQUEST
-            ) from e  # caller's fault
+        except CallbackResultError as exc:
+            raise HandlerError(str(exc), type=HandlerErrorType.BAD_REQUEST) from exc
         return ProvideCallbackResultOutput(
             tool_id=result.tool_id, accepted=result.accepted
-        )
-
-    # -----------------------------------------------------------------------
-    # closeSession: close the target agent workflow
-    # -----------------------------------------------------------------------
-
-    @sync_operation
-    async def close_session(
-        self, ctx: StartOperationContext, input: QuerySessionInput
-    ) -> CloseSessionOutput:
-        await self._agent_client(input.session_id).close()
-        return CloseSessionOutput(closed=True)
-
-    # -----------------------------------------------------------------------
-    # pollMessages — live update-with-callback plus completed-workflow replay
-    # -----------------------------------------------------------------------
-
-    @nexus.temporal_operation
-    async def poll_messages(
-        self,
-        ctx: nexus.TemporalStartOperationContext,
-        client: nexus.TemporalNexusClient,
-        input: PollMessagesInput,
-    ) -> nexus.TemporalOperationResult[PollMessagesOutput]:
-        """Long-poll a live stream, or query its retained state after completion."""
-        workflow_id = self._workflow_id(input.session_id)
-        timeout_seconds = (
-            input.timeout_seconds
-            if input.timeout_seconds is not None
-            else DEFAULT_POLL_TIMEOUT_SECONDS
-        )
-        if timeout_seconds <= 0:
-            raise HandlerError(
-                "timeout_seconds must be positive",
-                type=HandlerErrorType.BAD_REQUEST,
-            )
-
-        try:
-            result = await client.start_workflow_update(
-                workflow_id,
-                AGENT_STREAM_POLL_UPDATE,
-                AgentStreamPollInput(
-                    from_offset=input.cursor,
-                    topics=[TURN_EVENTS_TOPIC],
-                    timeout_seconds=timeout_seconds,
-                ),
-                result_type=AgentStreamPollResult,
-            )
-        except RPCError as e:
-            if _is_workflow_already_completed(e):
-                replay = await self._client.get_workflow_handle(workflow_id).query(
-                    AGENT_STREAM_REPLAY_QUERY,
-                    AgentStreamPollInput(
-                        from_offset=input.cursor,
-                        topics=[TURN_EVENTS_TOPIC],
-                        timeout_seconds=timeout_seconds,
-                    ),
-                    result_type=AgentStreamPollResult,
-                )
-                return nexus.TemporalOperationResult.sync(
-                    self._poll_messages_output(replay, closed=True)
-                )
-            if _is_workflow_not_found(e):
-                return nexus.TemporalOperationResult.sync(
-                    PollMessagesOutput(
-                        items=[],
-                        more_ready=False,
-                        next_offset=input.cursor,
-                        closed=True,
-                    )
-                )
-            raise
-
-        if result.token is not None:
-            return nexus.TemporalOperationResult.async_token(result.token)
-
-        bounded_result: AgentStreamPollResult = result.value
-        return nexus.TemporalOperationResult.sync(
-            self._poll_messages_output(bounded_result)
-        )
-
-    @staticmethod
-    def _poll_messages_output(
-        result: AgentStreamPollResult,
-        *,
-        closed: bool | None = None,
-    ) -> PollMessagesOutput:
-        source_closed = result.closed if closed is None else closed
-        return PollMessagesOutput(
-            items=[
-                StreamItem(topic=item.topic, data=item.data, offset=item.offset)
-                for item in result.items
-            ],
-            more_ready=result.more_ready,
-            next_offset=result.next_offset,
-            # A closed source can still have additional retained pages. Report closure only
-            # after the caller has drained them; otherwise connectors terminate at page one.
-            closed=source_closed and not result.more_ready,
         )

--- a/temporal_agent_harness/nexus_agent_adapter/worker.py
+++ b/temporal_agent_harness/nexus_agent_adapter/worker.py
@@ -1,6 +1,6 @@
-# ABOUTME: Standalone Nexus worker exposing AgentService on its own task queue.
+# ABOUTME: Standalone worker exposing A2A plus harness controls over Nexus.
 #
-# Optional: AgentServiceHandler can instead be added to an agent's own Worker (same
+# Optional: the service handlers can instead be added to an agent's own Worker (same
 # process, same task queue as the workflow) — use this only if you want Nexus traffic
 # scaled independently.
 #
@@ -17,7 +17,13 @@ from temporalio.client import Client
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.worker import Worker
 
-from .handler import AgentServiceHandler, Config
+from temporal_agent_harness.a2a.adapter import (
+    A2AHandlerConfig,
+    A2AServiceHandler,
+    make_agent_card,
+)
+
+from .handler import HarnessControlConfig, HarnessControlServiceHandler
 
 logger = logging.getLogger(__name__)
 
@@ -44,16 +50,31 @@ async def main() -> None:
         data_converter=pydantic_data_converter,
     )
 
-    config = Config(
-        agent_task_queue=agent_task_queue,
-        workflow_name=agent_workflow_name,
-        workflow_id_prefix=workflow_id_prefix,
-        is_message_queuing_enabled=True,
-    )
+    control_config = HarnessControlConfig(workflow_id_prefix=workflow_id_prefix)
     worker = Worker(
         client,
         task_queue=nexus_task_queue,
-        nexus_service_handlers=[AgentServiceHandler(client, config)],
+        nexus_service_handlers=[
+            A2AServiceHandler(
+                client,
+                A2AHandlerConfig(
+                    agent_task_queue=agent_task_queue,
+                    workflow_name=agent_workflow_name,
+                    workflow_id_prefix=workflow_id_prefix,
+                    is_message_queuing_enabled=True,
+                    agent_card=make_agent_card(
+                        name=_env_or_default("AGENT_NAME", agent_workflow_name),
+                        description=_env_or_default(
+                            "AGENT_DESCRIPTION", "Temporal Agent Harness agent."
+                        ),
+                        endpoint=_env_or_default(
+                            "NEXUS_AGENT_ENDPOINT", "agent-endpoint"
+                        ),
+                    ),
+                ),
+            ),
+            HarnessControlServiceHandler(client, control_config),
+        ],
     )
 
     logger.info(

--- a/tests/ai_sdks/openai_agents/_toolbox_sandbox_probe.py
+++ b/tests/ai_sdks/openai_agents/_toolbox_sandbox_probe.py
@@ -1,0 +1,41 @@
+"""Workflow used to prove A2A toolbox materialization is sandbox-safe."""
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from durable_tools_gateway.resources import ResourceDescriptor, text_agent_card
+
+    from temporal_agent_harness.ai_sdks.openai_agents._nexus_mcp import (
+        _materialize_toolbox,
+    )
+
+
+@workflow.defn
+class ToolboxSandboxProbe:
+    @workflow.run
+    async def run(self) -> list[str]:
+        toolbox = _materialize_toolbox(
+            [
+                ResourceDescriptor(
+                    resource_id="research",
+                    revision=1,
+                    category="agent",
+                    transport="nexus",
+                    label="Research",
+                    description="Sandbox probe",
+                    endpoint="research-endpoint",
+                    service="A2AService",
+                    agent_card=text_agent_card(
+                        name="Research",
+                        description="Sandbox probe",
+                        endpoint="research-endpoint",
+                        transport="nexus",
+                    ),
+                )
+            ],
+            account_id="account-1",
+            gateway_name="RegistryService",
+            gateway_endpoint="registry-endpoint",
+            version="1",
+        )
+        return [tool.__name__ for tool in toolbox.subagent_tools]

--- a/tests/ai_sdks/openai_agents/test_nexus_mcp.py
+++ b/tests/ai_sdks/openai_agents/test_nexus_mcp.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,12 +23,15 @@ from durable_tools_gateway.generated import (
     ListAccountEntriesOutputRemoteTools,
     ListAccountEntriesOutputRemoteToolsValueItem,
 )
-from durable_tools_gateway.resources import ResourceDescriptor, TEXT_AGENT_HANDLER
+from durable_tools_gateway.resources import ResourceDescriptor, text_agent_card
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
 
 from temporal_agent_harness.ai_sdks.openai_agents._nexus_mcp import (
-    _NexusGatewayMCPServer,
     _materialize_toolbox,
+    _NexusGatewayMCPServer,
 )
+from tests.ai_sdks.openai_agents._toolbox_sandbox_probe import ToolboxSandboxProbe
 
 
 def _server() -> _NexusGatewayMCPServer:
@@ -51,8 +55,13 @@ def test_dynamic_toolbox_materializes_native_and_external_routes() -> None:
                 "Research",
                 "",
                 "research-endpoint",
-                "AgentService",
-                (TEXT_AGENT_HANDLER,),
+                "A2AService",
+                text_agent_card(
+                    name="Research",
+                    description="",
+                    endpoint="research-endpoint",
+                    transport="nexus",
+                ),
             ),
             ResourceDescriptor(
                 "writer",
@@ -62,7 +71,12 @@ def test_dynamic_toolbox_materializes_native_and_external_routes() -> None:
                 "Writer",
                 "",
                 "http://writer",
-                handlers=(TEXT_AGENT_HANDLER,),
+                agent_card=text_agent_card(
+                    name="Writer",
+                    description="",
+                    endpoint="http://writer",
+                    transport="external_http",
+                ),
             ),
             ResourceDescriptor(
                 "native-tools",
@@ -105,6 +119,30 @@ def test_dynamic_toolbox_materializes_native_and_external_routes() -> None:
     ]
 
 
+async def test_dynamic_toolbox_materializes_inside_workflow_sandbox() -> None:
+    env = await WorkflowEnvironment.start_time_skipping()
+    task_queue = f"toolbox-sandbox-{uuid.uuid4()}"
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        workflows=[ToolboxSandboxProbe],
+    ):
+        try:
+            names = await env.client.execute_workflow(
+                ToolboxSandboxProbe.run,
+                id=f"toolbox-sandbox-{uuid.uuid4()}",
+                task_queue=task_queue,
+            )
+        finally:
+            await env.shutdown()
+
+    assert names == [
+        "start_research",
+        "research_ask",
+        "stop_research",
+    ]
+
+
 @patch(
     "temporal_agent_harness.ai_sdks.openai_agents._nexus_mcp.workflow.create_nexus_client"
 )
@@ -139,9 +177,7 @@ async def test_list_tools_unwraps_remote_tools(mock_create_client: MagicMock) ->
 @patch(
     "temporal_agent_harness.ai_sdks.openai_agents._nexus_mcp.workflow.create_nexus_client"
 )
-@patch(
-    "temporal_agent_harness.ai_sdks.openai_agents._nexus_mcp.workflow.info"
-)
+@patch("temporal_agent_harness.ai_sdks.openai_agents._nexus_mcp.workflow.info")
 async def test_call_tool_wraps_arguments_and_unwraps_result(
     mock_info: MagicMock, mock_create_client: MagicMock
 ) -> None:

--- a/tests/examples/nexus_hello/test_native_subagent.py
+++ b/tests/examples/nexus_hello/test_native_subagent.py
@@ -1,0 +1,10 @@
+from temporalio import workflow
+from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
+
+from examples.nexus_hello.native_subagent import NativeResearchSubagentWorkflow
+
+
+async def test_native_subagent_workflow_passes_worker_sandbox_validation() -> None:
+    SandboxedWorkflowRunner().prepare_workflow(
+        workflow._Definition.must_from_class(NativeResearchSubagentWorkflow)
+    )

--- a/tests/examples/nexus_hello/test_subagent_server.py
+++ b/tests/examples/nexus_hello/test_subagent_server.py
@@ -1,79 +1,61 @@
 from __future__ import annotations
 
-import pytest
 from fastapi.testclient import TestClient
 
 from examples.nexus_hello import subagent_server
 
 
-@pytest.fixture(autouse=True)
-def reset_server_state() -> None:
-    subagent_server._start_keys.clear()
-    subagent_server._sessions.clear()
+def _message(message_id: str, text: str, *, task: dict | None = None) -> dict:
+    message = {
+        "messageId": message_id,
+        "role": "ROLE_USER",
+        "parts": [{"text": text}],
+    }
+    if task:
+        message.update(taskId=task["id"], contextId=task["contextId"])
+    return {"message": message}
 
 
-@pytest.fixture
-def client() -> TestClient:
-    return TestClient(subagent_server.app)
+def test_publishes_standard_a2a_agent_card() -> None:
+    client = TestClient(subagent_server.app)
+    response = client.get("/.well-known/agent-card.json")
 
-
-def _start(client: TestClient, key: str) -> str:
-    response = client.post("/sessions", json={"idempotency_key": key})
     assert response.status_code == 200
-    return response.json()["instance_id"]
+    card = response.json()
+    assert card["name"] == "Writer HTTP"
+    assert card["supportedInterfaces"][0]["protocolBinding"] == "HTTP+JSON"
+    assert card["skills"][0]["id"] == "ask"
 
 
-def _turn(client: TestClient, instance_id: str, text: str, turn: int):
-    return client.post(
-        f"/sessions/{instance_id}/turns",
-        json={
-            "idempotency_key": f"agent:writer:{instance_id}:{turn}",
-            "msg_type": "ask",
-            "payload": f'{{"text": "{text}"}}',
-            "expected_turn": turn,
-        },
+def test_first_message_creates_a2a_task_and_returns_answer() -> None:
+    client = TestClient(subagent_server.app)
+    response = client.post(
+        "/message:send",
+        headers={"A2A-Version": "1.0"},
+        json=_message("message-1", "hello"),
     )
 
-
-def test_start_is_idempotent(client: TestClient) -> None:
-    assert _start(client, "start-1") == _start(client, "start-1")
-
-
-def test_instances_have_independent_turn_state(client: TestClient) -> None:
-    first = _start(client, "start-1")
-    second = _start(client, "start-2")
-    assert first != second
-
-    first_reply = _turn(client, first, "session A", 1)
-    second_reply = _turn(client, second, "session B", 1)
-
-    assert first_reply.status_code == 200
-    assert second_reply.status_code == 200
-    assert "session A" in first_reply.json()["output"]["text"]
-    assert "session B" in second_reply.json()["output"]["text"]
-    assert first_reply.json()["turn_number"] == 1
-    assert second_reply.json()["turn_number"] == 1
+    assert response.status_code == 200
+    task = response.json()["task"]
+    assert task["id"]
+    assert task["status"]["state"] == "TASK_STATE_INPUT_REQUIRED"
+    assert "hello" in task["artifacts"][-1]["parts"][0]["text"]
 
 
-def test_turn_retry_returns_the_first_result(client: TestClient) -> None:
-    instance_id = _start(client, "start-1")
-    first = _turn(client, instance_id, "hello", 1)
-    retry = _turn(client, instance_id, "hello", 1)
+def test_followup_message_reuses_the_same_a2a_task() -> None:
+    client = TestClient(subagent_server.app)
+    first = client.post(
+        "/message:send",
+        headers={"A2A-Version": "1.0"},
+        json=_message("message-2", "first"),
+    ).json()["task"]
+    second_response = client.post(
+        "/message:send",
+        headers={"A2A-Version": "1.0"},
+        json=_message("message-3", "second", task=first),
+    )
 
-    assert retry.status_code == 200
-    assert retry.json() == first.json()
-
-
-def test_stale_turn_is_rejected(client: TestClient) -> None:
-    instance_id = _start(client, "start-1")
-    response = _turn(client, instance_id, "wrong turn", 2)
-    assert response.status_code == 409
-
-
-def test_close_removes_only_the_selected_instance(client: TestClient) -> None:
-    first = _start(client, "start-1")
-    second = _start(client, "start-2")
-
-    assert client.post(f"/sessions/{first}/close").status_code == 200
-    assert _turn(client, first, "closed", 1).status_code == 404
-    assert _turn(client, second, "open", 1).status_code == 200
+    assert second_response.status_code == 200
+    second = second_response.json()["task"]
+    assert second["id"] == first["id"]
+    assert "second" in second["artifacts"][-1]["parts"][0]["text"]

--- a/tests/harness/test_subagent_gateway_transport.py
+++ b/tests/harness/test_subagent_gateway_transport.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from durable_tools_gateway.generated import (
-    DispatchSubagentTurnOutput,
-    StartSubagentOutput,
-)
+from a2a.types import Artifact, Part, SendMessageResponse, Task
 
 from temporal_agent_harness.harness.agent_protocol import AgentConfig
 from temporal_agent_harness.harness.stream_context import TurnStreamContext
@@ -15,24 +12,44 @@ from temporal_agent_harness.harness.subagent_gateway_transport import GatewayTra
 @patch(
     "temporal_agent_harness.harness.subagent_gateway_transport.workflow.create_nexus_client"
 )
-async def test_gateway_transport_uses_started_instance(mock_create_client: MagicMock) -> None:
+async def test_gateway_transport_uses_started_instance(
+    mock_create_client: MagicMock,
+) -> None:
     client = MagicMock()
     client.execute_operation = AsyncMock(
         side_effect=[
-            StartSubagentOutput(instance_id="instance-1"),
-            DispatchSubagentTurnOutput(
-                output='{"text":"done"}', turn_id="turn-1", turn_number=1
+            SendMessageResponse(
+                task=Task(
+                    id="writer-subagent-instance-1",
+                    artifacts=[
+                        Artifact(artifact_id="turn-1", parts=[Part(text="done")])
+                    ],
+                    metadata={
+                        "temporal.io/turn-number": 1,
+                        "temporal.io/turn-id": "turn-1",
+                    },
+                )
             ),
-            None,
+            Task(id="writer-subagent-instance-1"),
         ]
     )
     mock_create_client.return_value = client
     transport = GatewayTransport("agent-1", "writer")
 
-    instance_id = await transport.start(agent_key="writer", config=AgentConfig())
     with patch(
-        "temporal_agent_harness.harness.subagent_gateway_transport._current_runner"
-    ) as current_runner:
+        "temporal_agent_harness.harness.subagent_gateway_transport.workflow.uuid4",
+        return_value="instance-1",
+    ):
+        instance_id = await transport.start(agent_key="writer", config=AgentConfig())
+    with (
+        patch(
+            "temporal_agent_harness.harness.subagent_gateway_transport._current_runner"
+        ) as current_runner,
+        patch(
+            "temporal_agent_harness.harness.subagent_gateway_transport.workflow.uuid4",
+            return_value="message-1",
+        ),
+    ):
         current_runner.return_value.publish = MagicMock()
         result = await transport.dispatch(
             target=instance_id,
@@ -48,10 +65,8 @@ async def test_gateway_transport_uses_started_instance(mock_create_client: Magic
         )
     await transport.stop(target=instance_id)
 
-    start_input = client.execute_operation.await_args_list[0].args[1]
-    dispatch_input = client.execute_operation.await_args_list[1].args[1]
-    stop_input = client.execute_operation.await_args_list[2].args[1]
-    assert start_input.alias == "writer"
-    assert dispatch_input.instance_id == "instance-1"
-    assert stop_input.instance_id == "instance-1"
+    dispatch_input = client.execute_operation.await_args_list[0].args[1]
+    stop_input = client.execute_operation.await_args_list[1].args[1]
+    assert dispatch_input.message.task_id == "writer-subagent-instance-1"
+    assert stop_input.id == "writer-subagent-instance-1"
     assert result.output == {"text": "done"}

--- a/tests/nexus_agent_adapter/test_handler_integration.py
+++ b/tests/nexus_agent_adapter/test_handler_integration.py
@@ -1,42 +1,43 @@
-# ABOUTME: End-to-end integration tests for AgentServiceHandler against a real dev server.
-#
-# Needs a real dev server, not the time-skipping test server — update-with-callback requires
-# dynamic config the time-skipping server doesn't have (see _DEV_SERVER_ARGS below).
-#
-# Run with: uv run pytest tests/nexus_agent_adapter/test_handler_integration.py -v
+"""End-to-end tests for the A2A Nexus binding against a real dev server."""
 
 from __future__ import annotations
 
-import json
 import uuid
 from collections.abc import AsyncGenerator
 
 import pytest_asyncio
 from pydantic import BaseModel
 from temporalio import workflow
-from temporalio.api.enums.v1 import EventType
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.contrib.workflow_streams import WorkflowStream
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
-from temporal_agent_harness.harness import AgentWorkflowRunner, agent
-from temporal_agent_harness.harness.agent_protocol import AgentConfig, ToolApprovalPolicy
-from temporal_agent_harness.nexus_agent_adapter.generated import (
-    AgentService as AgentServiceDefinition,
-)
-from temporal_agent_harness.nexus_agent_adapter.generated import (
-    ApproveToolCallInput,
-    ExecuteOperatorCommandInput,
-    PollMessagesInput,
-    QuerySessionInput,
-    SendAgentMessageInput,
-)
-from temporal_agent_harness.nexus_agent_adapter.handler import AgentServiceHandler, Config
+with workflow.unsafe.imports_passed_through():
+    from a2a.types import (
+        CancelTaskRequest,
+        GetExtendedAgentCardRequest,
+        Message,
+        Part,
+        Role,
+        SendMessageRequest,
+        StreamResponse,
+        TaskState,
+    )
+    from google.protobuf.json_format import MessageToDict
 
-# Custom dev-server build with the Nexus-update-callback dynamic config surface (matches
-# sdk-python's own tests/conftest.py for PR #1631 — the stock time-skipping test server and
-# ordinary dev-server releases don't have these flags).
+    from temporal_agent_harness.a2a.adapter import (
+        A2AHandlerConfig,
+        A2AServiceHandler,
+        make_agent_card,
+    )
+    from temporal_agent_harness.a2a.nexus import A2AService, SubscribeToTaskInput
+    from temporal_agent_harness.harness import AgentWorkflowRunner, agent
+    from temporal_agent_harness.harness.agent_protocol import (
+        AgentConfig,
+        ToolApprovalPolicy,
+    )
+
 _DEV_SERVER_VERSION = "v1.7.1-system-nexus-operations"
 _DEV_SERVER_ARGS = [
     "--dynamic-config-value",
@@ -57,13 +58,13 @@ _DEV_SERVER_ARGS = [
 
 
 class AskMessage(BaseModel):
-    """A user message to the probe agent."""
+    """Probe input."""
 
     text: str
 
 
 class AskReply(BaseModel):
-    """The probe agent's reply."""
+    """Probe output."""
 
     text: str
 
@@ -71,8 +72,6 @@ class AskReply(BaseModel):
 @workflow.defn
 @agent.defn
 class ProbeAgent:
-    """2s reply delay so pollMessages is provably still pending (async path, not sync)."""
-
     @workflow.init
     def __init__(self, config: AgentConfig) -> None:
         self._runner = AgentWorkflowRunner(
@@ -87,75 +86,99 @@ class ProbeAgent:
 
     @agent.accepts
     async def ask(self, message: AskMessage) -> AskReply:
-        """Reply to a user message."""
-        await workflow.sleep(2)
+        """Echo one probe message."""
+        await workflow.sleep(0.1)
         return AskReply(text=f"echo: {message.text}")
 
 
 class CallerInput(BaseModel):
     endpoint: str
-    session_id: str
+    task_id: str
 
 
 class CallerOutput(BaseModel):
-    turn_id: str
     turn_number: int
-    poll_closed: bool
-    poll_item_count: int
+    item_count: int
+    closed: bool
 
 
-@workflow.defn
-class TimeoutPollCallerWorkflow:
-    """Poll an idle agent and return after the requested timeout."""
-
-    @workflow.run
-    async def run(self, input: CallerInput) -> int:
-        client = workflow.create_nexus_client(
-            service=AgentServiceDefinition, endpoint=input.endpoint
-        )
-        result = await client.execute_operation(
-            AgentServiceDefinition.poll_messages,
-            PollMessagesInput(
-                session_id=input.session_id,
-                cursor=0,
-                timeout_seconds=0.1,
-            ),
-        )
-        assert not result.closed
-        return len(result.items)
-
-
-@workflow.defn
-class CallerWorkflow:
-    """Stands in for ui_connector — calls AgentService purely over the Nexus wire."""
-
+@workflow.defn(sandboxed=False)
+class A2ACallerWorkflow:
     @workflow.run
     async def run(self, input: CallerInput) -> CallerOutput:
         client = workflow.create_nexus_client(
-            service=AgentServiceDefinition, endpoint=input.endpoint
+            service=A2AService, endpoint=input.endpoint
         )
-        send_out = await client.execute_operation(
-            AgentServiceDefinition.send_agent_message,
-            SendAgentMessageInput(
-                session_id=input.session_id,
-                msg_type="ask",
-                payload=json.dumps({"text": "hi"}),
+        sent = await client.execute_operation(
+            A2AService.send_message,
+            SendMessageRequest(
+                message=Message(
+                    message_id=str(workflow.uuid4()),
+                    task_id=input.task_id,
+                    context_id=input.task_id,
+                    role=Role.ROLE_USER,
+                    parts=[Part(text="hi")],
+                )
             ),
         )
-        poll_out = await client.execute_operation(
-            AgentServiceDefinition.poll_messages,
-            PollMessagesInput(
-                session_id=input.session_id,
-                cursor=send_out.stream_head_offset or 0,
-                timeout_seconds=20,
-            ),
+        metadata = MessageToDict(sent.task.metadata)
+        cursor = int(metadata["temporal.io/accepted-offset"])
+        count = 0
+        for _ in range(10):
+            page = await client.execute_operation(
+                A2AService.subscribe_to_task,
+                SubscribeToTaskInput(
+                    id=input.task_id, cursor=cursor, timeout_seconds=5
+                ),
+            )
+            count += len(page.items)
+            cursor = page.next_cursor
+            for item in page.items:
+                response = StreamResponse()
+                import base64
+
+                response.ParseFromString(base64.b64decode(item.data))
+                if (
+                    response.HasField("status_update")
+                    and response.status_update.status.state
+                    == TaskState.TASK_STATE_INPUT_REQUIRED
+                ):
+                    return CallerOutput(
+                        turn_number=int(metadata["temporal.io/turn-number"]),
+                        item_count=count,
+                        closed=page.closed,
+                    )
+        raise RuntimeError("A2A turn did not reach input-required")
+
+
+@workflow.defn(sandboxed=False)
+class ReplayCallerWorkflow:
+    @workflow.run
+    async def run(self, input: CallerInput) -> CallerOutput:
+        client = workflow.create_nexus_client(
+            service=A2AService, endpoint=input.endpoint
+        )
+        await client.execute_operation(
+            A2AService.cancel_task, CancelTaskRequest(id=input.task_id)
+        )
+        page = await client.execute_operation(
+            A2AService.subscribe_to_task,
+            SubscribeToTaskInput(id=input.task_id, cursor=0, timeout_seconds=1),
         )
         return CallerOutput(
-            turn_id=send_out.turn_id,
-            turn_number=send_out.turn_number,
-            poll_closed=bool(poll_out.closed),
-            poll_item_count=len(poll_out.items),
+            turn_number=0, item_count=len(page.items), closed=page.closed
         )
+
+
+@workflow.defn(sandboxed=False)
+class CardCallerWorkflow:
+    @workflow.run
+    async def run(self, endpoint: str) -> str:
+        client = workflow.create_nexus_client(service=A2AService, endpoint=endpoint)
+        card = await client.execute_operation(
+            A2AService.get_extended_agent_card, GetExtendedAgentCardRequest()
+        )
+        return card.name
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -169,559 +192,97 @@ async def env() -> AsyncGenerator[WorkflowEnvironment, None]:
     await env.shutdown()
 
 
-async def test_poll_messages_delivers_via_async_callback(env: WorkflowEnvironment) -> None:
-    client = env.client
-    endpoint_name = f"agent-endpoint-{uuid.uuid4()}"
-    agent_task_queue = f"agent-{uuid.uuid4()}"
-    nexus_task_queue = f"nexus-agent-{uuid.uuid4()}"
-    caller_task_queue = f"caller-{uuid.uuid4()}"
-
-    await env.create_nexus_endpoint(endpoint_name, nexus_task_queue)
-
-    config = Config(
-        agent_task_queue=agent_task_queue,
+async def _run_stack(env: WorkflowEnvironment, caller: type, argument):
+    endpoint = f"a2a-agent-{uuid.uuid4()}"
+    agent_queue = f"agent-{uuid.uuid4()}"
+    nexus_queue = f"nexus-{uuid.uuid4()}"
+    caller_queue = f"caller-{uuid.uuid4()}"
+    await env.create_nexus_endpoint(endpoint, nexus_queue)
+    config = A2AHandlerConfig(
+        agent_task_queue=agent_queue,
         workflow_name="ProbeAgent",
-        workflow_id_prefix="probe-",
-        is_message_queuing_enabled=False,
+        workflow_id_prefix="",
+        is_message_queuing_enabled=True,
+        agent_card=make_agent_card(
+            name="Probe", description="Probe", endpoint=endpoint
+        ),
     )
-
-    async with Worker(
-        client,
-        task_queue=agent_task_queue,
-        workflows=[ProbeAgent],
-    ), Worker(
-        client,
-        task_queue=nexus_task_queue,
-        nexus_service_handlers=[AgentServiceHandler(client, config)],
-    ), Worker(
-        client,
-        task_queue=caller_task_queue,
-        workflows=[CallerWorkflow],
-    ):
-        session_id = str(uuid.uuid4())
-        handle = await client.start_workflow(
-            CallerWorkflow.run,
-            CallerInput(endpoint=endpoint_name, session_id=session_id),
-            id=f"caller-{session_id}",
-            task_queue=caller_task_queue,
-        )
-        result = await handle.result()
-
-        assert result.turn_number == 1
-        assert not result.poll_closed
-        assert result.poll_item_count > 0, (
-            "pollMessages must deliver the reply's stream items"
-        )
-
-        # Proves the async callback path was taken, not a sync completion.
-        history = await handle.fetch_history()
-        op_types = {e.event_type for e in history.events}
-        assert EventType.EVENT_TYPE_NEXUS_OPERATION_STARTED in op_types
-        assert EventType.EVENT_TYPE_NEXUS_OPERATION_COMPLETED in op_types
-
-
-async def test_poll_messages_honors_timeout(env: WorkflowEnvironment) -> None:
-    client = env.client
-    endpoint_name = f"agent-endpoint-{uuid.uuid4()}"
-    agent_task_queue = f"agent-{uuid.uuid4()}"
-    nexus_task_queue = f"nexus-agent-{uuid.uuid4()}"
-    caller_task_queue = f"caller-{uuid.uuid4()}"
-    session_id = str(uuid.uuid4())
-
-    await env.create_nexus_endpoint(endpoint_name, nexus_task_queue)
-    config = Config(
-        agent_task_queue=agent_task_queue,
-        workflow_name="ProbeAgent",
-        workflow_id_prefix="probe-",
-        is_message_queuing_enabled=False,
-    )
-
-    async with Worker(
-        client, task_queue=agent_task_queue, workflows=[ProbeAgent]
-    ), Worker(
-        client,
-        task_queue=nexus_task_queue,
-        nexus_service_handlers=[AgentServiceHandler(client, config)],
-    ), Worker(
-        client, task_queue=caller_task_queue, workflows=[TimeoutPollCallerWorkflow]
-    ):
-        agent_handle = await client.start_workflow(
-            ProbeAgent.run,
-            AgentConfig(),
-            id=f"probe-{session_id}",
-            task_queue=agent_task_queue,
-        )
-        caller_handle = await client.start_workflow(
-            TimeoutPollCallerWorkflow.run,
-            CallerInput(endpoint=endpoint_name, session_id=session_id),
-            id=f"caller-{session_id}",
-            task_queue=caller_task_queue,
-        )
-
-        assert await caller_handle.result() == 0
-        await agent_handle.signal("close")
-
-
-class SendOnlyOutput(BaseModel):
-    turn_number: int
-
-
-@workflow.defn
-class SendOnlyCallerWorkflow:
-    """Send-only, no poll — avoids racing the probe agent's reply delay across a restart."""
-
-    @workflow.run
-    async def run(self, input: CallerInput) -> SendOnlyOutput:
-        client = workflow.create_nexus_client(
-            service=AgentServiceDefinition, endpoint=input.endpoint
-        )
-        send_out = await client.execute_operation(
-            AgentServiceDefinition.send_agent_message,
-            SendAgentMessageInput(
-                session_id=input.session_id,
-                msg_type="ask",
-                payload=json.dumps({"text": "hi"}),
-            ),
-        )
-        return SendOnlyOutput(turn_number=send_out.turn_number)
-
-
-async def test_send_agent_message_survives_handler_worker_restart(
-    env: WorkflowEnvironment,
-) -> None:
-    """Handler worker restarts between two sends on the same session; turn count still
-    advances — state lives in the workflow, not the handler."""
-    client = env.client
-    endpoint_name = f"agent-endpoint-{uuid.uuid4()}"
-    agent_task_queue = f"agent-{uuid.uuid4()}"
-    nexus_task_queue = f"nexus-agent-{uuid.uuid4()}"
-    caller_task_queue = f"caller-{uuid.uuid4()}"
-
-    await env.create_nexus_endpoint(endpoint_name, nexus_task_queue)
-
-    config = Config(
-        agent_task_queue=agent_task_queue,
-        workflow_name="ProbeAgent",
-        workflow_id_prefix="probe-",
-        is_message_queuing_enabled=False,
-    )
-    session_id = str(uuid.uuid4())
-
-    async with Worker(
-        client, task_queue=agent_task_queue, workflows=[ProbeAgent]
-    ), Worker(
-        client, task_queue=caller_task_queue, workflows=[SendOnlyCallerWorkflow]
-    ):
-        handler_worker_0 = Worker(
-            client,
-            task_queue=nexus_task_queue,
-            nexus_service_handlers=[AgentServiceHandler(client, config)],
-        )
-        async with handler_worker_0:
-            handle_1 = await client.start_workflow(
-                SendOnlyCallerWorkflow.run,
-                CallerInput(endpoint=endpoint_name, session_id=session_id),
-                id=f"caller-restart-msg1-{session_id}",
-                task_queue=caller_task_queue,
-            )
-            result_1 = await handle_1.result()
-        assert result_1.turn_number == 1
-
-        handler_worker_1 = Worker(
-            client,
-            task_queue=nexus_task_queue,
-            nexus_service_handlers=[AgentServiceHandler(client, config)],
-        )
-        async with handler_worker_1:
-            handle_2 = await client.start_workflow(
-                SendOnlyCallerWorkflow.run,
-                CallerInput(endpoint=endpoint_name, session_id=session_id),
-                id=f"caller-restart-msg2-{session_id}",
-                task_queue=caller_task_queue,
-            )
-            result_2 = await handle_2.result()
-        assert result_2.turn_number == 2, (
-            "turn counter must advance after a handler worker restart"
-        )
-
-
-class PollOnlyOutput(BaseModel):
-    poll_closed: bool
-    poll_item_count: int
-
-
-@workflow.defn
-class PollOnlyCallerWorkflow:
-    """Calls only pollMessages, targeting a session whose workflow has already completed."""
-
-    @workflow.run
-    async def run(self, input: CallerInput) -> PollOnlyOutput:
-        client = workflow.create_nexus_client(
-            service=AgentServiceDefinition, endpoint=input.endpoint
-        )
-        poll_out = await client.execute_operation(
-            AgentServiceDefinition.poll_messages,
-            PollMessagesInput(session_id=input.session_id, cursor=0),
-        )
-        return PollOnlyOutput(
-            poll_closed=bool(poll_out.closed), poll_item_count=len(poll_out.items)
-        )
-
-
-async def test_poll_messages_closed_when_workflow_already_completed(
-    env: WorkflowEnvironment,
-) -> None:
-    """A completed harness workflow with no events returns an empty closed page."""
-    client = env.client
-    endpoint_name = f"agent-endpoint-{uuid.uuid4()}"
-    nexus_task_queue = f"nexus-agent-{uuid.uuid4()}"
-    agent_task_queue = f"agent-{uuid.uuid4()}"
-    caller_task_queue = f"caller-{uuid.uuid4()}"
-
-    await env.create_nexus_endpoint(endpoint_name, nexus_task_queue)
-
-    config = Config(
-        agent_task_queue=agent_task_queue,
-        workflow_name="ProbeAgent",
-        workflow_id_prefix="probe-",
-        is_message_queuing_enabled=False,
-    )
-
-    async with Worker(
-        client,
-        task_queue=agent_task_queue,
-        workflows=[ProbeAgent],
-    ), Worker(
-        client,
-        task_queue=nexus_task_queue,
-        nexus_service_handlers=[AgentServiceHandler(client, config)],
-    ), Worker(
-        client,
-        task_queue=caller_task_queue,
-        workflows=[PollOnlyCallerWorkflow],
-    ):
-        session_id = str(uuid.uuid4())
-        agent_handle = await client.start_workflow(
-            ProbeAgent.run,
-            AgentConfig(),
-            id=f"probe-{session_id}",
-            task_queue=agent_task_queue,
-        )
-        await agent_handle.signal("close")
-        await agent_handle.result()
-
-        handle = await client.start_workflow(
-            PollOnlyCallerWorkflow.run,
-            CallerInput(endpoint=endpoint_name, session_id=session_id),
-            id=f"poll-only-caller-{session_id}",
-            task_queue=caller_task_queue,
-        )
-        result = await handle.result()
-
-        assert result.poll_closed
-        assert result.poll_item_count == 0
-
-
-async def test_poll_messages_replays_completed_agent_history(
-    env: WorkflowEnvironment,
-) -> None:
-    client = env.client
-    endpoint_name = f"agent-endpoint-{uuid.uuid4()}"
-    agent_task_queue = f"agent-{uuid.uuid4()}"
-    nexus_task_queue = f"nexus-agent-{uuid.uuid4()}"
-    caller_task_queue = f"caller-{uuid.uuid4()}"
-    session_id = str(uuid.uuid4())
-
-    await env.create_nexus_endpoint(endpoint_name, nexus_task_queue)
-    config = Config(
-        agent_task_queue=agent_task_queue,
-        workflow_name="ProbeAgent",
-        workflow_id_prefix="probe-",
-        is_message_queuing_enabled=False,
-    )
-
     async with (
-        Worker(client, task_queue=agent_task_queue, workflows=[ProbeAgent]),
+        Worker(env.client, task_queue=agent_queue, workflows=[ProbeAgent]),
         Worker(
-            client,
-            task_queue=nexus_task_queue,
-            nexus_service_handlers=[AgentServiceHandler(client, config)],
+            env.client,
+            task_queue=nexus_queue,
+            nexus_service_handlers=[A2AServiceHandler(env.client, config)],
         ),
-        Worker(
-            client,
-            task_queue=caller_task_queue,
-            workflows=[CallerWorkflow, PollOnlyCallerWorkflow],
-        ),
+        Worker(env.client, task_queue=caller_queue, workflows=[caller]),
     ):
-        live_caller = await client.start_workflow(
-            CallerWorkflow.run,
-            CallerInput(endpoint=endpoint_name, session_id=session_id),
-            id=f"live-caller-{session_id}",
-            task_queue=caller_task_queue,
-        )
-        assert (await live_caller.result()).poll_item_count > 0
-
-        agent_handle = client.get_workflow_handle(f"probe-{session_id}")
-        await agent_handle.signal("close")
-        await agent_handle.result()
-
-        replay_caller = await client.start_workflow(
-            PollOnlyCallerWorkflow.run,
-            CallerInput(endpoint=endpoint_name, session_id=session_id),
-            id=f"replay-caller-{session_id}",
-            task_queue=caller_task_queue,
-        )
-        replay = await replay_caller.result()
-
-        assert replay.poll_closed
-        assert replay.poll_item_count > 0
-
-
-# ---------------------------------------------------------------------------
-# Full operation surface — approveToolCall, executeOperatorCommand,
-# queryAgentInterface, queryOperatorInterface, queryAgentStatus.
-# ---------------------------------------------------------------------------
-
-
-@agent.tool_defn()
-async def gated_tool(text: str) -> str:
-    """A non-safe inline tool: gated under the default policy."""
-    return f"tool-result:{text}"
-
-
-@workflow.defn
-@agent.defn
-class GatedProbeAgent:
-    """Gates every tool call, unlike ProbeAgent — needed to exercise approveToolCall."""
-
-    @workflow.init
-    def __init__(self, config: AgentConfig) -> None:
-        self._runner = AgentWorkflowRunner(
-            config,
-            stream=WorkflowStream(),
-            approval_policy_default=ToolApprovalPolicy.always_require_approvals(),
-        )
-
-    @workflow.run
-    async def run(self, _config: AgentConfig) -> None:
-        await self._runner.run(self)
-
-    @agent.accepts
-    async def use_tool(self, message: AskMessage) -> AskReply:
-        """Run a gated tool call and reply with its result."""
-        result = await self._runner.run_tool("fixed-tool-id", gated_tool, message.text)
-        return AskReply(text=result)
-
-
-class FullSurfaceOutput(BaseModel):
-    handler_names: list[str]
-    operator_command_names: list[str]
-    pending_tool_id: str
-    approve_accepted: bool
-    status_reply: str
-    poll_item_count: int
-
-
-@workflow.defn
-class FullSurfaceCallerWorkflow:
-    """Exercises the remaining operations: interface/status queries, approveToolCall,
-    executeOperatorCommand."""
-
-    @workflow.run
-    async def run(self, input: CallerInput) -> FullSurfaceOutput:
-        client = workflow.create_nexus_client(
-            service=AgentServiceDefinition, endpoint=input.endpoint
-        )
-
-        # Must go first — starts the workflow the queries below need.
-        send_out = await client.execute_operation(
-            AgentServiceDefinition.send_agent_message,
-            SendAgentMessageInput(
-                session_id=input.session_id,
-                msg_type="use_tool",
-                payload=json.dumps({"text": "hi"}),
-            ),
-        )
-
-        iface = await client.execute_operation(
-            AgentServiceDefinition.query_agent_interface,
-            QuerySessionInput(session_id=input.session_id),
-        )
-        ops_iface = await client.execute_operation(
-            AgentServiceDefinition.query_operator_interface,
-            QuerySessionInput(session_id=input.session_id),
-        )
-
-        # Poll instead of sleep — the approval record lands asynchronously.
-        status = None
-        for _ in range(20):
-            status = await client.execute_operation(
-                AgentServiceDefinition.query_agent_status,
-                QuerySessionInput(session_id=input.session_id),
-            )
-            if status.pending_approvals:
-                break
-            await workflow.sleep(0.1)
-        assert status is not None and status.pending_approvals
-        tool_id = status.pending_approvals[0].tool_id
-
-        approve_out = await client.execute_operation(
-            AgentServiceDefinition.approve_tool_call,
-            ApproveToolCallInput(
-                session_id=input.session_id, tool_id=tool_id, approved=True
-            ),
-        )
-
-        status_out = await client.execute_operation(
-            AgentServiceDefinition.execute_operator_command,
-            ExecuteOperatorCommandInput(session_id=input.session_id, name="status"),
-        )
-
-        poll_out = await client.execute_operation(
-            AgentServiceDefinition.poll_messages,
-            PollMessagesInput(
-                session_id=input.session_id,
-                cursor=send_out.stream_head_offset or 0,
-                timeout_seconds=20,
-            ),
-        )
-
-        return FullSurfaceOutput(
-            handler_names=sorted(h.name for h in iface.handlers),
-            operator_command_names=sorted(c.name for c in ops_iface.commands),
-            pending_tool_id=tool_id,
-            approve_accepted=approve_out.accepted,
-            status_reply=status_out.reply,
-            poll_item_count=len(poll_out.items),
+        return await env.client.execute_workflow(
+            caller.run,
+            argument(endpoint) if callable(argument) else argument,
+            id=f"caller-{uuid.uuid4()}",
+            task_queue=caller_queue,
         )
 
 
-class MalformedCallOutput(BaseModel):
-    error_type: str
-    error_message: str
+async def test_a2a_send_and_subscription(env: WorkflowEnvironment) -> None:
+    task_id = f"task-{uuid.uuid4()}"
+    result = await _run_stack(
+        env,
+        A2ACallerWorkflow,
+        lambda endpoint: CallerInput(endpoint=endpoint, task_id=task_id),
+    )
+    assert result.turn_number == 1
+    assert result.item_count > 0
+    assert not result.closed
 
 
-@workflow.defn
-class MalformedInputCallerWorkflow:
-    """Sends session_id=None for a required str field. The generated dataclass has no
-    constructor-time validation (unlike the old pydantic models), so this only gets
-    caught by TransferTypeConverter.from_transfer_type on the handler side, once the
-    value crosses the wire. Proves that boundary still rejects malformed input."""
-
-    @workflow.run
-    async def run(self, input: CallerInput) -> MalformedCallOutput:
-        client = workflow.create_nexus_client(
-            service=AgentServiceDefinition, endpoint=input.endpoint
-        )
-        try:
-            await client.execute_operation(
-                AgentServiceDefinition.send_agent_message,
-                SendAgentMessageInput(
-                    session_id=None,  # type: ignore[arg-type]
-                    msg_type="ask",
-                    payload=json.dumps({"text": "hi"}),
-                ),
-            )
-        except Exception as e:
-            chain = [f"{type(e).__name__}: {e}"]
-            # Protobuf singular message fields are never None when unset (they return
-            # an empty message), so walk with HasField instead of an is-None check.
-            failure = getattr(e, "failure", None)
-            while failure is not None and failure.HasField("cause"):
-                failure = failure.cause
-                chain.append(f"failure.cause: {failure.message}")
-            return MalformedCallOutput(
-                error_type=type(e).__name__, error_message=" | ".join(chain)
-            )
-        raise AssertionError("malformed input should not have succeeded")
+async def test_agent_card_is_discoverable_over_nexus(env: WorkflowEnvironment) -> None:
+    result = await _run_stack(env, CardCallerWorkflow, lambda endpoint: endpoint)
+    assert result == "Probe"
 
 
-async def test_send_agent_message_rejects_malformed_input(
-    env: WorkflowEnvironment,
-) -> None:
-    """A required field sent as null over the wire must fail the Nexus call, not crash
-    the handler worker or silently proceed with a bad value."""
-    client = env.client
-    endpoint_name = f"agent-endpoint-{uuid.uuid4()}"
-    agent_task_queue = f"agent-{uuid.uuid4()}"
-    nexus_task_queue = f"nexus-agent-{uuid.uuid4()}"
-    caller_task_queue = f"caller-{uuid.uuid4()}"
-
-    await env.create_nexus_endpoint(endpoint_name, nexus_task_queue)
-
-    # No agent workflow worker needed: input conversion fails before the handler's
-    # send_agent_message body (and therefore AgentClient) ever runs.
-    config = Config(
-        agent_task_queue=agent_task_queue,
+async def test_completed_task_history_is_replayable(env: WorkflowEnvironment) -> None:
+    task_id = f"task-{uuid.uuid4()}"
+    # The first stack starts and completes one turn. A second endpoint would not route
+    # to that workflow, so exercise close/replay in one longer-lived worker stack here.
+    endpoint = f"a2a-agent-{uuid.uuid4()}"
+    agent_queue = f"agent-{uuid.uuid4()}"
+    nexus_queue = f"nexus-{uuid.uuid4()}"
+    caller_queue = f"caller-{uuid.uuid4()}"
+    await env.create_nexus_endpoint(endpoint, nexus_queue)
+    config = A2AHandlerConfig(
+        agent_task_queue=agent_queue,
         workflow_name="ProbeAgent",
-        workflow_id_prefix="probe-",
-        is_message_queuing_enabled=False,
+        workflow_id_prefix="",
+        is_message_queuing_enabled=True,
+        agent_card=make_agent_card(
+            name="Probe", description="Probe", endpoint=endpoint
+        ),
     )
-
-    async with Worker(
-        client,
-        task_queue=nexus_task_queue,
-        nexus_service_handlers=[AgentServiceHandler(client, config)],
-    ), Worker(
-        client,
-        task_queue=caller_task_queue,
-        workflows=[MalformedInputCallerWorkflow],
+    async with (
+        Worker(env.client, task_queue=agent_queue, workflows=[ProbeAgent]),
+        Worker(
+            env.client,
+            task_queue=nexus_queue,
+            nexus_service_handlers=[A2AServiceHandler(env.client, config)],
+        ),
+        Worker(
+            env.client,
+            task_queue=caller_queue,
+            workflows=[A2ACallerWorkflow, ReplayCallerWorkflow],
+        ),
     ):
-        session_id = str(uuid.uuid4())
-        handle = await client.start_workflow(
-            MalformedInputCallerWorkflow.run,
-            CallerInput(endpoint=endpoint_name, session_id=session_id),
-            id=f"malformed-caller-{session_id}",
-            task_queue=caller_task_queue,
+        await env.client.execute_workflow(
+            A2ACallerWorkflow.run,
+            CallerInput(endpoint=endpoint, task_id=task_id),
+            id=f"send-{uuid.uuid4()}",
+            task_queue=caller_queue,
         )
-        result = await handle.result()
-
-        assert result.error_type == "NexusOperationError"
-        assert "sessionId" in result.error_message
-        assert "required" in result.error_message
-
-
-async def test_full_operation_surface(env: WorkflowEnvironment) -> None:
-    client = env.client
-    endpoint_name = f"agent-endpoint-{uuid.uuid4()}"
-    agent_task_queue = f"agent-{uuid.uuid4()}"
-    nexus_task_queue = f"nexus-agent-{uuid.uuid4()}"
-    caller_task_queue = f"caller-{uuid.uuid4()}"
-
-    await env.create_nexus_endpoint(endpoint_name, nexus_task_queue)
-
-    config = Config(
-        agent_task_queue=agent_task_queue,
-        workflow_name="GatedProbeAgent",
-        workflow_id_prefix="gated-probe-",
-        is_message_queuing_enabled=False,
-    )
-
-    async with Worker(
-        client,
-        task_queue=agent_task_queue,
-        workflows=[GatedProbeAgent],
-    ), Worker(
-        client,
-        task_queue=nexus_task_queue,
-        nexus_service_handlers=[AgentServiceHandler(client, config)],
-    ), Worker(
-        client,
-        task_queue=caller_task_queue,
-        workflows=[FullSurfaceCallerWorkflow],
-    ):
-        session_id = str(uuid.uuid4())
-        handle = await client.start_workflow(
-            FullSurfaceCallerWorkflow.run,
-            CallerInput(endpoint=endpoint_name, session_id=session_id),
-            id=f"full-surface-caller-{session_id}",
-            task_queue=caller_task_queue,
+        replay = await env.client.execute_workflow(
+            ReplayCallerWorkflow.run,
+            CallerInput(endpoint=endpoint, task_id=task_id),
+            id=f"replay-{uuid.uuid4()}",
+            task_queue=caller_queue,
         )
-        result = await handle.result()
-
-        assert result.handler_names == ["use_tool"]
-        assert "status" in result.operator_command_names
-        assert result.pending_tool_id == "fixed-tool-id"
-        assert result.approve_accepted
-        assert result.status_reply
-        assert result.poll_item_count > 0
+    assert replay.item_count > 0
+    assert replay.closed

--- a/tests/nexus_agent_adapter/test_handler_unit.py
+++ b/tests/nexus_agent_adapter/test_handler_unit.py
@@ -5,26 +5,18 @@
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
-from types import SimpleNamespace
 
 from temporalio.converter import DataConverter
 
 from temporal_agent_harness.harness.agent_protocol.agent_interface import (
     CallbackResultAck,
 )
-from temporal_agent_harness.harness.stream_poll import (
-    AgentStreamPollItem,
-    AgentStreamPollResult,
-)
 from temporal_agent_harness.nexus_agent_adapter.generated import (
     ProvideCallbackResultInput,
     ProvideCallbackResultInputResult,
-    SendAgentMessageInput,
 )
 from temporal_agent_harness.nexus_agent_adapter.handler import (
-    AgentServiceHandler,
-    Config,
-    _is_workflow_already_completed,
+    HarnessControlServiceHandler,
     _is_workflow_not_found,
 )
 
@@ -52,49 +44,6 @@ def test_provide_callback_result_input_result_round_trips() -> None:
     assert decoded.result.additional_properties == {"ok": True}
 
 
-def test_agent_stream_poll_result_round_trips() -> None:
-    result = AgentStreamPollResult(
-        items=[
-            AgentStreamPollItem(topic="turn_events", data='{"type":"reply"}', offset=7)
-        ],
-        more_ready=False,
-        next_offset=8,
-        closed=True,
-    )
-
-    decoded = _round_trip(result, AgentStreamPollResult)
-
-    assert decoded == result
-
-
-def test_poll_messages_does_not_close_before_retained_pages_are_drained() -> None:
-    result = AgentStreamPollResult(
-        items=[AgentStreamPollItem(topic="turn_events", data="first", offset=0)],
-        more_ready=True,
-        next_offset=1,
-        closed=True,
-    )
-
-    output = AgentServiceHandler._poll_messages_output(result)
-
-    assert output.more_ready
-    assert not output.closed
-
-
-def test_poll_messages_closes_on_the_final_retained_page() -> None:
-    result = AgentStreamPollResult(
-        items=[AgentStreamPollItem(topic="turn_events", data="last", offset=1)],
-        more_ready=False,
-        next_offset=2,
-        closed=True,
-    )
-
-    output = AgentServiceHandler._poll_messages_output(result)
-
-    assert not output.more_ready
-    assert output.closed
-
-
 @patch("temporal_agent_harness.nexus_agent_adapter.handler.AgentClient")
 async def test_provide_callback_result_unwraps_result_before_forwarding(
     mock_agent_client_cls: MagicMock,
@@ -106,7 +55,7 @@ async def test_provide_callback_result_unwraps_result_before_forwarding(
     mock_agent_client.provide_callback_result = AsyncMock(
         return_value=CallbackResultAck(tool_id="t1", accepted=True)
     )
-    handler = AgentServiceHandler(client=MagicMock(), config=MagicMock())
+    handler = HarnessControlServiceHandler(client=MagicMock(), config=MagicMock())
 
     await handler.provide_callback_result(
         MagicMock(),
@@ -122,75 +71,6 @@ async def test_provide_callback_result_unwraps_result_before_forwarding(
     assert mock_agent_client.provide_callback_result.await_args.kwargs["result"] == {
         "answer": 42
     }
-
-
-@patch("temporal_agent_harness.nexus_agent_adapter.handler.AgentClient")
-async def test_send_agent_message_stamps_account_and_lineage_on_new_session(
-    mock_agent_client_cls: MagicMock,
-) -> None:
-    mock_agent_client_cls.return_value.start_and_submit_message = AsyncMock(
-        return_value=SimpleNamespace(
-            turn_number=1,
-            turn_id="turn-1",
-            accepted_offset=0,
-            pending=False,
-        )
-    )
-    handler = AgentServiceHandler(
-        MagicMock(),
-        Config(
-            agent_task_queue="agents",
-            workflow_name="Agent",
-            workflow_id_prefix="",
-            is_message_queuing_enabled=True,
-        ),
-    )
-
-    await handler.send_agent_message(
-        SimpleNamespace(request_id="request-1"),
-        SendAgentMessageInput(
-            session_id="session-1",
-            msg_type="ask",
-            payload='{"text":"hello"}',
-            expected_turn=1,
-            account_id="account-1",
-            registered_agent_id="whimsical-agent",
-            delegation_lineage=["nexus-hello"],
-            delegation_depth=1,
-            max_delegation_depth=5,
-        ),
-    )
-
-    config = (
-        mock_agent_client_cls.return_value.start_and_submit_message.await_args.kwargs[
-            "start_config"
-        ]
-    )
-    assert config.account_id == "account-1"
-    assert config.registered_agent_id == "whimsical-agent"
-    assert config.delegation_lineage == ("nexus-hello",)
-    assert config.delegation_depth == 1
-    assert config.max_delegation_depth == 5
-
-
-def test_is_workflow_already_completed_true() -> None:
-    err = MagicMock()
-    err.__str__.return_value = (
-        "rpc error: workflow execution already completed for id 'x'"
-    )
-    assert _is_workflow_already_completed(err) is True
-
-
-def test_is_workflow_already_completed_case_insensitive() -> None:
-    err = MagicMock()
-    err.__str__.return_value = "Workflow Execution Already Completed"
-    assert _is_workflow_already_completed(err) is True
-
-
-def test_is_workflow_already_completed_false_for_unrelated_error() -> None:
-    err = MagicMock()
-    err.__str__.return_value = "deadline exceeded"
-    assert _is_workflow_already_completed(err) is False
 
 
 def test_is_workflow_not_found_recognizes_temporal_error() -> None:

--- a/tests/nexus_mcp/test_account_registry.py
+++ b/tests/nexus_mcp/test_account_registry.py
@@ -12,7 +12,7 @@ from durable_tools_gateway.registry import (
     ToolRegistryWorkflow,
     account_registry_workflow_id,
 )
-from durable_tools_gateway.resources import ResourceDescriptor, TEXT_AGENT_HANDLER
+from durable_tools_gateway.resources import ResourceDescriptor, text_agent_card
 
 
 def test_account_workflow_ids_are_stable_isolated_and_opaque() -> None:
@@ -34,8 +34,13 @@ def test_catalog_and_account_share_pinned_resource_descriptors() -> None:
         label="Assistant",
         description="Catalog agent",
         endpoint="assistant-endpoint",
-        service="AgentService",
-        handlers=(TEXT_AGENT_HANDLER,),
+        service="A2AService",
+        agent_card=text_agent_card(
+            name="Assistant",
+            description="Catalog agent",
+            endpoint="assistant-endpoint",
+            transport="nexus",
+        ),
     )
 
     assert catalog.publish_resources([published]) == [published]
@@ -243,6 +248,127 @@ def test_registered_spawned_agents_become_account_sessions() -> None:
     )
     assert registry.get_session(child.session_id).closed
     assert registry.get_session(parent.session_id).discovery_offset == 12
+
+
+def test_allocated_spawned_agent_is_not_started_until_a_message_is_sent() -> None:
+    registry = ToolRegistryWorkflow("account-1")
+    registry.register_agent(
+        AgentRegistration(
+            agent_id="parent",
+            kind="harness_nexus",
+            label="Parent",
+            description="Parent agent",
+            nexus_endpoint="parent-endpoint",
+        )
+    )
+    registry.register_agent(
+        AgentRegistration(
+            agent_id="research",
+            kind="harness_nexus",
+            label="Research",
+            description="Research child",
+            nexus_endpoint="research-endpoint",
+        )
+    )
+    with (
+        patch(
+            "durable_tools_gateway.registry.workflow.uuid4",
+            side_effect=["parent-session", "child-session"],
+        ),
+        patch("durable_tools_gateway.registry.workflow.time", return_value=123.0),
+        patch("durable_tools_gateway.registry.workflow.logger"),
+    ):
+        parent = registry.create_session("parent")
+        child = registry.sync_spawned_agents(
+            parent.session_id,
+            [
+                SpawnedAgentObservation(
+                    subagent_id="research-a1b2c3",
+                    agent_key="research",
+                    provider_session_id="research-workflow",
+                )
+            ],
+        )[0]
+
+        assert not child.has_started
+        assert child.current_turn == 0
+
+        child = registry.sync_spawned_agents(
+            parent.session_id,
+            [
+                SpawnedAgentObservation(
+                    subagent_id="research-a1b2c3",
+                    agent_key="research",
+                    provider_session_id="research-workflow",
+                    next_expected_turn=2,
+                    has_started=True,
+                )
+            ],
+        )[0]
+
+    assert child.has_started
+    assert child.current_turn == 1
+
+
+def test_active_snapshot_repairs_a_spawned_agent_marked_started_too_early() -> None:
+    registry = ToolRegistryWorkflow("account-1")
+    registry.register_agent(
+        AgentRegistration(
+            agent_id="parent",
+            kind="harness_nexus",
+            label="Parent",
+            description="Parent agent",
+            nexus_endpoint="parent-endpoint",
+        )
+    )
+    registry.register_agent(
+        AgentRegistration(
+            agent_id="research",
+            kind="harness_nexus",
+            label="Research",
+            description="Research child",
+            nexus_endpoint="research-endpoint",
+        )
+    )
+    with (
+        patch(
+            "durable_tools_gateway.registry.workflow.uuid4",
+            side_effect=["parent-session", "child-session"],
+        ),
+        patch("durable_tools_gateway.registry.workflow.time", return_value=123.0),
+        patch("durable_tools_gateway.registry.workflow.logger"),
+    ):
+        parent = registry.create_session("parent")
+        registry.record_spawned_agent_batch(
+            parent.session_id,
+            [
+                SpawnedAgentObservation(
+                    subagent_id="research-a1b2c3",
+                    agent_key="research",
+                    provider_session_id="research-workflow",
+                    has_started=True,
+                )
+            ],
+            [],
+            1,
+        )
+        child = next(
+            session for session in registry._sessions.values() if session.is_spawned
+        )
+        assert child is not None and child.has_started
+
+        child = registry.sync_spawned_agents(
+            parent.session_id,
+            [
+                SpawnedAgentObservation(
+                    subagent_id="research-a1b2c3",
+                    agent_key="research",
+                    provider_session_id="research-workflow",
+                )
+            ],
+        )[0]
+
+    assert not child.has_started
 
 
 def test_gateway_spawned_agent_resolves_to_the_provider_instance() -> None:

--- a/tests/nexus_mcp/test_agent_broker.py
+++ b/tests/nexus_mcp/test_agent_broker.py
@@ -4,6 +4,7 @@ import base64
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from a2a.types import SendMessageResponse, Task
 from durable_tools_gateway.agent_broker import (
     AgentActionInput,
     AgentAttachInput,
@@ -12,6 +13,7 @@ from durable_tools_gateway.agent_broker import (
     AgentDiscoveryWorkflow,
     PublishBatchInput,
     PublishBatchResult,
+    _spawned_lifecycle,
     event_broker,
     execute_agent_action,
     publish_agent_events,
@@ -21,17 +23,18 @@ from durable_tools_gateway.registry_service_handler import (
     SubagentDispatchOutput,
     SubagentStartResult,
 )
+from google.protobuf.json_format import MessageToDict
 from temporalio.api.common.v1 import Payload
 
-from temporal_agent_harness.nexus_agent_adapter.generated import (
-    PollMessagesOutput,
-    SendMessageOutput,
-    StreamItem,
-    SubagentInfo,
+from temporal_agent_harness.a2a.nexus import (
+    SubscribeToTaskItem,
+    SubscribeToTaskOutput,
+    stream_response,
 )
+from temporal_agent_harness.nexus_agent_adapter.generated import SubagentInfo
 
 
-def _stream_item(offset: int = 4, text: str = "hello") -> StreamItem:
+def _stream_item(offset: int = 4, text: str = "hello") -> SubscribeToTaskItem:
     envelope = {
         "agent_id": "agent-1",
         "turn_id": "turn-1",
@@ -40,30 +43,35 @@ def _stream_item(offset: int = 4, text: str = "hello") -> StreamItem:
         "event": {"type": "reply_delta", "text": text},
     }
     payload = Payload(data=json.dumps(envelope).encode())
-    return StreamItem(
-        topic="turn_events",
-        data=base64.b64encode(payload.SerializeToString()).decode(),
+    encoded = base64.b64encode(payload.SerializeToString()).decode()
+    return SubscribeToTaskItem(
+        data=base64.b64encode(stream_response(encoded).SerializeToString()).decode(),
         offset=offset,
     )
 
 
-def _subagent_stream_item(event_type: str, offset: int) -> StreamItem:
+def _subagent_stream_item(
+    event_type: str, offset: int, *, subagent_turn: int | None = None
+) -> SubscribeToTaskItem:
+    event = {
+        "type": event_type,
+        "subagent_id": "research-a1b2c3",
+        "agent_key": "research",
+        "workflow_id": "research-workflow",
+    }
+    if subagent_turn is not None:
+        event["subagent_turn"] = subagent_turn
     envelope = {
         "agent_id": "parent-1",
         "turn_id": "turn-1",
         "turn_number": 1,
         "timestamp": 123.0,
-        "event": {
-            "type": event_type,
-            "subagent_id": "research-a1b2c3",
-            "agent_key": "research",
-            "workflow_id": "research-workflow",
-        },
+        "event": event,
     }
     payload = Payload(data=json.dumps(envelope).encode())
-    return StreamItem(
-        topic="turn_events",
-        data=base64.b64encode(payload.SerializeToString()).decode(),
+    encoded = base64.b64encode(payload.SerializeToString()).decode()
+    return SubscribeToTaskItem(
+        data=base64.b64encode(stream_response(encoded).SerializeToString()).decode(),
         offset=offset,
     )
 
@@ -104,19 +112,30 @@ async def test_publish_activity_coalesces_adjacent_reply_deltas() -> None:
 
 
 async def test_publish_activity_projects_spawned_agent_lifecycle() -> None:
-    result = await publish_agent_events(
-        PublishBatchInput(
-            stream_id="no-browser",
-            items=[
-                _subagent_stream_item("subagent_started", 1),
-                _subagent_stream_item("subagent_stopped", 2),
-            ],
-        )
+    spawned, stopped = _spawned_lifecycle(
+        [
+            _subagent_stream_item("subagent_started", 1),
+            _subagent_stream_item("subagent_stopped", 2),
+        ]
     )
 
-    assert result.spawned_agents[0].agent_key == "research"
-    assert result.spawned_agents[0].provider_session_id == "research-workflow"
-    assert result.stopped_provider_session_ids == ["research-workflow"]
+    assert spawned[0].agent_key == "research"
+    assert spawned[0].provider_session_id == "research-workflow"
+    assert not spawned[0].has_started
+    assert stopped == ["research-workflow"]
+
+
+async def test_publish_activity_marks_spawned_agent_started_after_first_message() -> None:
+    spawned, _ = _spawned_lifecycle(
+        [
+            _subagent_stream_item("subagent_started", 1),
+            _subagent_stream_item("subagent_message_sent", 2, subagent_turn=1),
+        ]
+    )
+
+    assert not spawned[0].has_started
+    assert spawned[1].has_started
+    assert spawned[1].next_expected_turn == 2
 
 
 @patch("durable_tools_gateway.agent_broker.workflow.get_external_workflow_handle")
@@ -154,11 +173,16 @@ async def test_native_send_is_one_standalone_nexus_operation() -> None:
     temporal = MagicMock()
     nexus = MagicMock()
     nexus.execute_operation = AsyncMock(
-        return_value=SendMessageOutput(
-            turn_number=2,
-            turn_id="turn-2",
-            stream_head_offset=8,
-            pending=False,
+        return_value=SendMessageResponse(
+            task=Task(
+                id="provider-session",
+                metadata={
+                    "temporal.io/turn-number": 2,
+                    "temporal.io/turn-id": "turn-2",
+                    "temporal.io/accepted-offset": 8,
+                    "temporal.io/pending": False,
+                },
+            )
         )
     )
     temporal.create_nexus_client.return_value = nexus
@@ -179,8 +203,8 @@ async def test_native_send_is_one_standalone_nexus_operation() -> None:
     )
 
     sent = nexus.execute_operation.await_args.args[1]
-    assert sent.session_id == "provider-session"
-    assert sent.expected_turn == 2
+    assert sent.message.task_id == "provider-session"
+    assert MessageToDict(sent.metadata)["expected_turn"] == 2
     assert nexus.execute_operation.await_args.kwargs["id"] == "broker-action-1"
     assert result == {
         "turn_number": 2,
@@ -194,11 +218,16 @@ async def test_native_send_can_defer_turn_reconciliation_to_agent_service() -> N
     temporal = MagicMock()
     nexus = MagicMock()
     nexus.execute_operation = AsyncMock(
-        return_value=SendMessageOutput(
-            turn_number=3,
-            turn_id="turn-3",
-            stream_head_offset=9,
-            pending=False,
+        return_value=SendMessageResponse(
+            task=Task(
+                id="provider-session",
+                metadata={
+                    "temporal.io/turn-number": 3,
+                    "temporal.io/turn-id": "turn-3",
+                    "temporal.io/accepted-offset": 9,
+                    "temporal.io/pending": False,
+                },
+            )
         )
     )
     temporal.create_nexus_client.return_value = nexus
@@ -215,7 +244,7 @@ async def test_native_send_can_defer_turn_reconciliation_to_agent_service() -> N
     )
 
     sent = nexus.execute_operation.await_args.args[1]
-    assert sent.expected_turn is None
+    assert "expected_turn" not in MessageToDict(sent.metadata)
 
 
 @patch("durable_tools_gateway.agent_broker.workflow.create_nexus_client")
@@ -235,9 +264,9 @@ async def test_subagent_discovery_reads_missed_lifecycle_and_live_status(
     )
     nexus.execute_operation = AsyncMock(
         side_effect=[
-            PollMessagesOutput(
+            SubscribeToTaskOutput(
                 items=[_subagent_stream_item("subagent_started", 4)],
-                next_offset=5,
+                next_cursor=5,
                 more_ready=False,
                 closed=False,
             ),
@@ -313,7 +342,9 @@ async def test_attach_stops_after_an_empty_poll_when_agent_is_idle(
     nexus = MagicMock()
     nexus.execute_operation = AsyncMock(
         side_effect=[
-            PollMessagesOutput(items=[], next_offset=3, more_ready=False, closed=False),
+            SubscribeToTaskOutput(
+                items=[], next_cursor=3, more_ready=False, closed=False
+            ),
             MagicMock(
                 turn_active=False,
                 pending_turns=[],
@@ -351,9 +382,9 @@ async def test_attach_stays_open_until_all_pending_approvals_resolve(
     nexus = MagicMock()
     nexus.execute_operation = AsyncMock(
         side_effect=[
-            PollMessagesOutput(
+            SubscribeToTaskOutput(
                 items=[_stream_item()],
-                next_offset=5,
+                next_cursor=5,
                 more_ready=False,
                 closed=False,
             ),
@@ -363,8 +394,8 @@ async def test_attach_stays_open_until_all_pending_approvals_resolve(
                 pending_approvals=[MagicMock()],
                 pending_callbacks=[],
             ),
-            PollMessagesOutput(
-                items=[], next_offset=5, more_ready=False, closed=False
+            SubscribeToTaskOutput(
+                items=[], next_cursor=5, more_ready=False, closed=False
             ),
             MagicMock(
                 turn_active=False,
@@ -403,8 +434,8 @@ async def test_attach_publishes_final_items_before_closing(
 ) -> None:
     nexus = MagicMock()
     nexus.execute_operation = AsyncMock(
-        return_value=PollMessagesOutput(
-            items=[_stream_item()], next_offset=5, more_ready=False, closed=True
+        return_value=SubscribeToTaskOutput(
+            items=[_stream_item()], next_cursor=5, more_ready=False, closed=True
         )
     )
     mock_create_client.return_value = nexus

--- a/tests/nexus_mcp/test_brokered_web.py
+++ b/tests/nexus_mcp/test_brokered_web.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from a2a.types import SendMessageResponse, Task
 from durable_tools_gateway.registry import (
     AccountEntries,
     AgentRegistration,
@@ -18,9 +19,9 @@ from durable_tools_gateway.registry_service_handler import (
     SubagentDispatchOutput,
 )
 from durable_tools_gateway.resources import (
-    TEXT_AGENT_HANDLER,
     AccountResourceRegistration,
     ResourceDescriptor,
+    text_agent_card,
 )
 from durable_tools_gateway.tool_history import ToolCallRecord
 from durable_tools_gateway.web import (
@@ -28,12 +29,12 @@ from durable_tools_gateway.web import (
     create_account_agent_app,
 )
 from fastapi.testclient import TestClient
+from google.protobuf.json_format import MessageToDict
 from temporalio.api.workflowservice.v1 import DescribeActivityExecutionResponse
 from temporalio.contrib.pydantic import pydantic_data_converter
 
 from temporal_agent_harness.nexus_agent_adapter.generated import (
     AgentInterfaceOutput,
-    SendMessageOutput,
 )
 
 
@@ -155,8 +156,13 @@ def test_catalog_installs_shared_descriptor_into_account_registry() -> None:
         "Catalog Agent",
         "Published globally",
         "catalog-agent-endpoint",
-        "AgentService",
-        (TEXT_AGENT_HANDLER,),
+        "A2AService",
+        text_agent_card(
+            name="Catalog Agent",
+            description="Published globally",
+            endpoint="catalog-agent-endpoint",
+            transport="nexus",
+        ),
     )
     client, handle, _ = _app_client(catalog_override=[catalog_agent])
 
@@ -334,6 +340,40 @@ def test_provider_session_alias_resolves_through_the_account_registry() -> None:
     assert resolved_ids == ["provider-child", "source-child"]
 
 
+def test_provider_alias_waits_for_spawned_session_projection() -> None:
+    spawned = SessionRecord(
+        account_id="account-1",
+        session_id="session-child",
+        agent_id="assistant",
+        provider_session_id="provider-child",
+        source_session_id="writer-subagent-child",
+        created_at=123.0,
+        label="Spawned child",
+        is_spawned=True,
+        has_started=True,
+        current_turn=1,
+    )
+    client, handle, _ = _app_client(session_override=spawned)
+    query = handle.query.side_effect
+    attempts = 0
+
+    async def delayed_projection(method, *args, **kwargs):
+        nonlocal attempts
+        if method is ToolRegistryWorkflow.resolve_session:
+            attempts += 1
+            if attempts < 3:
+                return None
+        return await query(method, *args, **kwargs)
+
+    handle.query.side_effect = delayed_projection
+
+    with client:
+        response = client.get("/api/agent-interface/writer-subagent-child")
+
+    assert response.status_code == 200
+    assert attempts == 3
+
+
 def test_refresh_reconciles_registered_children_from_native_status() -> None:
     started = SessionRecord(
         account_id="account-1",
@@ -387,11 +427,16 @@ def test_refresh_reconciles_registered_children_from_native_status() -> None:
 def test_native_send_defers_stale_turn_reconciliation_to_agent_service() -> None:
     client, handle, temporal = _app_client()
     temporal.create_nexus_client.return_value.execute_operation.return_value = (
-        SendMessageOutput(
-            turn_number=2,
-            turn_id="turn-2",
-            stream_head_offset=8,
-            pending=False,
+        SendMessageResponse(
+            task=Task(
+                id="session-1",
+                metadata={
+                    "temporal.io/turn-number": 2,
+                    "temporal.io/turn-id": "turn-2",
+                    "temporal.io/accepted-offset": 8,
+                    "temporal.io/pending": False,
+                },
+            )
         )
     )
 
@@ -408,7 +453,7 @@ def test_native_send_defers_stale_turn_reconciliation_to_agent_service() -> None
     assert response.status_code == 200
     nexus = temporal.create_nexus_client.return_value
     operation_input = nexus.execute_operation.await_args.args[1]
-    assert operation_input.expected_turn is None
+    assert "expected_turn" not in MessageToDict(operation_input.metadata)
     assert nexus.execute_operation.await_args.kwargs["id"].startswith("ui-agent-send-")
     temporal.execute_workflow.assert_not_awaited()
     assert any(
@@ -494,10 +539,10 @@ async def test_external_turn_replays_from_deterministic_activity_history() -> No
     response.info.activity_type.name = "subagent_proxy_activity"
     response.info.task_queue = "mcp-registry"
     response.info.schedule_time.FromDatetime(
-        datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+        datetime(2026, 9, 1, 12, 0, tzinfo=UTC)
     )
     response.info.close_time.FromDatetime(
-        datetime(2026, 9, 1, 12, 0, 2, tzinfo=timezone.utc)
+        datetime(2026, 9, 1, 12, 0, 2, tzinfo=UTC)
     )
     activity_input = SubagentDispatchInput(
         url="http://writer",
@@ -612,9 +657,8 @@ def test_spawned_external_stream_merges_temporal_and_ui_turn_offsets() -> None:
     with patch(
         "durable_tools_gateway.web._replay_external_activity_turn",
         new=AsyncMock(return_value=replayed_turn_one),
-    ) as replay:
-        with client:
-            response = client.get("/api/attach?session_id=session-writer&from_offset=2")
+    ) as replay, client:
+        response = client.get("/api/attach?session_id=session-writer&from_offset=2")
 
     assert response.status_code == 200
     body = response.text

--- a/tests/nexus_mcp/test_registry_wire_shapes.py
+++ b/tests/nexus_mcp/test_registry_wire_shapes.py
@@ -18,9 +18,6 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import temporalio.nexus
-from mcp.types import CallToolResult, TextContent
-from temporalio.converter import DataConverter
-
 from durable_tools_gateway.generated import (
     CallToolInput,
     CallToolInputArguments,
@@ -36,11 +33,13 @@ from durable_tools_gateway.registry import (
     account_registry_workflow_id,
     fetch_external_tools,
 )
-from durable_tools_gateway.resources import ResourceDescriptor, TEXT_AGENT_HANDLER
 from durable_tools_gateway.registry_service_handler import (
     RegistryServiceHandler,
     mcp_proxy_activity,
 )
+from durable_tools_gateway.resources import ResourceDescriptor, text_agent_card
+from mcp.types import CallToolResult, TextContent
+from temporalio.converter import DataConverter
 
 _payload_converter = DataConverter.default.payload_converter
 _FAKE_NEXUS_INFO = temporalio.nexus.Info(
@@ -92,8 +91,13 @@ async def test_resolve_toolbox_filters_self_ancestors_and_max_depth() -> None:
             "Parent",
             "",
             "parent-endpoint",
-            "AgentService",
-            (TEXT_AGENT_HANDLER,),
+            "A2AService",
+            text_agent_card(
+                name="Parent",
+                description="",
+                endpoint="parent-endpoint",
+                transport="nexus",
+            ),
         ),
         "child": ResourceDescriptor(
             "child",
@@ -103,8 +107,13 @@ async def test_resolve_toolbox_filters_self_ancestors_and_max_depth() -> None:
             "Child",
             "",
             "child-endpoint",
-            "AgentService",
-            (TEXT_AGENT_HANDLER,),
+            "A2AService",
+            text_agent_card(
+                name="Child",
+                description="",
+                endpoint="child-endpoint",
+                transport="nexus",
+            ),
         ),
         "tool": ResourceDescriptor(
             "tool", 1, "mcp", "nexus", "Tool", "", "tool-endpoint", "tool-service"

--- a/tests/nexus_mcp/test_subagent_gateway.py
+++ b/tests/nexus_mcp/test_subagent_gateway.py
@@ -6,6 +6,7 @@ import httpx
 import nexusrpc
 import pytest
 import temporalio.nexus
+from a2a.types import Message, Part, Role, SendMessageRequest
 from durable_tools_gateway.generated import (
     DispatchSubagentTurnInput,
     StartSubagentInput,
@@ -13,6 +14,7 @@ from durable_tools_gateway.generated import (
 )
 from durable_tools_gateway.registry import SubagentInstanceRoute, ToolRegistryWorkflow
 from durable_tools_gateway.registry_service_handler import (
+    GatewayA2AServiceHandler,
     RegistryServiceHandler,
     SubagentDispatchOutput,
     SubagentStartResult,
@@ -86,11 +88,118 @@ def test_instance_route_survives_factory_reregistration() -> None:
         registry.bind_subagent_instance("gateway-instance-1", route)
         registry.register_subagent("writer", "http://provider-v2")
 
-    assert (
-        registry.find_subagent_instance("gateway-instance-1") == route
-    )
+    assert registry.find_subagent_instance("gateway-instance-1") == route
     registry.unbind_subagent_instance("gateway-instance-1")
     assert registry.find_subagent_instance("gateway-instance-1") is None
+
+
+def test_allocated_instance_route_can_bind_its_provider_task() -> None:
+    registry = ToolRegistryWorkflow("account-1")
+    allocated = SubagentInstanceRoute(
+        alias="writer",
+        url="http://provider-v1",
+        provider_instance_id="",
+    )
+    bound = SubagentInstanceRoute(
+        alias="writer",
+        url="http://provider-v1",
+        provider_instance_id="provider-instance-1",
+    )
+
+    registry.bind_subagent_instance("gateway-instance-1", allocated)
+    registry.bind_subagent_instance("gateway-instance-1", bound)
+
+    assert registry.find_subagent_instance("gateway-instance-1") == bound
+
+
+def test_bound_instance_route_cannot_change_provider_task() -> None:
+    registry = ToolRegistryWorkflow("account-1")
+    registry.bind_subagent_instance(
+        "gateway-instance-1",
+        SubagentInstanceRoute(
+            alias="writer",
+            url="http://provider-v1",
+            provider_instance_id="provider-instance-1",
+        ),
+    )
+
+    with pytest.raises(ApplicationError, match="has a different route"):
+        registry.bind_subagent_instance(
+            "gateway-instance-1",
+            SubagentInstanceRoute(
+                alias="writer",
+                url="http://provider-v1",
+                provider_instance_id="provider-instance-2",
+            ),
+        )
+
+
+@patch("temporalio.nexus.info", return_value=_FAKE_NEXUS_INFO)
+async def test_gateway_a2a_send_binds_the_provider_task(
+    _mock_info: MagicMock,
+) -> None:
+    registry = ToolRegistryWorkflow("account-1")
+    registry.bind_subagent_instance(
+        "gateway-instance-1",
+        SubagentInstanceRoute(
+            alias="writer",
+            url="http://provider-v1",
+            provider_instance_id="",
+        ),
+    )
+    handle = MagicMock()
+
+    async def query(method, task_id, **_kwargs):
+        assert method is ToolRegistryWorkflow.find_subagent_instance
+        return registry.find_subagent_instance(task_id)
+
+    async def update(method, *, args, **_kwargs):
+        assert method is ToolRegistryWorkflow.bind_subagent_instance
+        registry.bind_subagent_instance(*args)
+
+    handle.query = AsyncMock(side_effect=query)
+    handle.execute_update = AsyncMock(side_effect=update)
+    client = MagicMock()
+    client.start_workflow = AsyncMock(return_value=handle)
+    client.execute_activity = AsyncMock(
+        return_value=SubagentDispatchOutput(
+            output='{"text":"done"}',
+            turn_id="provider-instance-1-turn-1",
+            turn_number=1,
+            provider_instance_id="provider-instance-1",
+        )
+    )
+    request = SendMessageRequest(
+        message=Message(
+            message_id="message-1",
+            role=Role.ROLE_USER,
+            task_id="gateway-instance-1",
+            context_id="gateway-instance-1",
+            parts=[Part(text="hello")],
+            metadata={"temporal.io/message-type": "ask"},
+        ),
+        metadata={
+            "account_id": "account-1",
+            "agent_id": "writer",
+            "expected_turn": 1,
+        },
+    )
+
+    response = await GatewayA2AServiceHandler(client).send_message(
+        _context(), request
+    )
+
+    assert response.task.artifacts[0].parts[0].text == "done"
+    assert registry.find_subagent_instance(
+        "gateway-instance-1"
+    ) == SubagentInstanceRoute(
+        alias="writer",
+        url="http://provider-v1",
+        provider_instance_id="provider-instance-1",
+    )
+    assert handle.execute_update.await_args.kwargs["id"] == (
+        "a2a-provider-bind-gateway-instance-1-provider-instance-1"
+    )
 
 
 @patch("temporalio.nexus.info", return_value=_FAKE_NEXUS_INFO)
@@ -112,9 +221,12 @@ async def test_start_binds_a_gateway_instance(_mock_info: MagicMock) -> None:
         provider_instance_id="provider-instance-7",
     )
     assert activity_input.idempotency_key == "agent-1:writer:start:start-request"
-    assert client.execute_activity.await_args.kwargs[
-        "schedule_to_close_timeout"
-    ].total_seconds() == 50
+    assert (
+        client.execute_activity.await_args.kwargs[
+            "schedule_to_close_timeout"
+        ].total_seconds()
+        == 50
+    )
 
 
 @patch("temporalio.nexus.info", return_value=_FAKE_NEXUS_INFO)
@@ -145,9 +257,12 @@ async def test_dispatch_key_includes_instance_id(_mock_info: MagicMock) -> None:
     assert client.execute_activity.await_args.kwargs["id_conflict_policy"] == (
         ActivityIDConflictPolicy.USE_EXISTING
     )
-    assert client.execute_activity.await_args.kwargs[
-        "schedule_to_close_timeout"
-    ].total_seconds() == 300
+    assert (
+        client.execute_activity.await_args.kwargs[
+            "schedule_to_close_timeout"
+        ].total_seconds()
+        == 300
+    )
 
 
 @patch("temporalio.nexus.info", return_value=_FAKE_NEXUS_INFO)
@@ -171,9 +286,7 @@ async def test_stop_targets_one_instance(_mock_info: MagicMock) -> None:
     client = _client()
     await RegistryServiceHandler(client).stop_subagent(
         _context("stop-request"),
-        StopSubagentInput(
-            account_id="agent-1", instance_id="gateway-instance-1"
-        ),
+        StopSubagentInput(account_id="agent-1", instance_id="gateway-instance-1"),
     )
 
     activity_input = client.execute_activity.await_args.args[1]
@@ -181,34 +294,26 @@ async def test_stop_targets_one_instance(_mock_info: MagicMock) -> None:
     update = client.start_workflow.return_value.execute_update
     assert update.await_args.args[0] is ToolRegistryWorkflow.unbind_subagent_instance
     assert update.await_args.args[1] == "gateway-instance-1"
-    assert client.execute_activity.await_args.kwargs[
-        "schedule_to_close_timeout"
-    ].total_seconds() == 50
-
-
-async def test_provider_rejection_is_not_retried() -> None:
-    response = httpx.Response(
-        409,
-        json={"detail": "stale turn"},
-        request=httpx.Request("POST", "http://provider/sessions"),
+    assert (
+        client.execute_activity.await_args.kwargs[
+            "schedule_to_close_timeout"
+        ].total_seconds()
+        == 50
     )
-    http = AsyncMock()
-    http.post.return_value = response
-    context = MagicMock()
-    context.__aenter__ = AsyncMock(return_value=http)
-    context.__aexit__ = AsyncMock(return_value=None)
 
-    with patch(
-        "durable_tools_gateway.registry_service_handler.httpx.AsyncClient",
-        return_value=context,
-    ):
-        with pytest.raises(ApplicationError) as exc_info:
-            await subagent_start_activity(
-                ActivityStartInput(url="http://provider", idempotency_key="start-1")
-            )
 
-    assert exc_info.value.non_retryable
-    assert exc_info.value.type == "SubagentProtocolError"
+async def test_a2a_task_allocation_is_deterministic_and_does_not_call_provider() -> (
+    None
+):
+    first = await subagent_start_activity(
+        ActivityStartInput(url="http://provider", idempotency_key="start-1")
+    )
+    second = await subagent_start_activity(
+        ActivityStartInput(url="http://provider", idempotency_key="start-1")
+    )
+
+    assert first == second
+    assert first.instance_id
 
 
 def test_provider_rate_limit_remains_retryable() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,31 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "a2a-sdk"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "culsans", marker = "python_full_version < '3.13'" },
+    { name = "google-api-core" },
+    { name = "googleapis-common-protos" },
+    { name = "httpx" },
+    { name = "json-rpc" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/cc/59b35c518d8289bd59d20d9d216ca29ccb41c4697eb85971efe41d1adaf3/a2a_sdk-1.1.2.tar.gz", hash = "sha256:f928d8bf9a0dc0a473ee8258bd5226c1b8520a85c70e7f233c3b9b0e30a1bd10", size = 379627, upload-time = "2026-07-22T13:40:51.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/33/d414a03d5ef5a7d6d09a20dc9f8094e7fb9edb488662ff99c535a2a62cf1/a2a_sdk-1.1.2-py3-none-any.whl", hash = "sha256:eb9a698f526dc45a9ea967d7804e7aa363ff273d2c44fbed699bc68c9399f9c9", size = 245981, upload-time = "2026-07-22T13:40:49.484Z" },
+]
+
+[package.optional-dependencies]
+http-server = [
+    { name = "sse-starlette", marker = "python_full_version >= '3.13'" },
+    { name = "starlette", marker = "python_full_version >= '3.13'" },
+]
+
+[[package]]
 name = "aioboto3"
 version = "15.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -186,6 +211,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
+]
+
+[[package]]
+name = "aiologic"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/d3/2d310b1b839014034dba0cba685e492df8a5c7ad32c19cab7e979eed6554/aiologic-0.17.1-py3-none-any.whl", hash = "sha256:c66b319830fedb7ca3d2b2125fa6f5b653f89418c2a27ea76f259ec5f00943c0", size = 161331, upload-time = "2026-06-27T20:41:31.877Z" },
 ]
 
 [[package]]
@@ -591,6 +630,19 @@ wheels = [
 ]
 
 [[package]]
+name = "culsans"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiologic", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5d/9fb19fb38f6d6120422064279ea5532e22b84aa2be8831d49607194feda3/culsans-0.11.0-py3-none-any.whl", hash = "sha256:278d118f63fc75b9db11b664b436a1b83cc30d9577127848ba41420e66eb5a47", size = 21811, upload-time = "2025-12-31T23:15:37.189Z" },
+]
+
+[[package]]
 name = "detect-installer"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -963,6 +1015,22 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7c/9be3903e3d45415e8ca493c75f8990a0f6f579d168015d44c379350d0ab0/google_api_core-2.34.0.tar.gz", hash = "sha256:98a779fe72de956eb1c9c2f47ff4c4432a668ece1a002ec38bed07ec2698ae59", size = 187953, upload-time = "2026-08-06T06:23:58.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/c1/a8a92ae1bc4b1a8f804c776d7d3f0c771b78a62c3ad4df1be41b3fd8c767/google_api_core-2.34.0-py3-none-any.whl", hash = "sha256:cdf9c67e7ca2402d86ccbfde5f2503fc83e3cc3f58cc78456ae96cad24a6d2de", size = 180545, upload-time = "2026-08-06T06:22:47.502Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.55.0"
 source = { registry = "https://pypi.org/simple" }
@@ -999,6 +1067,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/52/0244e310812f3063d09d60b30ae29ab7df9343bd005744cd5eeaa6ba39b4/google_genai-2.8.0.tar.gz", hash = "sha256:37a9b3cb127d763e7f4ca47452ae3562c87728773bd1b149f7b559c239da2bc1", size = 564955, upload-time = "2026-06-03T22:55:38.397Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/de/747ad1aa49e902da9a4699081c282a1ed8ceed3b4d295fd99a6d286e09e4/google_genai-2.8.0-py3-none-any.whl", hash = "sha256:4da0a223a100f4b37f609a68b835e3326ab0fa313314dc0fd9d34e76ee293844", size = 832497, upload-time = "2026-06-03T22:55:36.598Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/90/fb8f1c84537fbf210c1f53a53ae473a805f6599c5a40b93c1bbadd211f7a/googleapis_common_protos-1.75.2.tar.gz", hash = "sha256:8829a3d1e4508c5b7b9a6b9525f7fccff611f8531644579a76466c29295d4bb2", size = 154083, upload-time = "2026-08-25T19:19:13.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/5b/1c9e55363c3b1890a98cae813de5b4ea327845756cd8fb7ee690140c7eac/googleapis_common_protos-1.75.2-py3-none-any.whl", hash = "sha256:6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e", size = 307002, upload-time = "2026-08-25T19:18:08.927Z" },
 ]
 
 [[package]]
@@ -1281,6 +1361,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
+]
+
+[[package]]
+name = "json-rpc"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/9e/59f4a5b7855ced7346ebf40a2e9a8942863f644378d956f68bcef2c88b90/json-rpc-1.15.0.tar.gz", hash = "sha256:e6441d56c1dcd54241c937d0a2dcd193bdf0bdc539b5316524713f554b7f85b9", size = 28854, upload-time = "2023-06-11T09:45:49.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/9e/820c4b086ad01ba7d77369fb8b11470a01fac9b4977f02e18659cf378b6b/json_rpc-1.15.0-py2.py3-none-any.whl", hash = "sha256:4a4668bbbe7116feb4abbd0f54e64a4adcf4b8f648f19ffa0848ad0f6606a9bf", size = 39450, upload-time = "2023-06-11T09:45:47.136Z" },
 ]
 
 [[package]]
@@ -1699,6 +1788,7 @@ name = "nexus-mcp"
 version = "0.1.0"
 source = { editable = "nexus/mcp" }
 dependencies = [
+    { name = "a2a-sdk", extra = ["http-server"], marker = "python_full_version >= '3.13'" },
     { name = "anyio", marker = "python_full_version >= '3.13'" },
     { name = "fastapi", marker = "python_full_version >= '3.13'" },
     { name = "httpx", marker = "python_full_version >= '3.13'" },
@@ -1711,6 +1801,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=1.1.2" },
     { name = "anyio", specifier = ">=4.0.0" },
     { name = "fastapi", specifier = ">=0.136.3" },
     { name = "httpx", specifier = ">=0.27.0" },
@@ -1985,6 +2076,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/a6/4fbadcc2044034449b3f8f0ce82dcf3005d53f37c136642103fd4836a31c/proto_plus-1.28.4.tar.gz", hash = "sha256:5ff7ecad828e032a491fcb86947801768e32237f99dd049b649965b892ae9a63", size = 58679, upload-time = "2026-08-25T19:19:15.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5d/0f04b85dafdc3250ced7f2592efc17dce7f40712e941e9632202481e600d/proto_plus-1.28.4-py3-none-any.whl", hash = "sha256:4b01341272f8a348db3f003b6143109f83ab43091019d5181b3fcdf500ab32aa", size = 50797, upload-time = "2026-08-25T19:18:12.338Z" },
 ]
 
 [[package]]
@@ -2977,6 +3080,7 @@ name = "temporal-agent-harness"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "a2a-sdk" },
     { name = "pydantic" },
     { name = "temporalio" },
 ]
@@ -3039,6 +3143,7 @@ examples = [
 
 [package.metadata]
 requires-dist = [
+    { name = "a2a-sdk", specifier = ">=1.1.2" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'ui'", specifier = ">=0.136.3" },
     { name = "google-auth", marker = "extra == 'genai'", specifier = ">=2.53.0" },
     { name = "google-genai", marker = "extra == 'genai'", specifier = ">=2.0.0" },


### PR DESCRIPTION
> Superseded by #92. This work was rebuilt into the foundational subagent commit so A2A is the protocol from the start rather than a compatibility layer added at the top of the stack. The head branch has been deleted.

## Original scope

- replace the bespoke agent capability/session wire shape with standard A2A AgentCards, Messages, Tasks, and task lifecycle operations
- expose harness-native agents through an A2A Temporal Nexus binding
- route account-registered HTTP agents with official A2A HTTP semantics
- keep approvals, callbacks, operator commands, and rich harness rendering as explicit harness extensions