### PR TITLE
Point users at tagged releases instead of cloning main

### DIFF
--- a/.github/workflows/ui-dist.yml
+++ b/.github/workflows/ui-dist.yml
@@ -32,9 +32,12 @@ jobs:
       - uses: actions/checkout@v4
 
       # Must come BEFORE setup-node: `cache: pnpm` needs the pnpm binary to resolve the store
-      # path. With no `version` input, action-setup reads package.json's "packageManager" field,
-      # so the pnpm pin stays in exactly one place.
+      # path. With no `version` input, action-setup reads the "packageManager" field, so the pnpm
+      # pin stays in exactly one place — but it looks in the repo ROOT by default, and this repo's
+      # only package.json is ui/package.json, so the path has to be given explicitly.
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: ui/package.json
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ui-dist.yml
+++ b/.github/workflows/ui-dist.yml
@@ -1,0 +1,71 @@
+name: UI dist
+
+# The browser UI is committed prebuilt to temporal_agent_harness/ui/dist so that a downloaded
+# release archive runs with no Node toolchain at all (see the Installation section of README.md).
+# That makes the committed build load-bearing: if it drifts from ui/, a release ships a stale UI
+# and nothing catches it — the server happily serves whatever is in dist/, and the tests only
+# assert that the assets exist and are wired up, not that they match the current source.
+#
+# This job rebuilds the UI and fails if the result differs from what is committed.
+#
+# Deliberately NOT filtered by changed paths: a filter that misses a file is precisely the silent
+# staleness this guards against, and the whole job runs in well under a minute.
+
+on:
+  pull_request:
+  # Also on main so a direct push can't slip a stale build into the commit a release is cut from.
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-dist-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Committed dist matches ui/ source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Must come BEFORE setup-node: `cache: pnpm` needs the pnpm binary to resolve the store
+      # path. With no `version` input, action-setup reads package.json's "packageManager" field,
+      # so the pnpm pin stays in exactly one place.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
+
+      - name: Install UI dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: ui
+
+      # vite.config.ts writes to ../temporal_agent_harness/ui/dist with emptyOutDir, so this
+      # overwrites the committed build in place. The git check below is what compares them.
+      # Asset filenames are content-hashed, so a source change shows up as new untracked files
+      # plus deletions of the old ones rather than as modified content.
+      - name: Rebuild the UI
+        run: pnpm run build
+        working-directory: ui
+
+      - name: Verify the committed build is current
+        run: |
+          set -euo pipefail
+          changes="$(git status --porcelain -- temporal_agent_harness/ui/dist)"
+          if [ -n "$changes" ]; then
+            echo "::error::temporal_agent_harness/ui/dist is out of date with the source in ui/."
+            echo
+            echo "Rebuild it and commit the result:"
+            echo "    just app-build        # or: pnpm --dir ui run build"
+            echo
+            echo "Differences (?? = new, D = removed, M = changed):"
+            echo "$changes"
+            exit 1
+          fi
+          echo "Committed UI build matches ui/ source."

--- a/README.md
+++ b/README.md
@@ -28,15 +28,38 @@ agent development, so you get the power without hand-rolling the orchestration.
 
 ## Installation
 
-Add it to your project as a **git dependency**. In a [`uv`](https://docs.astral.sh/uv/)-managed project, the quickest way is `uv add`:
+There are two ways in, depending on what you want to do. Both pin to a **tagged release** —
+see [Versioning and stability](#versioning-and-stability) for why that matters.
+
+### Try it — run the example agents
+
+Clone at a release tag. No Node/pnpm needed: the browser UI ships prebuilt.
+
+```bash
+git clone --branch 0.1.0 https://github.com/temporal-community/temporal-agent-harness.git
+cd temporal-agent-harness
+```
+
+Git will note that you're in "detached HEAD" — that's expected, it just means you're sitting on
+the tag rather than on a branch. Later, move to a newer release with
+`git fetch --tags && git checkout <version>`, or see what changed between two of them with
+`git diff 0.1.0 0.2.0`.
+
+Then jump to [Run the examples](#run-the-examples). You'll need
+[uv](https://docs.astral.sh/uv/), [just](https://just.systems/), and the Temporal cli (or Temporal Cloud).
+
+### Build with it — add the harness to your own project
+
+Add it as a **git dependency pinned to a tag**. In a [`uv`](https://docs.astral.sh/uv/)-managed
+project:
 
 ```bash
 # core harness — define and run agent workflows
-uv add "temporal-agent-harness @ git+https://github.com/temporal-community/temporal-agent-harness.git"
+uv add "temporal-agent-harness @ git+https://github.com/temporal-community/temporal-agent-harness.git@0.1.0"
 ```
 
 Or declare it in `pyproject.toml` — depend on the package (with any extras you need) and point
-its source at the git repository:
+its source at the tag:
 
 ```toml
 [project]
@@ -45,11 +68,10 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-temporal-agent-harness = { git = "https://github.com/temporal-community/temporal-agent-harness.git", branch = "main" }
+temporal-agent-harness = { git = "https://github.com/temporal-community/temporal-agent-harness.git", tag = "0.1.0" }
 ```
 
-Then run `uv sync`. (Pin to a specific `rev = "..."` instead of `branch = "main"` for a
-reproducible build.)
+Then run `uv sync`.
 
 **Extras:**
 
@@ -111,6 +133,20 @@ description = "A short description shown in the UI."
 The app factory serves both `/api/*` and the packaged Svelte UI. The helper
 `create_session_manager_worker` only registers the packaged session-manager
 workflow; run your own agent workflows on their own workers and task queues.
+
+## Versioning and stability
+
+**Install from a tagged release.** Every release is listed on the
+[releases page](https://github.com/temporal-community/temporal-agent-harness/releases), and each
+tag marks a commit that is known-good at the moment it was cut: the tests passed, and the
+prebuilt browser UI matches the source it was built from.
+
+**This project is very early and experimental - `main` may break at any time.** 
+
+Releases are cut manually, when the maintainers judge the state stable. This project is 
+**experimental** and pre-1.0: APIs will change between releases, without warning. Pinning to a 
+tag is what keeps that churn from reaching you unannounced — so pin, and upgrade deliberately 
+when you want to try out new harness capabilities.
 
 ## What you get
 
@@ -382,17 +418,22 @@ self._runner = AgentWorkflowRunner(
 - Python **3.11+**
 - [uv](https://docs.astral.sh/uv/) for dependency management
 - [just](https://just.systems/) for the example recipes
-- [pnpm](https://pnpm.io/) for building or developing the Svelte UI
 - A Temporal service. `just temporal` starts a local dev server if you have the `temporal`
   CLI installed.
 
+[pnpm](https://pnpm.io/) is **not** required to run anything: the browser UI ships prebuilt in
+`temporal_agent_harness/ui/dist`, both in release archives and in the repo. You only need it to
+*change* the UI — see [UI development](docs/internal/development.md#ui-development).
+
 ## Run the examples
 
-One `.env.local` at the **repo root** serves every example. Create it and install the UI deps once:
+These run from a checkout or an unpacked
+[release archive](#try-it--run-the-example-agents) — the steps are identical.
+
+One `.env.local` at the **project root** serves every example. Create it once:
 
 ```bash
 cp .env.example .env.local
-just app-install
 ```
 
 Set the creds for whichever agents you'll run: `OPENAI_API_KEY` (react_agent, openai_hello,
@@ -408,18 +449,18 @@ conversational Code Mode travel agent + a subagent variant) is the best starting
 cd examples/monty
 just temporal          # local Temporal dev server; skip if you bring your own
 just session-manager   # worker hosting the packaged SessionManagerWorkflow
-just server            # builds + serves the Svelte UI + /api on :8000 (this example's agents only)
+just server            # serves the Svelte UI + /api on :8000 (this example's agents only)
 just worker            # this example's agent worker
 ```
 
 Open <http://localhost:8000> and pick an agent. Every example follows the same recipe set
 (`temporal` / `session-manager` / `server` / `worker`, plus `client` where noted). `just server`
-runs `app-build` first, so :8000 serves the freshly built UI from
-`temporal_agent_harness/ui/dist`.
+serves the prebuilt UI from `temporal_agent_harness/ui/dist`, so it needs no Node/pnpm. If you're
+changing the UI, use `just dev-server` (rebuild + serve) instead.
 
 ### All examples behind one UI
 
-The **root** justfile runs every example agent at once so the UI lists them all. From the repo root,
+The **root** justfile runs every example agent at once so the UI lists them all. From the project root,
 each in its own terminal:
 
 ```bash
@@ -448,8 +489,9 @@ its worker.
 
 ## Status & docs
 
-This is experimental and under active development; expect breaking changes. Deeper design
-documentation — the agent protocol, the streaming model, human-in-the-loop approvals, and
+This is experimental and under active development; expect breaking changes — see
+[Versioning and stability](#versioning-and-stability) for what that means for installs. Deeper
+design documentation — the agent protocol, the streaming model, human-in-the-loop approvals, and
 agents-as-subagents — lives under [`docs/internal/`](docs/internal). Contributor setup
 (repository layout, the root `justfile`, UI development, and packaging) is in
 [`docs/internal/development.md`](docs/internal/development.md).

--- a/docs/internal/development.md
+++ b/docs/internal/development.md
@@ -43,10 +43,16 @@ Local stack recipes delegate into `examples/monty`:
 ```bash
 just temporal          # local Temporal dev server
 just session-manager   # packaged session-manager worker
-just server            # built Svelte UI + FastAPI API on http://localhost:8000
+just server            # serves the COMMITTED UI build + FastAPI API on http://localhost:8000
+just dev-server        # rebuild the UI first, then serve (use after editing ui/)
 just monty-worker      # Monty agent worker
 just ui-dev            # Vite hot reload on http://127.0.0.1:5173
 ```
+
+`just server` deliberately does **not** rebuild the UI: it serves the committed
+`temporal_agent_harness/ui/dist`, so a downloaded release archive runs with no Node/pnpm
+installed. That makes the committed build load-bearing — after changing anything under `ui/`,
+run `just app-build` (or `just dev-server`) and commit the result.
 
 All example recipes read one shared env file, `.env.local` at the repo root: the root
 justfile loads it directly, and `examples/*/justfile` read the same root file (via

--- a/examples/callback_tools/coding_agent/justfile
+++ b/examples/callback_tools/coding_agent/justfile
@@ -15,6 +15,9 @@
 # First-time setup: create the shared repo-root .env.local (`cp .env.example .env.local` from the
 # repo root) and set GEMINI_API_KEY. See README.md.
 
+# Shows a notice when running from an untagged commit (silent on a release archive).
+import '../../../scripts/untagged-notice.just'
+
 # Read the single shared env file at the repo root (resolved relative to this justfile).
 set dotenv-path := "../../../.env.local"
 set dotenv-load := true

--- a/examples/callback_tools/wiki_agent/justfile
+++ b/examples/callback_tools/wiki_agent/justfile
@@ -11,6 +11,9 @@
 # First-time setup: create the shared repo-root .env.local (`cp .env.example .env.local` from the
 # repo root) and set GEMINI_API_KEY. See README.md.
 
+# Shows a notice when running from an untagged commit (silent on a release archive).
+import '../../../scripts/untagged-notice.just'
+
 # Read the single shared env file at the repo root (resolved relative to this justfile).
 set dotenv-path := "../../../.env.local"
 set dotenv-load := true

--- a/examples/monty/justfile
+++ b/examples/monty/justfile
@@ -12,6 +12,9 @@
 # demand, so there's no separate install step. First-time setup: `cp .env.example .env.local`
 # and fill it in (Temporal connection + GEMINI_API_KEY). See README.md.
 
+# Shows a notice when running from an untagged commit (silent on a release archive).
+import '../../scripts/untagged-notice.just'
+
 # Read the single shared env file at the repo root (resolved relative to this justfile).
 set dotenv-path := "../../.env.local"
 set dotenv-load := true
@@ -36,9 +39,11 @@ temporal:
 session-manager:
     cd "{{root}}" && uv run --group examples python -m examples.session_manager_worker
 
-# Build and serve the Svelte UI + FastAPI API on http://localhost:8000. The shared examples app
-# entrypoint is pointed at this example's registry.
-server: app-build
+# Serves the COMMITTED UI build in temporal_agent_harness/ui/dist, so this needs no Node/pnpm —
+# a downloaded release archive runs as-is. Rebuild with `just app-build` if you changed ui/.
+#
+# Serve the Svelte UI + FastAPI API on http://localhost:8000, pointed at this example's registry.
+server:
     cd "{{root}}" && uv run --group examples python -m examples.app "{{justfile_directory()}}/agents.toml" --host 0.0.0.0 --port 8000
 
 # Install the shared Svelte UI dependencies.

--- a/examples/nexus_hello/justfile
+++ b/examples/nexus_hello/justfile
@@ -32,6 +32,9 @@
 # `uv sync` picks it up too, since the repo's `dev` group includes it on 3.13+).
 # First-time setup: `cp .env.example .env.local` from the repo root and fill in OPENAI_API_KEY.
 
+# Shows a notice when running from an untagged commit (silent on a release archive).
+import '../../scripts/untagged-notice.just'
+
 set dotenv-path := "../../.env.local"
 set dotenv-load := true
 
@@ -135,9 +138,11 @@ register-third-party:
 session-manager:
     cd "{{root}}" && uv run --group examples python -m examples.session_manager_worker
 
-# Serve the packaged FastAPI API + UI on http://localhost:8000, pointed at this example's
-# registry. Builds the Svelte UI first (app-build).
-server: app-build
+# Serves the COMMITTED UI build in temporal_agent_harness/ui/dist, so this needs no Node/pnpm —
+# a downloaded release archive runs as-is. Rebuild with `just app-build` if you changed ui/.
+#
+# Serve the packaged FastAPI API + UI on http://localhost:8000, pointed at this example's registry.
+server:
     cd "{{root}}" && uv run --group examples python -m examples.app "{{justfile_directory()}}/agents.toml" --host 0.0.0.0 --port 8000
 
 # Build the shared Svelte UI into temporal_agent_harness/ui/dist for the server to serve.

--- a/examples/openai_hello/justfile
+++ b/examples/openai_hello/justfile
@@ -15,6 +15,9 @@
 # so there's no separate install step. First-time setup: `cp .env.example .env.local` from the
 # repo root and fill it in (Temporal connection + OPENAI_API_KEY). See README.md.
 
+# Shows a notice when running from an untagged commit (silent on a release archive).
+import '../../scripts/untagged-notice.just'
+
 # Read the single shared env file at the repo root (resolved relative to this justfile).
 set dotenv-path := "../../.env.local"
 set dotenv-load := true
@@ -39,9 +42,11 @@ temporal:
 session-manager:
     cd "{{root}}" && uv run --group examples python -m examples.session_manager_worker
 
-# Serve the packaged FastAPI API + UI on http://localhost:8000, pointed at this example's registry
-# via the shared examples app entrypoint. Builds the Svelte UI first (app-build).
-server: app-build
+# Serves the COMMITTED UI build in temporal_agent_harness/ui/dist, so this needs no Node/pnpm —
+# a downloaded release archive runs as-is. Rebuild with `just app-build` if you changed ui/.
+#
+# Serve the packaged FastAPI API + UI on http://localhost:8000, pointed at this example's registry.
+server:
     cd "{{root}}" && uv run --group examples python -m examples.app "{{justfile_directory()}}/agents.toml" --host 0.0.0.0 --port 8000
 
 # Build the shared Svelte UI into temporal_agent_harness/ui/dist for the server to serve.

--- a/examples/pydantic_ai_hello/justfile
+++ b/examples/pydantic_ai_hello/justfile
@@ -15,6 +15,9 @@
 # separate install step. First-time setup: `cp .env.example .env.local` from the repo root and fill
 # it in (Temporal connection + OPENAI_API_KEY). See README.md.
 
+# Shows a notice when running from an untagged commit (silent on a release archive).
+import '../../scripts/untagged-notice.just'
+
 # Read the single shared env file at the repo root (resolved relative to this justfile).
 set dotenv-path := "../../.env.local"
 set dotenv-load := true
@@ -39,9 +42,11 @@ temporal:
 session-manager:
     cd "{{root}}" && uv run --group examples python -m examples.session_manager_worker
 
-# Serve the packaged FastAPI API + UI on http://localhost:8000, pointed at this example's registry
-# via the shared examples app entrypoint. Builds the Svelte UI first (app-build).
-server: app-build
+# Serves the COMMITTED UI build in temporal_agent_harness/ui/dist, so this needs no Node/pnpm —
+# a downloaded release archive runs as-is. Rebuild with `just app-build` if you changed ui/.
+#
+# Serve the packaged FastAPI API + UI on http://localhost:8000, pointed at this example's registry.
+server:
     cd "{{root}}" && uv run --group examples python -m examples.app "{{justfile_directory()}}/agents.toml" --host 0.0.0.0 --port 8000
 
 # Build the shared Svelte UI into temporal_agent_harness/ui/dist for the server to serve.

--- a/examples/react_agent/justfile
+++ b/examples/react_agent/justfile
@@ -21,6 +21,9 @@
 # so there's no separate install step. First-time setup: `cp .env.example .env.local` from the
 # repo root and fill it in (Temporal connection + OPENAI_API_KEY). See README.md.
 
+# Shows a notice when running from an untagged commit (silent on a release archive).
+import '../../scripts/untagged-notice.just'
+
 # Read the single shared env file at the repo root (resolved relative to this justfile).
 set dotenv-path := "../../.env.local"
 set dotenv-load := true
@@ -45,9 +48,11 @@ temporal:
 session-manager:
     cd "{{root}}" && uv run --group examples python -m examples.session_manager_worker
 
-# Serve the packaged FastAPI API + UI on http://localhost:8000, pointed at this example's registry
-# via the shared examples app entrypoint. Builds the Svelte UI first (app-build).
-server: app-build
+# Serves the COMMITTED UI build in temporal_agent_harness/ui/dist, so this needs no Node/pnpm —
+# a downloaded release archive runs as-is. Rebuild with `just app-build` if you changed ui/.
+#
+# Serve the packaged FastAPI API + UI on http://localhost:8000, pointed at this example's registry.
+server:
     cd "{{root}}" && uv run --group examples python -m examples.app "{{justfile_directory()}}/agents.toml" --host 0.0.0.0 --port 8000
 
 # Build the shared Svelte UI into temporal_agent_harness/ui/dist for the server to serve.

--- a/justfile
+++ b/justfile
@@ -8,6 +8,9 @@
 # F1_MCP_SERVER_HOME, ...). Prerequisites + run order: see the "Run everything" section in README.md.
 # Build/package + Nexus/Slack/Teams connector recipes follow the run recipes.
 
+# Shows a notice when running from an untagged commit (silent on a release archive).
+import 'scripts/untagged-notice.just'
+
 ui := justfile_directory() / "ui"
 monty := justfile_directory() / "examples" / "monty"
 nexus_dir := justfile_directory() / "nexus"
@@ -169,9 +172,13 @@ session-manager:
     set -a; [ -f .env.local ] && . ./.env.local; set +a
     uv run --group examples python -m examples.session_manager_worker
 
-# Build the UI, then serve EVERY example's agents.toml merged on http://localhost:8000, so the UI
-# lists all agents. (An agent only runs if its worker is up — see the worker recipes below.)
-server: app-build
+# Serves the COMMITTED UI build in temporal_agent_harness/ui/dist, so this needs no Node/pnpm —
+# a downloaded release archive runs as-is. If you changed anything under ui/, rebuild it first
+# with `just app-build`, or use `just dev-server` (build + serve). An agent only runs if its
+# worker is up — see the worker recipes below.
+#
+# Serve EVERY example's agents.toml merged on http://localhost:8000, so the UI lists all agents.
+server:
     #!/usr/bin/env bash
     set -euo pipefail
     cd "{{justfile_directory()}}"
@@ -184,6 +191,9 @@ server: app-build
         examples/callback_tools/wiki_agent/agents.toml \
         examples/callback_tools/coding_agent/agents.toml \
         --host 0.0.0.0 --port 8000
+
+# Rebuild the Svelte UI, then serve — the contributor loop after editing ui/ (needs pnpm).
+dev-server: app-build server
 
 # Run the Svelte Vite dev server with /api proxied to the server on :8000.
 ui-dev:

--- a/nexus/mcp/pyproject.toml
+++ b/nexus/mcp/pyproject.toml
@@ -1,5 +1,10 @@
 [project]
-name = "nexus-mcp"
+# Named `temporal-nexus-mcp`, not `nexus-mcp`: an unrelated third-party project already owns
+# `nexus-mcp` on PyPI, and this package is consumed by the root pyproject's `nexus-mcp` extra.
+# A bare `nexus-mcp` requirement there resolves to that stranger's package anywhere the
+# workspace-local [tool.uv.sources] path isn't in effect. The import names (transport,
+# durable_tools_gateway, authoring) are unaffected by the distribution name.
+name = "temporal-nexus-mcp"
 version = "0.1.0"
 description = "Bridge MCP tools with Temporal's reliable workflow execution via Nexus RPC"
 requires-python = ">=3.13"

--- a/nexus/mcp/uv.lock
+++ b/nexus/mcp/uv.lock
@@ -280,39 +280,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nexus-mcp"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "anyio" },
-    { name = "mcp" },
-    { name = "nexus-rpc" },
-    { name = "pydantic" },
-    { name = "temporalio" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anyio", specifier = ">=4.0.0" },
-    { name = "mcp", specifier = ">=1.28.1" },
-    { name = "nexus-rpc", specifier = ">=1.1.0" },
-    { name = "pydantic", specifier = ">=2.0" },
-    { name = "temporalio", specifier = ">=1.15.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=1.0" },
-]
-
-[[package]]
 name = "nexus-rpc"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -667,6 +634,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "temporal-nexus-mcp"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "nexus-rpc" },
+    { name = "pydantic" },
+    { name = "temporalio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=4.0.0" },
+    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "nexus-rpc", specifier = ">=1.1.0" },
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "temporalio", specifier = ">=1.15.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=1.0" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,16 @@ code-mode = [
 # nexus_brokered_mcp_server. Lets an Agent reach an MCP tool over a Temporal Nexus endpoint,
 # one server per Nexus service, passed directly via Agent(mcp_servers=[...]). Needs the
 # `openai-agents` extra's deps too (restated here so this extra is self-sufficient), and
-# Python >=3.13 (nexus-mcp's own floor). Only resolvable from an editable checkout of this
-# repo — nexus-mcp isn't published to PyPI.
+# Python >=3.13 (temporal-nexus-mcp's own floor). Only resolvable from an editable checkout of
+# this repo — temporal-nexus-mcp isn't published to PyPI.
+#
+# NOTE: the distribution is named `temporal-nexus-mcp`, NOT `nexus-mcp`. An unrelated
+# third-party project already owns `nexus-mcp` on PyPI, so a bare `nexus-mcp` requirement here
+# would resolve to that stranger's package for anyone installing outside a checkout of this repo
+# (the [tool.uv.sources] path below is workspace-local and does NOT travel in built metadata).
+# The extra keeps the short `nexus-mcp` name; only the dependency changed.
 nexus-mcp = [
-    "nexus-mcp; python_version >= '3.13'",
+    "temporal-nexus-mcp; python_version >= '3.13'",
     "openai-agents>=0.17.5",
     "mcp>=1.13.0,<2",
     "temporalio[opentelemetry]>=1.31.0",
@@ -93,9 +99,9 @@ dev = [
     "temporalio[opentelemetry]>=1.31.0",
     # Pydantic AI integration (the ai_sdks glue + its tests) — mirrors the `pydantic-ai` extra.
     "pydantic-ai-slim[temporal]>=2.13",
-    # Nexus-brokered MCP server tests — only on Python >=3.13, nexus-mcp's own floor, so
-    # `uv sync`/`pytest` on older Pythons just skip it.
-    "nexus-mcp; python_version >= '3.13'",
+    # Nexus-brokered MCP server tests — only on Python >=3.13, temporal-nexus-mcp's own floor,
+    # so `uv sync`/`pytest` on older Pythons just skip it.
+    "temporal-nexus-mcp; python_version >= '3.13'",
     { include-group = "examples" },
 ]
 
@@ -114,15 +120,15 @@ include = ["temporal_agent_harness*"]
 ]
 
 [tool.uv]
-# nexus-mcp declares multiple top-level packages (transport, durable_tools_gateway,
+# temporal-nexus-mcp declares multiple top-level packages (transport, durable_tools_gateway,
 # authoring -- see its own pyproject.toml). Setuptools' default editable install for that
 # shape uses a PEP 660 custom MetaPathFinder that pyright can't follow. "compat" mode
 # emits a plain .pth file instead, which pyright (and any tool that reads .pth files) can
 # follow directly. No import paths change.
-config-settings-package = { "nexus-mcp" = { "editable_mode" = "compat" } }
+config-settings-package = { "temporal-nexus-mcp" = { "editable_mode" = "compat" } }
 
 [tool.uv.sources]
-nexus-mcp = { path = "nexus/mcp", editable = true }
+temporal-nexus-mcp = { path = "nexus/mcp", editable = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/untagged-notice.just
+++ b/scripts/untagged-notice.just
@@ -1,0 +1,23 @@
+# Shared "you're on an untagged commit" notice, imported by the root justfile and by each
+# examples/*/justfile so every entry point carries it.
+#
+# This is a variable assignment rather than a recipe dependency on purpose: just evaluates it once
+# per invocation, before any recipe runs, so a single line per justfile covers every recipe. It is
+# NOT evaluated for `just --list`, `just --help`, or `just -n`, so browsing recipes stays quiet.
+#
+# The notice goes to stderr, which is also why the variable ends up empty and nothing is injected
+# into any recipe.
+#
+# Silent when there is no git metadata at all: that means an unpacked release archive, which is
+# precisely the recommended setup — warning there would scold the people who got it right. Also
+# silent when git is missing, or when HEAD sits exactly on a tag (including a shallow clone made
+# with `git clone --depth 1 --branch <tag>`).
+_untagged_notice := ```
+    if command -v git >/dev/null 2>&1 \
+       && git rev-parse --git-dir >/dev/null 2>&1 \
+       && ! git describe --exact-match --tags HEAD >/dev/null 2>&1; then
+        if [ -n "${NO_COLOR:-}" ]; then y=''; r=''; else y='\033[33m'; r='\033[0m'; fi
+        printf "$y\n  Running from an untagged commit.\n  This project is experimental and main is a development branch - we do our best\n  to keep it working, but make no promises. For a more reliable setup, use a tagged\n  release: https://github.com/temporal-community/temporal-agent-harness/releases\n$r\n" >&2
+    fi
+    true
+    ```

--- a/uv.lock
+++ b/uv.lock
@@ -1695,33 +1695,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nexus-mcp"
-version = "0.1.0"
-source = { editable = "nexus/mcp" }
-dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.13'" },
-    { name = "mcp", marker = "python_full_version >= '3.13'" },
-    { name = "nexus-rpc", marker = "python_full_version >= '3.13'" },
-    { name = "pydantic", marker = "python_full_version >= '3.13'" },
-    { name = "temporalio", marker = "python_full_version >= '3.13'" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anyio", specifier = ">=4.0.0" },
-    { name = "mcp", specifier = ">=1.28.1" },
-    { name = "nexus-rpc", specifier = ">=1.1.0" },
-    { name = "pydantic", specifier = ">=2.0" },
-    { name = "temporalio", specifier = ">=1.15.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=1.0" },
-]
-
-[[package]]
 name = "nexus-rpc"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2985,8 +2958,8 @@ genai = [
 ]
 nexus-mcp = [
     { name = "mcp" },
-    { name = "nexus-mcp", marker = "python_full_version >= '3.13'" },
     { name = "openai-agents" },
+    { name = "temporal-nexus-mcp", marker = "python_full_version >= '3.13'" },
     { name = "temporalio", extra = ["opentelemetry"] },
 ]
 openai-agents = [
@@ -3012,13 +2985,13 @@ dev = [
     { name = "httpx" },
     { name = "mcp" },
     { name = "moto", extra = ["server"] },
-    { name = "nexus-mcp", marker = "python_full_version >= '3.13'" },
     { name = "openai-agents" },
     { name = "pydantic-ai-slim", extra = ["temporal"] },
     { name = "pydantic-monty" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "setuptools" },
+    { name = "temporal-nexus-mcp", marker = "python_full_version >= '3.13'" },
     { name = "temporalio", extra = ["aioboto3", "opentelemetry"] },
 ]
 examples = [
@@ -3038,12 +3011,12 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'genai'", specifier = ">=2.0.0" },
     { name = "mcp", marker = "extra == 'nexus-mcp'", specifier = ">=1.13.0,<2" },
     { name = "mcp", marker = "extra == 'openai-agents'", specifier = ">=1.9.4,<2" },
-    { name = "nexus-mcp", marker = "python_full_version >= '3.13' and extra == 'nexus-mcp'", editable = "nexus/mcp" },
     { name = "openai-agents", marker = "extra == 'nexus-mcp'", specifier = ">=0.17.5" },
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.17.5" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-ai-slim", extras = ["temporal"], marker = "extra == 'pydantic-ai'", specifier = ">=2.13" },
     { name = "pydantic-monty", marker = "extra == 'code-mode'", specifier = ">=0.0.18" },
+    { name = "temporal-nexus-mcp", marker = "python_full_version >= '3.13' and extra == 'nexus-mcp'", editable = "nexus/mcp" },
     { name = "temporalio", specifier = ">=1.31.0" },
     { name = "temporalio", extras = ["aioboto3"], marker = "extra == 's3'", specifier = ">=1.31.0" },
     { name = "temporalio", extras = ["opentelemetry"], marker = "extra == 'nexus-mcp'", specifier = ">=1.31.0" },
@@ -3059,13 +3032,13 @@ dev = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "mcp", specifier = ">=1.9.4,<2" },
     { name = "moto", extras = ["server"], specifier = ">=5.2.1" },
-    { name = "nexus-mcp", marker = "python_full_version >= '3.13'", editable = "nexus/mcp" },
     { name = "openai-agents", specifier = ">=0.17.5" },
     { name = "pydantic-ai-slim", extras = ["temporal"], specifier = ">=2.13" },
     { name = "pydantic-monty", specifier = ">=0.0.18" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "setuptools", specifier = ">=83.0.0" },
+    { name = "temporal-nexus-mcp", marker = "python_full_version >= '3.13'", editable = "nexus/mcp" },
     { name = "temporalio", extras = ["aioboto3"], specifier = ">=1.31.0" },
     { name = "temporalio", extras = ["opentelemetry"], specifier = ">=1.31.0" },
 ]
@@ -3077,6 +3050,33 @@ examples = [
     { name = "openai-agents", specifier = ">=0.17.5" },
     { name = "pydantic-ai-slim", extras = ["temporal"], specifier = ">=2.13" },
     { name = "pydantic-monty", specifier = ">=0.0.18" },
+]
+
+[[package]]
+name = "temporal-nexus-mcp"
+version = "0.1.0"
+source = { editable = "nexus/mcp" }
+dependencies = [
+    { name = "anyio", marker = "python_full_version >= '3.13'" },
+    { name = "mcp", marker = "python_full_version >= '3.13'" },
+    { name = "nexus-rpc", marker = "python_full_version >= '3.13'" },
+    { name = "pydantic", marker = "python_full_version >= '3.13'" },
+    { name = "temporalio", marker = "python_full_version >= '3.13'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=4.0.0" },
+    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "nexus-rpc", specifier = ">=1.1.0" },
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "temporalio", specifier = ">=1.15.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=1.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Installation currently tells users to clone main, so every commit has to be ready for anyone trying the project out. Document cloning at a release tag instead: the tagged tree already carries the prebuilt browser UI, so it runs with no Node toolchain, and main is free to be a development branch.

Releases are plain git tags, so there is no build pipeline to maintain. Tags are unprefixed (0.1.0) to match the version in pyproject.toml.

- README: split Installation into "try it" (clone at a tag, with the source archive as a no-git alternative) and "build with it" (uv add pinned to a tag), add a Versioning and stability section, and demote pnpm to a UI-development-only requirement.

- Rename the nexus/mcp distribution to temporal-nexus-mcp. An unrelated project owns `nexus-mcp` on PyPI and [tool.uv.sources] is workspace-local, so a bare `nexus-mcp` requirement resolved to that package anywhere outside a checkout of this repo. The extra keeps its short name; import names are unchanged.

- Stop `just server` rebuilding the UI so a tagged checkout runs without Node. Contributors use the new `just dev-server` after editing ui/.

- Add a CI job that rebuilds the UI and fails if the committed temporal_agent_harness/ui/dist differs from it. Shipping a prebuilt UI makes the committed build load-bearing, and nothing else catches it going stale.

- Show a notice on any `just` recipe run from an untagged commit. Silent when there is no git metadata, which is what an unpacked source archive looks like.