### PR TITLE
Tease out MCP structure a bit more, separate README.md and ARCHITECTURE.md

### DIFF
--- a/examples/nexus_hello/README.md
+++ b/examples/nexus_hello/README.md
@@ -1,189 +1,248 @@
-# Nexus-hello agent
+# Nexus hello agent
 
-Demonstrates two ways to reach a tool over Nexus, side by side in one
-`Agent(mcp_servers=[...])`:
+This example gives one agent access to three tools through Temporal Nexus. The
+preferred path uses Nexus as the transport for an `MCPServer`-shaped AI SDK
+adapter. The example also shows a compatibility path for an existing external
+HTTP MCP server.
 
-- `nexus_native_mcp_server(name, endpoint)` -- one hard-coded native Nexus service,
-  called directly. No registry, no registration, ever.
-- `nexus_tools_gateway().mcp_servers(...)` -- an explicit set of 3rd-party servers,
-  registered ahead of time with the Durable Tools Gateway, proxied through it.
-  `agent_id` is inferred from this workflow's own type (`workflow_type`), not chosen
-  by hand.
+The agent uses two access paths:
 
-Native and 3rd-party tools never mix inside the gateway -- the gateway only ever
-tracks 3rd-party servers. Tool lists are never cached: they're fetched live, from the
-real MCP server, on every `list_tools()` call.
+- `nexus_native_mcp_server(name, endpoint)` connects the agent directly to a
+  native Nexus tool service.
+- `nexus_tools_gateway().mcp_servers(...)` connects the agent to selected
+  external MCP servers through the Durable Tools Gateway.
 
-Tools available to the agent:
-
-- `demo_get_fun_fact` - a 3rd-party (non-Nexus) MCP server, reached through the
-  **Durable Tools Gateway** (`demo` maps to `http://127.0.0.1:8765/mcp`). This
-  gateway route is registered under agent ID `NexusHelloAgent`.
-- `demo-nexus_get_lucky_number` - a native Nexus tool service, called directly - no
-  gateway, no registration.
-- `demo-nexus_get_delayed_lucky_number` - a workflow-backed Nexus operation. It
-  waits on a durable timer before it returns.
-
-## How it works
+The complete agent workflow is in [`workflow.py`](workflow.py). It configures
+both paths in one `Agent`:
 
 ```python
-nexus_gateway = nexus_tools_gateway()  # agent_id inferred from workflow_type
-mcp_servers=[
-    nexus_gateway.mcp_servers("demo"),
+nexus_gateway = nexus_tools_gateway()
+mcp_servers = [
     nexus_native_mcp_server("demo-nexus", "nexus-hello-demo-endpoint"),
+    nexus_gateway.mcp_servers("demo"),
 ]
 ```
 
-Three ways for an agent to reach tools. This demo uses the first two.
+The example provides these tools:
 
-**1. Nexus-native tools** (`demo-nexus_get_lucky_number` and
-`demo-nexus_get_delayed_lucky_number`). The tool service is a Nexus operation
-handler. There is no gateway or registry. The agent knows the service name and
-endpoint from `nexus_native_mcp_server(...)`. Tool listing and tool calls each
-use a direct Nexus hop. The delayed tool starts a backing workflow and uses
-`workflow.sleep()`.
+| Tool | Implementation | Access path |
+| --- | --- | --- |
+| `demo-nexus_get_lucky_number` | Synchronous Nexus operation | Direct Nexus call |
+| `demo-nexus_get_delayed_lucky_number` | Workflow-backed Nexus operation | Direct Nexus call |
+| `demo_get_fun_fact` | External HTTP MCP server | Durable Tools Gateway compatibility path |
 
-```mermaid
-flowchart LR
-    agent[Agent workflow]
-    service[Nexus tool service]
-    delayed[Delayed lucky-number workflow]
+## Data flow of the example
 
-    agent -->|Nexus list_tools and tool calls| service
-    service -->|workflow-backed operation| delayed
-```
-
-**2. Gateway-proxied tool** (`demo_get_fun_fact`). The real MCP server only speaks
-HTTP. The gateway holds the URL and dispatches for it, so the agent never has to.
-`.mcp_servers("demo")` asks the gateway for exactly those aliases' tools, once per
-turn, in a single Nexus call -- an alias that isn't actually registered is silently
-skipped (no error yet; this is a prototype). `just register-third-party` (`temporal
-workflow signal`) only validates the URL — the actual tool list is fetched live at
-discovery time, every turn, as a standalone activity (Nexus + SAA). Needs the dynamic
-config `just temporal` sets: `nexusoperation.enableStandalone`/`activity.enableStandalone`.
+The following diagram shows tool discovery and tool calls. It also shows the
+workflow that supports the delayed tool.
 
 ```mermaid
 flowchart LR
-    agent[Agent workflow]
-    gateway[Durable Tools Gateway]
-    activity[mcp_proxy_activity]
-    server[HTTP MCP server]
+    subgraph default_ns[default namespace]
+        agent[Agent workflow]
+    end
 
-    agent -->|Nexus list and call operations| gateway
-    gateway -->|standalone activity| activity
-    activity -->|MCP over HTTP| server
+    subgraph native_ns[nexus-mcp-server namespace]
+        subgraph native_service[DemoNexusToolsServiceHandler]
+            manifest[list_tools synchronous Nexus operation]
+            lucky[get_lucky_number synchronous Nexus operation]
+            delayed_op[get_delayed_lucky_number workflow-run Nexus operation]
+        end
+        delayed_workflow[DelayedLuckyNumberWorkflow]
+    end
+
+    subgraph gateway_ns[gateway namespace]
+        gateway[RegistryService]
+        registry[ToolRegistry workflow]
+        fetch[fetch_external_tools activity]
+        proxy[mcp_proxy_activity]
+    end
+
+    external[External HTTP MCP server]
+
+    agent -->|Nexus: discover tools| manifest
+    agent -->|Nexus: call immediate tool| lucky
+    agent -->|Nexus: call durable tool| delayed_op
+    delayed_op -->|start workflow and return handle| delayed_workflow
+
+    agent -->|Nexus: discover tools or call tool| gateway
+    gateway -->|query alias URL| registry
+    gateway -->|start for tool discovery| fetch
+    gateway -->|start for tool call| proxy
+    fetch -->|MCP tools/list| external
+    proxy -->|MCP tools/call| external
 ```
 
-**3. Traditional MCP with Temporal plugin** (not used by this demo — shown for contrast). HTTP wrapped in activities.
-This is what `stateless_mcp_server`/`MCPServerStreamableHttp` give you.
+### Native Nexus tools
 
-```mermaid
-flowchart LR
-    agent[Agent workflow]
-    activity[Temporal activity]
-    server[HTTP MCP server]
+The agent has the service name and Nexus endpoint in its configuration. It
+calls the service through `nexus-hello-demo-endpoint`. The gateway does not
+process these calls.
 
-    agent -->|list or call| activity
-    activity -->|MCP over HTTP| server
+The service exposes three Nexus operations. The generated `list_tools`
+operation returns the current tool manifest and the exact route for each tool.
+
+`get_lucky_number` is a synchronous Nexus handler operation. The handler
+creates the result and returns it directly. This operation does not start a
+workflow.
+
+`get_delayed_lucky_number` is a workflow-run Nexus operation. Its handler
+starts `DelayedLuckyNumberWorkflow` and returns a workflow handle. The backing
+workflow uses `workflow.sleep()` for its durable timer.
+
+The complete implementation is in
+[`nexus_tool_service.py`](nexus_tool_service.py). This reduced excerpt shows
+the two tool implementations and the worker registration:
+
+```python
+@nexusrpc.handler.service_handler(name=SERVICE_NAME)
+class DemoNexusToolsServiceHandler(MCPOverNexusServiceHandler):
+    @nexus_mcp_tool
+    async def get_lucky_number(self, topic: str) -> str:
+        return f"{topic}'s lucky number today is {random.randint(1, 100)}."
+
+    @nexus_mcp_operation(title="Get a delayed lucky number")
+    @temporalio.nexus.workflow_run_operation
+    async def get_delayed_lucky_number(
+        self,
+        ctx: temporalio.nexus.WorkflowRunOperationContext,
+        input: DelayedLuckyNumberInput,
+    ) -> temporalio.nexus.WorkflowHandle[DelayedLuckyNumberOutput]:
+        return await ctx.start_workflow(
+            DelayedLuckyNumberWorkflow.run,
+            input,
+            id=f"delayed-lucky-number-{ctx.request_id}",
+            task_queue=NEXUS_TASK_QUEUE,
+        )
+
+worker = Worker(
+    client,
+    task_queue=NEXUS_TASK_QUEUE,
+    workflows=[DelayedLuckyNumberWorkflow],
+    nexus_service_handlers=[DemoNexusToolsServiceHandler()],
+)
 ```
 
-Three Temporal namespaces to demonstrate cross-namespace Nexus calls:
+The excerpt omits the Pydantic model definitions and the MCP tool annotations.
 
-| Namespace | Hosts |
-|---|---|
-| `default` | The agent (`worker.py`), session-manager, FastAPI/UI. |
-| `gateway` | The Durable Tools Gateway. |
-| `nexus-mcp-server` | The demo native Nexus tool service. |
+### External MCP tool
 
-Note two different identifiers are in play: `agents.toml`'s `key` (`"nexus-hello"`) is
-just how the web UI routes to this agent; the gateway's `agent_id` (`"NexusHelloAgent"`)
-is this workflow's `workflow_type`, used only for gateway registration/lookup. They
-don't have to match, and here they don't.
+The gateway registry maps the alias `demo` to
+`http://127.0.0.1:8765/mcp`. The registry stores the URL. It does not store a
+tool list. The registration signal stores the URL and then tests the
+connection. The registry keeps the URL if this test fails.
 
-## Layout
+The external server is a standard MCP server. Its complete implementation is
+in [`tool_server.py`](tool_server.py):
 
-| File | Role |
-|---|---|
-| `workflow.py` | `NexusHelloAgentWorkflow` - one `ask` handler, `mcp_servers=[nexus_gateway.mcp_servers(...), nexus_native_mcp_server(...)]`. |
-| `worker.py` | Worker on `default`. No Nexus-related plugin config. |
-| `tool_server.py` | Demo 3rd-party MCP server (`get_fun_fact`). |
-| `nexus_tool_service.py` | Native Nexus tool service with a short tool and a workflow-backed delayed tool. |
+```python
+mcp = MCPServer("demo-tools")
 
-## Run it
+@mcp.tool()
+def get_fun_fact(topic: str) -> str:
+    facts = [
+        f"{topic} was mentioned in a movie script exactly once, allegedly.",
+        # Additional demo facts are in tool_server.py.
+    ]
+    return random.choice(facts)
+```
 
-Prereqs:
-- From the repo root, `cp .env.example .env.local` and set `OPENAI_API_KEY`.
-- The root project's `nexus-mcp` extra needs Python >=3.13
-  (`uv sync --extra nexus-mcp`, or `uv sync` on Python 3.13 or later). Here,
-  `nexus-mcp` is an extra name. It is not the package name on PyPI. Do not run
-  `pip install nexus-mcp`; that installs an unrelated project. This repository
-  installs the local `temporal-nexus-mcp` distribution.
-- `temporal` CLI on PATH (the stable public release; no custom build needed).
+The gateway uses `fetch_external_tools` for discovery and `mcp_proxy_activity`
+for tool calls. See the
+[gateway architecture](../../nexus/mcp/ARCHITECTURE.md#durable-tools-gateway),
+[`registry.py`](../../nexus/mcp/nexus_mcp/durable_tools_gateway/registry.py)
+and
+[`registry_service_handler.py`](../../nexus/mcp/nexus_mcp/durable_tools_gateway/registry_service_handler.py).
 
-Each in its own terminal, in order:
+The gateway requires these Temporal dynamic configuration values:
+
+```text
+nexusoperation.enableStandalone=true
+activity.enableStandalone=true
+```
+
+The `just temporal` recipe sets both values.
+
+### Agent identifiers
+
+This example uses two agent identifiers:
+
+| Identifier | Value | Purpose |
+| --- | --- | --- |
+| `agents.toml` key | `nexus-hello` | Routes UI requests to the agent. |
+| Gateway `agent_id` | `NexusHelloAgent` | Selects gateway registrations for this workflow type. |
+
+`nexus_tools_gateway()` gets `agent_id` from the current workflow type. The two
+identifiers do not have to match.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| [`workflow.py`](workflow.py) | Defines the agent workflow and configures both tool paths. |
+| [`worker.py`](worker.py) | Runs the agent worker in the `default` namespace. |
+| [`tool_server.py`](tool_server.py) | Runs the external MCP server for `demo_get_fun_fact`. |
+| [`nexus_tool_service.py`](nexus_tool_service.py) | Runs the native Nexus service and the delayed workflow. |
+| [`agents.toml`](agents.toml) | Adds the agent to the example UI. |
+| [`justfile`](justfile) | Starts the local services and creates the Nexus resources. |
+
+## Run the example
+
+### Requirements
+
+- Use Python 3.13 or later for the `nexus-mcp` extra.
+- Install the Temporal CLI and add it to `PATH`.
+- From the repository root, copy `.env.example` to `.env.local`.
+- Set `OPENAI_API_KEY` in `.env.local`.
+- From the repository root, run `uv sync --extra nexus-mcp`.
+
+The extra installs the local `temporal-nexus-mcp` distribution. Do not run
+`pip install nexus-mcp`. That command installs an unrelated project from PyPI.
+
+### Start the services
+
+Change to the example directory:
 
 ```sh
-just temporal             # 1. local Temporal dev server
-just setup-nexus          # 2. ONE-SHOT: 3 namespaces + 2 Nexus endpoints
-just tool-server          # 3. demo 3rd-party MCP tool server
-just registry             # 4. durable tools gateway (no seed config -- starts empty)
-just nexus-tool-service   # 5. demo native Nexus tool service
-just register-third-party # 6. ONE-SHOT: registers "demo" under agent_id "NexusHelloAgent"
-just session-manager      # 7. session-manager worker
-just server               # 8. builds UI, serves API + UI on :8000
-just worker               # 9. this agent's worker
+cd examples/nexus_hello
 ```
 
-Open http://localhost:8000, pick **Nexus Hello**, and start a chat. All three
-tools are available.
-
-```mermaid
-flowchart LR
-    agent[Agent in default namespace]
-    gateway[RegistryService in gateway namespace]
-    proxy[mcp_proxy_activity]
-    external[tool_server.py]
-    native[nexus_tool_service.py in nexus-mcp-server namespace]
-    delayed[DelayedLuckyNumberWorkflow]
-
-    agent -->|demo_get_fun_fact| gateway
-    gateway --> proxy
-    proxy -->|MCP over HTTP| external
-    agent -->|get_lucky_number| native
-    agent -->|get_delayed_lucky_number| native
-    native --> delayed
-```
-
-The agent workflow waits for the delayed tool result through its Nexus handle.
-This harness adapter is not an MCP task-capable caller. The MCP task wire flow
-is covered by
-[`test_caller_matrix_integration.py`](../../tests/nexus_mcp/test_caller_matrix_integration.py).
-That test calls the same type of workflow-backed Nexus operation through
-`NexusMCPBridge`. Its modern MCP client uses the Tasks extension to receive a
-task ID and poll `tasks/get`.
-
-Without `just` (from the repo root):
+Run each command in a separate terminal. Run the commands in the listed order.
 
 ```sh
-uv run --extra nexus-mcp python -m examples.nexus_hello.tool_server
-TEMPORAL_NAMESPACE=gateway uv run --extra nexus-mcp --group examples python -m nexus_mcp.durable_tools_gateway.worker
-TEMPORAL_NAMESPACE=nexus-mcp-server uv run --extra nexus-mcp python -m examples.nexus_hello.nexus_tool_service
-temporal workflow signal --namespace gateway --workflow-id mcp-tool-registry --name register_external \
-    --input '"NexusHelloAgent"' --input '"demo"' --input '"http://127.0.0.1:8765/mcp"'
-uv run --group examples python -m examples.session_manager_worker
-uv run --group examples python -m examples.app examples/nexus_hello/agents.toml --host 0.0.0.0 --port 8000
-uv run --extra nexus-mcp --group examples python -m examples.nexus_hello.worker
+just temporal
+just setup-nexus
+just tool-server
+just registry
+just nexus-tool-service
+just register-third-party
+just session-manager
+just server
+just worker
 ```
 
-(`just setup-nexus`'s namespace/endpoint creation is one-shot infra setup - see the justfile
-for the raw `temporal operator ...` commands if running without `just`.)
+`just setup-nexus` creates the three namespaces and two Nexus endpoints. Run it
+once for each new Temporal development server. `just register-third-party`
+registers the `demo` URL under agent ID `NexusHelloAgent`. You can run both
+commands again if necessary.
 
-## If the UI doesn't show "Nexus Hello"
+Open <http://localhost:8000>. Select **Nexus Hello**, and start a chat.
 
-The web UI's `SessionManagerWorkflow` is a singleton set once from whichever `agents.toml`
-first started it - restarting `just server` doesn't refresh it. Terminate and let a fresh one
-start:
+The agent waits on its Nexus operation handle when it calls the delayed tool.
+The harness adapter does not use the MCP Tasks extension. The
+[`test_caller_matrix_integration.py`](../../tests/nexus_mcp/test_caller_matrix_integration.py)
+test covers that protocol path. It uses `NexusMCPBridge` and a task-capable MCP
+client.
+
+## Refresh the agent list
+
+`SessionManagerWorkflow` stores the agent list when it starts. Restarting the
+web server does not update an existing workflow. If the UI does not show
+**Nexus Hello**, terminate the workflow:
 
 ```sh
 temporal workflow terminate --workflow-id session-manager
 ```
+
+The session-manager worker starts a new workflow when the application requests
+it.

--- a/nexus/mcp/ARCHITECTURE.md
+++ b/nexus/mcp/ARCHITECTURE.md
@@ -1,0 +1,239 @@
+# Temporal Nexus MCP architecture
+
+This document describes the package components, execution paths, and protocol
+behavior. For installation and public API examples, see the
+[package README](README.md).
+
+## Design
+
+`NexusToolResolver` is the protocol-neutral core. It discovers tools, validates
+routes, and sends calls to an executor. The caller selects the executor when it
+constructs the resolver. The resolver does not inspect the runtime environment.
+
+- `StandaloneNexusExecutor` uses a connected Temporal `Client`. Use it outside
+  a Temporal workflow.
+- `WorkflowNexusExecutor` uses the Temporal workflow API. Use it inside a
+  Temporal workflow.
+
+The AI SDK integrations and the MCP bridge are frontends for the same resolver.
+
+```mermaid
+flowchart TB
+    openai[OpenAI Agents process]
+    pydantic[Pydantic AI process]
+    workflow_ai[OpenAI agent workflow]
+    mcp[Standard MCP client]
+
+    openai_adapter[NexusMCPServer]
+    pydantic_adapter[NexusToolset]
+    workflow_adapter[WorkflowNexusMCPServer]
+    bridge[NexusMCPBridge]
+
+    standalone_resolver[NexusToolResolver]
+    workflow_resolver[NexusToolResolver]
+    standalone_executor[StandaloneNexusExecutor]
+    workflow_executor[WorkflowNexusExecutor]
+    endpoint[Temporal Nexus endpoint]
+    service[Native Nexus tool service]
+
+    openai --> openai_adapter
+    pydantic --> pydantic_adapter
+    workflow_ai --> workflow_adapter
+    mcp -->|MCP over stdio| bridge
+
+    openai_adapter --> standalone_resolver
+    pydantic_adapter --> standalone_resolver
+    bridge --> standalone_resolver
+    workflow_adapter --> workflow_resolver
+
+    standalone_resolver --> standalone_executor
+    workflow_resolver --> workflow_executor
+    standalone_executor --> endpoint
+    workflow_executor --> endpoint
+    endpoint --> service
+```
+
+## Direct AI SDK integrations
+
+The direct integrations adapt `NexusToolResolver` to the tool interface of each
+SDK. They do not create an MCP session or start an MCP server.
+
+`NexusMCPServer` implements the OpenAI Agents `MCPServer` interface. It uses
+`StandaloneNexusExecutor`. `WorkflowNexusMCPServer` implements the same
+interface with `WorkflowNexusExecutor`.
+
+`NexusToolset` implements the Pydantic AI toolset interface. It uses
+`StandaloneNexusExecutor`. It maps Nexus tool results to Pydantic AI result
+types and maps tool errors to `ModelRetry`.
+
+Each standalone adapter receives a Temporal client from its caller. The
+adapter does not own or close that client.
+
+## MCP bridge
+
+`NexusMCPBridge` is the compatibility frontend for standard MCP clients. The
+MCP SDK owns protocol initialization, negotiation, sessions, request
+validation, and stdio. The bridge converts each MCP request to a resolver call.
+
+```mermaid
+flowchart LR
+    client[Standard MCP client]
+    bridge[NexusMCPBridge]
+    resolver[NexusToolResolver]
+    executor[StandaloneNexusExecutor]
+    endpoint[Temporal Nexus endpoint]
+    service[Native Nexus tool service]
+
+    client -->|MCP over stdio| bridge
+    bridge --> resolver
+    resolver --> executor
+    executor --> endpoint
+    endpoint --> service
+```
+
+The bridge does not replace Nexus as the tool transport. MCP ends at the local
+bridge. Discovery and tool calls continue through Nexus.
+
+## Tool discovery and routing
+
+`MCPOverNexusServiceHandler` adds a synchronous `list_tools` Nexus operation to
+each native tool service. The operation returns:
+
+- The MCP definition for each marked tool.
+- The exact Nexus operation route for each public tool name.
+
+The resolver reads the current manifest before each tool call. The caller does
+not have to call `list_tools()` first.
+
+The resolver applies these rules:
+
+- Each public tool name must have an exact operation route.
+- Duplicate public names across configured services cause discovery to fail.
+- An unknown or constructed tool name does not reach Nexus.
+- A discovery error fails the full request. The resolver does not return a
+  partial tool list.
+- `allowed_servers` limits discovery to selected services.
+
+Exact routing limits accidental access. It does not replace authentication or
+authorization.
+
+## Result and failure behavior
+
+The resolver converts operation results as follows:
+
+| Operation result | MCP result |
+| --- | --- |
+| `CallToolResult` | Preserved without conversion |
+| Pydantic model | Returned as text and `structured_content` through a dictionary |
+| Dictionary | Returned as text and `structured_content` |
+| Other value | Converted to text |
+
+An exception from a listed Nexus operation becomes a tool error result.
+
+The Pydantic AI adapter returns `structured_content` when it is available. It
+maps other MCP content types to the nearest Pydantic AI content type. A tool
+error becomes `ModelRetry`.
+
+## MCP Tasks
+
+MCP Tasks are a bridge feature. They are available when `NexusMCPBridge` uses
+`StandaloneNexusExecutor` and the client negotiates protocol version
+`2026-07-28` with the `io.modelcontextprotocol/tasks` extension.
+
+A task-capable tool call starts a standalone Nexus operation. Here,
+*standalone* means that a Temporal client starts the operation outside a
+Temporal workflow. The operation still runs through Temporal Nexus.
+
+```mermaid
+sequenceDiagram
+    participant Client as Task-capable MCP client
+    participant Bridge as NexusMCPBridge
+    participant Nexus as Temporal Nexus operation
+
+    Client->>Bridge: MCP tools/call over stdio
+    Bridge->>Nexus: start standalone Nexus operation
+    alt Operation completed
+        Nexus-->>Bridge: result
+        Bridge-->>Client: CallToolResult
+    else Operation still running
+        Nexus-->>Bridge: operation ID and state
+        Bridge-->>Client: task ID
+        loop Until terminal state
+            Client->>Bridge: MCP tasks/get over stdio
+            Bridge->>Nexus: describe operation
+            Nexus-->>Bridge: state or result
+            Bridge-->>Client: task state or result
+        end
+    end
+```
+
+Clients that do not advertise Tasks receive a blocking tool result. A task ID
+is the Nexus operation ID. The bridge does not keep an in-memory task table, so
+a new bridge process can read an existing task.
+
+`NexusTasksClientExtension` claims task results. The high-level
+`Client.call_tool()` method then polls `tasks/get` and returns the final
+`CallToolResult`. The original `tools/call` request ends before polling starts.
+Use `cancel_task()` to request cancellation. The protocol also provides
+`update_task()`, but the Nexus operations in this package do not request more
+input.
+
+`task_ttl_ms` defaults to 24 hours. `task_poll_interval_ms` defaults to one
+second. Set both values on `NexusMCPBridge`. Apply the same authorization policy
+to task methods and tool calls. The package does not bind task IDs to
+application users.
+
+The direct OpenAI Agents and Pydantic AI integrations wait for the final Nexus
+result. They do not expose MCP Tasks.
+
+## Durable Tools Gateway
+
+The Durable Tools Gateway is a separate path for an existing HTTP MCP server.
+It does not process calls to native Nexus tool services.
+
+The registry stores an MCP server URL under an agent ID and alias. It does not
+store tool definitions. During discovery, `RegistryService` reads the selected
+URLs and starts one `fetch_external_tools` activity for each server. Each
+activity sends `tools/list` to the external server.
+
+During a tool call, `RegistryService` reads the URL and starts
+`mcp_proxy_activity`. The activity sends `tools/call` to the external server.
+The activity does not retry because the tool might not be idempotent.
+
+```mermaid
+flowchart LR
+    caller[Agent workflow]
+    gateway[RegistryService]
+    registry[ToolRegistry workflow]
+    fetch[fetch_external_tools activity]
+    proxy[mcp_proxy_activity]
+    server[External HTTP MCP server]
+
+    caller -->|Nexus: discover or call| gateway
+    gateway -->|query registered URL| registry
+    gateway -->|tool discovery| fetch
+    gateway -->|tool call| proxy
+    fetch -->|MCP tools/list| server
+    proxy -->|MCP tools/call| server
+```
+
+The gateway requires these Temporal dynamic configuration values:
+
+```text
+nexusoperation.enableStandalone=true
+activity.enableStandalone=true
+```
+
+See the [Nexus hello example](../../examples/nexus_hello/README.md) for a
+complete configuration.
+
+## Component responsibilities
+
+| Part | Responsibility | Implementation |
+| --- | --- | --- |
+| OpenAI Agents integration | Present Nexus tools through the SDK MCP server interface | `NexusMCPServer`, `WorkflowNexusMCPServer` |
+| Pydantic AI integration | Present Nexus tools through the SDK toolset interface | `NexusToolset` |
+| MCP protocol | Manage MCP connections, requests, responses, and Tasks | `NexusMCPBridge`, MCP SDK |
+| Tool resolution | Discover tools, validate routes, and convert results | `NexusToolResolver` |
+| Nexus execution | Execute calls and manage operation handles | `WorkflowNexusExecutor`, `StandaloneNexusExecutor` |
+| Tool service | Define metadata, routes, and tool behavior | `MCPOverNexusServiceHandler`, authoring decorators |

--- a/nexus/mcp/README.md
+++ b/nexus/mcp/README.md
@@ -1,62 +1,65 @@
 # Temporal Nexus MCP
 
-`nexus_mcp` exposes Nexus service operations as MCP tools. You can author one
-Nexus tool service and use it from:
+The `nexus_mcp` package exposes Nexus service operations as MCP tools. It
+supports direct OpenAI Agents and Pydantic AI integrations, Temporal workflow
+calls, standard MCP clients, and MCP Tasks.
 
-- a Temporal workflow, with direct Nexus calls;
-- a stateful MCP client, with the MCP initialization flow;
-- a stateless MCP client, with independent MCP requests;
-- a task-capable MCP client, with a durable Nexus operation behind each task.
+For component design, execution paths, and protocol behavior, see
+[Architecture](ARCHITECTURE.md).
 
-The package uses the MCP Python SDK for the protocol. The SDK owns
-initialization, protocol negotiation, sessions, Streamable HTTP, request
-validation, and normal MCP errors. This package adds the Nexus execution path
-and the MCP Tasks extension.
+## Install the package
 
-## Install
+The package requires Python 3.13 or later. The distribution name is
+`temporal-nexus-mcp`. The Python import name is `nexus_mcp`.
 
-The package requires Python 3.13 or later. Its distribution name is
-`temporal-nexus-mcp`. Its Python import name is `nexus_mcp`.
+An unrelated project owns the `nexus-mcp` name on PyPI. Do not run
+`pip install nexus-mcp` or `uv add nexus-mcp`.
 
-An unrelated project owns the `nexus-mcp` name on PyPI. Do not use
-`pip install nexus-mcp` or `uv add nexus-mcp`. Those commands install the
-unrelated project.
-
-From this repository:
+From this repository, run:
 
 ```sh
 uv sync --extra nexus-mcp
 ```
 
-For an editable package-only installation:
+For an editable package-only installation, run:
 
 ```sh
 uv pip install -e ./nexus/mcp
 ```
 
-To install from GitHub before this distribution is published:
+Install the optional dependency for the AI SDK that you use:
+
+```sh
+uv pip install -e './nexus/mcp[openai-agents]'
+uv pip install -e './nexus/mcp[pydantic-ai]'
+```
+
+To install from GitHub before the package is published, run:
 
 ```sh
 uv add "temporal-nexus-mcp @ git+https://github.com/temporal-community/temporal-agent-harness.git#subdirectory=nexus/mcp"
 ```
 
-## Choose a use case
+## Select an API
 
-| Goal | API | MCP connection |
+| Goal | API | Tool transport |
 | --- | --- | --- |
-| Call tools inside a Temporal workflow | `NexusToolResolver` and `WorkflowNexusExecutor` | None |
-| Call tools from a normal Python process | `NexusToolResolver` | None |
-| Serve Nexus tools to MCP clients | `NexusMCPBridge` | MCP SDK managed |
-| Run long tool calls as MCP tasks | `NexusMCPBridge` and Tasks helpers | Stateless MCP 2026 |
-| Reach an existing HTTP MCP server through Temporal | Durable Tools Gateway | Gateway opens the remote connection |
+| Add Nexus tools to an OpenAI agent outside a workflow | `NexusMCPServer` | Nexus |
+| Add Nexus tools to Pydantic AI outside a workflow | `NexusToolset` | Nexus |
+| Add Nexus tools to an OpenAI agent workflow | `nexus_native_mcp_server` | Nexus |
+| Call Nexus tools from a workflow without an AI SDK | `NexusToolResolver` with `WorkflowNexusExecutor` | Nexus |
+| Serve Nexus tools to a standard MCP client | `NexusMCPBridge` | stdio, then Nexus |
+| Run long calls as MCP tasks | `NexusMCPBridge` with Tasks support | stdio, then Nexus |
+| Call an existing HTTP MCP server through Temporal | Durable Tools Gateway | Nexus, then HTTP |
 
-Use a native Nexus tool service when you own the tool implementation. Use the
-Durable Tools Gateway when a tool already exists as an MCP server.
+Use a native Nexus tool service when you control the tool implementation. Use
+the Durable Tools Gateway when the tool is already available from an HTTP MCP
+server.
 
-## Author a Nexus tool service
+## Author a native Nexus tool service
 
-Inherit from `MCPOverNexusServiceHandler`. Use `@nexus_mcp_tool` for a short
-operation.
+Inherit from `MCPOverNexusServiceHandler`. Add `@nexus_mcp_tool` to each short
+operation that you want to expose.
 
 ```python
 import nexusrpc.handler
@@ -80,62 +83,32 @@ class WeatherTools(MCPOverNexusServiceHandler):
         annotations=ToolAnnotations(read_only_hint=True)
     )
 
-    @nexus_mcp_tool(
-        title="Get a weather forecast",
-        annotations=ToolAnnotations(idempotent_hint=True),
-    )
+    @nexus_mcp_tool(title="Get a weather forecast")
     async def forecast(self, city: str) -> Forecast:
-        """Get the current forecast."""
         return Forecast(city=city, summary="Clear")
 ```
 
-The method can use `def` or `async def`. The decorator creates a synchronous
-Nexus operation in both cases. Use it only for work that can finish within the
-Nexus handler deadline.
+The decorator creates the input and output schemas, the synchronous Nexus
+operation, the public MCP name, and the exact route to the operation. It accepts
+both `def` and `async def` methods. Use it only for work that can finish before
+the Nexus handler deadline.
 
-The package generates:
+Use `MCPToolConfig` for service defaults. Values on `@nexus_mcp_tool` override
+the defaults. Only marked operations appear in `tools/list`.
 
-- the public MCP name `weather_forecast`;
-- an input schema from the typed parameters;
-- an output schema from the return type;
-- the title, description, icons, annotations, and `_meta` values;
-- an exact route from `weather_forecast` to its Nexus operation.
+Service names and complete generated tool names must match
+`[a-zA-Z0-9_-]{1,64}`.
 
-`MCPToolConfig` sets defaults for the service. Values on the tool decorator
-override those defaults. MCP annotations are hints for clients. They do not
-enforce authorization or safe execution.
+### Define the Nexus operation directly
 
-Only marked operations appear in `tools/list`. Other operations on the same
-Nexus service cannot be called by guessing their names.
-
-### Authoring directly against a Nexus operation
-
-Use `@nexus_mcp_operation` above a Nexus operation decorator when you need a
-workflow-backed operation or custom Nexus behavior.
+Use `@nexus_mcp_operation` when you need direct control of the input and output
+types, operation name, operation context, or execution model. Put it above the
+Nexus operation decorator.
 
 ```python
 import nexusrpc.handler
 import temporalio.nexus
 from nexus_mcp.authoring import MCPOverNexusServiceHandler, nexus_mcp_operation
-from pydantic import BaseModel
-from temporalio import workflow
-
-
-class DelayedForecastInput(BaseModel):
-    city: str
-    delay_seconds: float = 5.0
-
-
-class DelayedForecastOutput(BaseModel):
-    summary: str
-
-
-@workflow.defn(sandboxed=False)
-class DelayedForecastWorkflow:
-    @workflow.run
-    async def run(self, input: DelayedForecastInput) -> DelayedForecastOutput:
-        await workflow.sleep(input.delay_seconds)
-        return DelayedForecastOutput(summary=f"Clear in {input.city}")
 
 
 @nexusrpc.handler.service_handler(name="weather")
@@ -147,7 +120,6 @@ class WeatherTools(MCPOverNexusServiceHandler):
         ctx: temporalio.nexus.WorkflowRunOperationContext,
         input: DelayedForecastInput,
     ) -> temporalio.nexus.WorkflowHandle[DelayedForecastOutput]:
-        """Get a forecast after a durable delay."""
         return await ctx.start_workflow(
             DelayedForecastWorkflow.run,
             input,
@@ -155,29 +127,112 @@ class WeatherTools(MCPOverNexusServiceHandler):
         )
 ```
 
-The Nexus decorator defines the input model, output model, operation name, and
-execution behavior. The MCP decorator adds MCP metadata. The Temporal data
-converter constructs the Pydantic input. Your operation returns its declared
-output type.
+The Nexus decorator defines the operation contract and execution behavior.
+`@nexus_mcp_operation` exposes the operation as an MCP tool and adds MCP
+metadata. The operation can be synchronous or workflow-backed. See the
+[Nexus hello service](../../examples/nexus_hello/nexus_tool_service.py) for a
+complete workflow-backed example.
 
-Register the service handler and any backing workflows on a Temporal worker.
-Create a Nexus endpoint that targets that worker task queue.
+Register the service handler and its workflows on a Temporal worker. Create a
+Nexus endpoint that targets the worker task queue.
 
-```sh
-temporal operator nexus endpoint create \
-    --name weather-endpoint \
-    --target-namespace default \
-    --target-task-queue weather-tools
+## Add Nexus tools to an AI SDK
+
+The OpenAI Agents and Pydantic AI integrations run in the caller process. They
+call Nexus directly and do not start an MCP protocol server. The Temporal
+server must enable standalone Nexus operations for these integrations. For a
+local Temporal server, set `nexusoperation.enableStandalone=true`.
+
+### OpenAI Agents outside a workflow
+
+Pass a connected Temporal client to
+[`NexusMCPServer`](nexus_mcp/integrations/openai_agents.py). Add the server to
+`Agent.mcp_servers`.
+
+```python
+from agents import Agent, Runner
+from nexus_mcp.integrations.openai_agents import NexusMCPServer
+from temporalio.client import Client
+
+temporal = await Client.connect("localhost:7233")
+nexus_tools = NexusMCPServer.for_service(
+    temporal,
+    "weather",
+    "weather-endpoint",
+)
+agent = Agent(name="weather-agent", mcp_servers=[nexus_tools])
+result = await Runner.run(agent, "What is the forecast for Boston?")
 ```
 
-Service names and complete generated tool names must match
-`[a-zA-Z0-9_-]{1,64}`.
+The caller owns the Temporal client. The adapter's `connect()` and `cleanup()`
+methods do not start or stop a process.
 
-## Call tools from a Temporal workflow
+Use the mapping constructor to expose more than one service:
 
-Compose `NexusToolResolver` with `WorkflowNexusExecutor`. This path uses
-`workflow.create_nexus_client`. It does not create an MCP connection or
-initialize an MCP session.
+```python
+nexus_tools = NexusMCPServer(
+    temporal,
+    {
+        "weather": "weather-endpoint",
+        "calendar": "calendar-endpoint",
+    },
+)
+```
+
+The optional `request_context_factory` callback receives MCP `_meta`, or `None`
+during tool discovery. By default,
+`_meta["io.temporal/idempotencyKey"]` sets the Nexus idempotency key.
+
+### OpenAI Agents in an Agent Harness workflow
+
+Use the Agent Harness
+[`nexus_native_mcp_server`](../../temporal_agent_harness/ai_sdks/openai_agents/workflow.py)
+factory inside a Temporal workflow:
+
+```python
+from agents import Agent
+from temporal_agent_harness.ai_sdks.openai_agents.workflow import (
+    nexus_native_mcp_server,
+)
+
+agent = Agent(
+    name="weather-agent",
+    mcp_servers=[nexus_native_mcp_server("weather", "weather-endpoint")],
+)
+```
+
+The factory creates `WorkflowNexusMCPServer`, which uses
+`WorkflowNexusExecutor`.
+
+### Pydantic AI outside a workflow
+
+Pass a connected Temporal client to
+[`NexusToolset`](nexus_mcp/integrations/pydantic_ai.py). Add the toolset to
+`Agent.toolsets`.
+
+```python
+from nexus_mcp.integrations.pydantic_ai import NexusToolset
+from pydantic_ai import Agent
+from temporalio.client import Client
+
+temporal = await Client.connect("localhost:7233")
+nexus_tools = NexusToolset.for_service(
+    temporal,
+    "weather",
+    "weather-endpoint",
+)
+agent = Agent("openai:gpt-5.1", toolsets=[nexus_tools])
+result = await agent.run("What is the forecast for Boston?")
+```
+
+Tool errors become `ModelRetry` errors. The optional
+`request_context_factory` receives the Pydantic AI run context, tool name, and
+tool arguments. The tool name and arguments are `None` during discovery.
+
+## Call tools directly from a workflow
+
+Use `NexusToolResolver` with `WorkflowNexusExecutor` when you do not use an AI
+SDK adapter.
 
 ```python
 from temporalio import workflow
@@ -199,135 +254,51 @@ class WeatherWorkflow:
         return result.structured_content
 ```
 
-A call first reads the service tool manifest. It then uses the exact route from
-that manifest. The caller does not need to call `list_tools()` first. This
-discovery step prevents a caller from reaching an unlisted operation by
-constructing a name with the correct service prefix.
-
 Use `allowed_servers` to expose only part of a shared service map.
 
-The Temporal Agent Harness provides an OpenAI Agents adapter:
+## Serve a standard MCP client
 
-```python
-from agents import Agent
-from temporal_agent_harness.ai_sdks.openai_agents.workflow import (
-    nexus_native_mcp_server,
-)
-
-agent = Agent(
-    name="weather-agent",
-    mcp_servers=[nexus_native_mcp_server("weather", "weather-endpoint")],
-)
-```
-
-This adapter composes `NexusToolResolver` and `WorkflowNexusExecutor`. The
-`nexus_mcp` package does not depend on the OpenAI Agents SDK.
-
-## Call tools from a normal Python process
-
-Use `StandaloneNexusExecutor` with a connected Temporal client.
-
-```python
-from nexus_mcp.execution import StandaloneNexusExecutor
-from nexus_mcp.resolver import NexusToolResolver
-from temporalio.client import Client
-
-client = await Client.connect("localhost:7233")
-resolver = NexusToolResolver(
-    {"weather": "weather-endpoint"},
-    StandaloneNexusExecutor(client),
-)
-
-tools = await resolver.list_tools()
-result = await resolver.call_tool("weather_forecast", {"city": "New York"})
-```
-
-This API returns MCP SDK types, but it does not use MCP on the wire. A local
-Temporal server must enable standalone Nexus operations:
-
-```text
-nexusoperation.enableStandalone=true
-```
-
-## Serve Nexus tools to MCP clients
-
-Build one `NexusMCPBridge`. The MCP SDK supplies both connection models.
+Use `NexusMCPBridge` when the caller requires an MCP protocol server. The
+bridge accepts MCP requests over stdio and sends discovery and tool calls
+through Nexus.
 
 ```python
 from nexus_mcp.execution import StandaloneNexusExecutor
 from nexus_mcp.frontends import NexusMCPBridge
 from nexus_mcp.resolver import NexusToolResolver
-from temporalio.client import Client as TemporalClient
+from temporalio.client import Client
 
-temporal_client = await TemporalClient.connect("localhost:7233")
+temporal = await Client.connect("localhost:7233")
 resolver = NexusToolResolver(
     {"weather": "weather-endpoint"},
-    StandaloneNexusExecutor(temporal_client),
+    StandaloneNexusExecutor(temporal),
 )
-bridge = NexusMCPBridge(
-    resolver,
-    name="weather-over-nexus",
-    version="1.0.0",
-    instructions="Use these tools for weather questions.",
-)
-```
-
-For a stateful stdio client:
-
-```python
+bridge = NexusMCPBridge(resolver, name="weather-over-nexus", version="1.0.0")
 await bridge.run_stdio_async()
 ```
 
-The client sends `initialize`. The MCP SDK owns initialization, capability
-negotiation, and session state.
-
-For Streamable HTTP with sessions:
-
-```python
-app = bridge.streamable_http_app(stateless_http=False)
-```
-
-For independent stateless requests:
-
-```python
-app = bridge.streamable_http_app(
-    stateless_http=True,
-    json_response=True,
-)
-```
-
-Serve the returned ASGI app with Uvicorn or another ASGI server. The MCP SDK
-owns `server/discover`, version checks, MCP headers, request envelopes, and
-result validation. Configure authentication, TLS, rate limits, and deployment
-policy in the application host or MCP SDK options.
-
-The bridge supports legacy and modern clients by mapping MCP to Nexus operations:
-
-```mermaid
-flowchart LR
-    legacy[Stateful MCP client] -->|initialize and requests| protocol[MCP protocol boundary]
-    modern[Stateless MCP client] -->|discover or direct requests| protocol
-    protocol --> tools[Tool discovery and dispatch]
-    tools --> nexus[Temporal Nexus]
-    nexus --> service[Native Nexus tool service]
-```
+The MCP client starts this module as a local stdio server. A local Temporal
+server must set `nexusoperation.enableStandalone=true`.
 
 ## Use MCP Tasks
 
-When the resolver uses `StandaloneNexusExecutor`, `NexusMCPBridge` advertises
-the `io.modelcontextprotocol/tasks` extension for protocol version
-`2026-07-28`. A task-capable tool call starts a standalone Nexus operation. The
-first response can return immediately with a durable task ID.
-
-A Python client can ask for the task handle and poll it:
+MCP Tasks are available through `NexusMCPBridge` when it uses
+`StandaloneNexusExecutor`. Configure the client for protocol version
+`2026-07-28` and add `NexusTasksClientExtension`.
 
 ```python
+from mcp import StdioServerParameters
 from mcp.client import Client
 from nexus_mcp import NexusTasksClientExtension
 from nexus_mcp.tasks import CreateTaskResult, get_task
 
+stdio_server = StdioServerParameters(
+    command="python",
+    args=["weather_bridge.py"],
+)
+
 async with Client(
-    "http://localhost:8000/mcp",
+    stdio_server,
     mode="2026-07-28",
     extensions=[NexusTasksClientExtension()],
 ) as client:
@@ -340,55 +311,15 @@ async with Client(
     current = await get_task(client.session, task.task_id)
 ```
 
-Use `cancel_task()` to request cancellation. `update_task()` is available for
-the protocol method, but Nexus operations in this package do not request more
-input while they run.
-
-For a simple blocking client experience, use the same client extension with
-the high-level call:
-
-```python
-result = await client.call_tool(
-    "weather_delayed_forecast",
-    {"city": "New York", "delay_seconds": 5},
-)
-```
-
-The extension polls `tasks/get` and returns the final `CallToolResult`. The
-caller waits, but the MCP request that created the task has already ended.
-
-Clients that do not advertise Tasks receive the normal blocking tool result.
-Legacy clients also receive the normal result. Task IDs are Nexus operation
-IDs, so a new bridge process can read an existing task. The bridge does not
-keep an in-memory task table.
-
-```mermaid
-sequenceDiagram
-    participant Client as Task-capable MCP client
-    participant Protocol as MCP task boundary
-    participant Nexus as Durable Nexus operation
-
-    Client->>Protocol: tools/call
-    Protocol->>Nexus: start operation
-    Protocol-->>Client: taskId
-    loop Until terminal
-        Client->>Protocol: tasks/get(taskId)
-        Protocol->>Nexus: read operation state
-        Protocol-->>Client: working or completed result
-    end
-```
-
-`task_ttl_ms` defaults to 24 hours. `task_poll_interval_ms` defaults to one
-second. Set both values on `NexusMCPBridge` when needed. Protect task methods
-with the same authorization policy as tool calls. This package does not bind a
-task ID to an application user.
+The direct OpenAI Agents and Pydantic AI integrations wait for the Nexus
+operation result. They do not expose the MCP Tasks protocol. See
+[MCP Tasks architecture](ARCHITECTURE.md#mcp-tasks) for the task lifecycle and
+failure behavior.
 
 ## Proxy an existing MCP server
 
-The Durable Tools Gateway is for an existing MCP server that cannot become a
-native Nexus service. It registers a server URL under an agent ID and alias.
-It fetches the remote tool list and runs each remote call in a standalone
-Temporal activity.
+Use the Durable Tools Gateway for an existing HTTP MCP server that cannot
+become a native Nexus service.
 
 ```python
 from agents import Agent
@@ -403,93 +334,14 @@ agent = Agent(
 )
 ```
 
-The gateway opens an MCP connection to the remote server for each operation.
-It is separate from the native Nexus tool path. See the
-[Nexus hello example](../../examples/nexus_hello/README.md).
+The gateway path is separate from the native Nexus tool path. See the
+[Nexus hello example](../../examples/nexus_hello/README.md) and the
+[gateway architecture](ARCHITECTURE.md#durable-tools-gateway).
 
-## Result and failure behavior
+## Further reading
 
-The resolver preserves an existing `CallToolResult`. It converts a Pydantic
-model to a dictionary. It returns a dictionary as text and as
-`structured_content`. It converts other values to text. An exception from a
-listed Nexus operation becomes a tool error result.
-
-Tool discovery is strict:
-
-- every listed public name must have an exact Nexus operation route;
-- duplicate public names across configured services fail discovery;
-- an unknown or constructed tool name does not reach Nexus;
-- discovery failure is visible instead of producing a partial, ambiguous list.
-
-Use authentication and authorization at the MCP and Nexus boundaries. Exact
-routing limits accidental reachability. It is not a replacement for access
-control.
-
-## Architecture
-
-The package has four logical domains. The arrows show responsibility boundaries and the table underneath shows modules that are responsible for each domain.
-
-```mermaid
-flowchart LR
-    mcp[MCP client]
-    workflow[Temporal workflow]
-    application[Python application]
-
-    subgraph protocol[MCP protocol]
-        edge[Accept MCP requests and tasks]
-    end
-
-    subgraph tools[Tool resolution]
-        resolve[Discover, validate, and resolve tools]
-    end
-
-    subgraph temporal[Temporal Nexus]
-        invoke[Call or manage an operation]
-    end
-
-    service[Native Nexus tool service]
-
-    mcp --> edge
-    edge --> resolve
-    workflow --> resolve
-    application --> resolve
-    resolve --> invoke
-    invoke --> service
-```
-
-The public types map to these domains:
-
-| Domain | Responsibility | Implementation |
-| --- | --- | --- |
-| MCP protocol | MCP initialization, requests, responses, and Tasks | `NexusMCPBridge` and the MCP SDK |
-| Tool resolution | Live discovery, manifest validation, exact routes, and result conversion | `NexusToolResolver` |
-| Nexus invocation | Calls from a workflow or a normal process; durable operation handles | `WorkflowNexusExecutor` or `StandaloneNexusExecutor` |
-| Tool service | Tool metadata and business logic | `MCPOverNexusServiceHandler` and authoring decorators |
-
-Workflow callers compose `NexusToolResolver` with `WorkflowNexusExecutor`. An
-MCP client enters through `NexusMCPBridge`. Application code can use
-`NexusToolResolver` directly.
-
-### Native service authoring
-
-```mermaid
-flowchart LR
-    author[Service author] --> helpers[Authoring helpers]
-    helpers --> service[Native Nexus tool service]
-    service --> manifest[Tool manifest and exact routes]
-```
-
-`MCPOverNexusServiceHandler` produces the tool manifest and exact route map.
-The decorators turn marked methods or existing Nexus operations into MCP tools.
-
-### Existing third-party MCP servers
-
-```mermaid
-flowchart LR
-    caller[Nexus caller] --> gateway[Durable Tools Gateway]
-    gateway --> activity[Standalone activity]
-    activity -->|MCP| existing[Existing HTTP MCP server]
-```
-
-The gateway is separate from the native Nexus tool path. It opens an MCP
-connection to an existing server for each list or call operation.
+- [Package architecture](ARCHITECTURE.md)
+- [Nexus hello example](../../examples/nexus_hello/README.md)
+- [Authoring helpers](nexus_mcp/authoring/authoring_helpers.py)
+- [OpenAI Agents integration](nexus_mcp/integrations/openai_agents.py)
+- [Pydantic AI integration](nexus_mcp/integrations/pydantic_ai.py)

--- a/nexus/mcp/nexus_mcp/__init__.py
+++ b/nexus/mcp/nexus_mcp/__init__.py
@@ -1,6 +1,7 @@
 """Nexus transport and gateway support for the MCP protocol."""
 
 from .resolver import (
+    IDEMPOTENCY_KEY_META_KEY,
     NexusOperationExecutor,
     NexusTask,
     NexusTaskExecutor,
@@ -10,6 +11,7 @@ from .resolver import (
 from .tasks import NexusTasksClientExtension
 
 __all__ = [
+    "IDEMPOTENCY_KEY_META_KEY",
     "NexusOperationExecutor",
     "NexusTask",
     "NexusTaskExecutor",

--- a/nexus/mcp/nexus_mcp/frontends/bridge.py
+++ b/nexus/mcp/nexus_mcp/frontends/bridge.py
@@ -10,11 +10,12 @@ from mcp.server.caching import CacheHint
 from mcp.server.mcpserver import Context, Extension, MCPServer
 from mcp.shared.exceptions import MCPError
 
-from nexus_mcp.resolver import NexusToolResolver, RequestContext, UnknownToolError
-
-# This follows the MCP guidance (https://modelcontextprotocol.io/specification/draft/basic#_meta)
-# to use reverse DNS notation.
-IDEMPOTENCY_KEY_META_KEY = "io.temporal/idempotencyKey"
+from nexus_mcp.resolver import (
+    IDEMPOTENCY_KEY_META_KEY,
+    NexusToolResolver,
+    RequestContext,
+    UnknownToolError,
+)
 
 
 def request_context_from_mcp(context: Context[Any, Any]) -> RequestContext:

--- a/nexus/mcp/nexus_mcp/integrations/__init__.py
+++ b/nexus/mcp/nexus_mcp/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Optional AI SDK integrations for Nexus tools."""

--- a/nexus/mcp/nexus_mcp/integrations/openai_agents.py
+++ b/nexus/mcp/nexus_mcp/integrations/openai_agents.py
@@ -1,0 +1,221 @@
+"""Public OpenAI Agents adapters for Nexus tools.
+
+Use ``NexusMCPServer`` outside a Temporal workflow. Pass it a connected
+Temporal ``Client``, and add it to ``Agent.mcp_servers``.
+
+Use ``WorkflowNexusMCPServer`` inside a Temporal workflow. Add it to
+``Agent.mcp_servers``.
+
+Use ``RequestContextFactory`` as the callback type for creating Nexus request
+metadata and headers.
+
+Example::
+
+    from agents import Agent
+
+    nexus_tools = NexusMCPServer.for_service(
+        temporal_client,
+        "weather",
+        "weather-endpoint",
+    )
+    agent = Agent(name="weather-agent", mcp_servers=[nexus_tools])
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Self
+
+from agents.mcp import MCPServer
+from mcp import types
+
+from nexus_mcp.execution import StandaloneNexusExecutor, WorkflowNexusExecutor
+from nexus_mcp.resolver import (
+    IDEMPOTENCY_KEY_META_KEY,
+    NexusToolResolver,
+    RequestContext,
+    UnknownToolError,
+)
+
+if TYPE_CHECKING:
+    from temporalio.client import Client
+
+RequestContextFactory = Callable[
+    [dict[str, Any] | None],
+    RequestContext | Awaitable[RequestContext],
+]
+
+
+def _error_result(error: Exception) -> types.CallToolResult:
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=str(error))],
+        is_error=True,
+    )
+
+
+def _request_context(meta: dict[str, Any] | None) -> RequestContext:
+    metadata = dict(meta or {})
+    idempotency_key = metadata.get(IDEMPOTENCY_KEY_META_KEY)
+    return RequestContext(
+        metadata=metadata,
+        idempotency_key=(idempotency_key if isinstance(idempotency_key, str) else None),
+    )
+
+
+class _ResolverBackedMCPServer(MCPServer):  # type: ignore[misc]
+    """Adapt a Nexus tool resolver to the OpenAI Agents SDK."""
+
+    def __init__(
+        self,
+        resolver: NexusToolResolver,
+        *,
+        request_context_factory: RequestContextFactory | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._resolver = resolver
+        self._request_context_factory = request_context_factory or _request_context
+
+    @property
+    def name(self) -> str:
+        return self._resolver.name
+
+    @property
+    def resolver(self) -> NexusToolResolver:
+        return self._resolver
+
+    async def connect(self) -> None:
+        """Do nothing because the adapter does not own a connection."""
+
+    async def cleanup(self) -> None:
+        """Do nothing because the adapter does not own a connection."""
+
+    async def __aenter__(self) -> Self:
+        await self.connect()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.cleanup()
+
+    async def list_tools(
+        self,
+        run_context: Any = None,
+        agent: Any = None,
+    ) -> list[types.Tool]:
+        return await self._resolver.list_tools(await self._make_request_context(None))
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> types.CallToolResult:
+        try:
+            return await self._resolver.call_tool(
+                tool_name,
+                arguments,
+                context=await self._make_request_context(meta),
+            )
+        except UnknownToolError as error:
+            return _error_result(error)
+
+    async def list_prompts(self) -> types.ListPromptsResult:
+        return types.ListPromptsResult(prompts=[])
+
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> types.GetPromptResult:
+        raise NotImplementedError(f"MCP server {self.name!r} does not support prompts.")
+
+    async def _make_request_context(
+        self,
+        meta: dict[str, Any] | None,
+    ) -> RequestContext:
+        context = self._request_context_factory(meta)
+        if inspect.isawaitable(context):
+            return await context
+        return context
+
+
+class NexusMCPServer(_ResolverBackedMCPServer):
+    """Expose Nexus tools to an OpenAI agent outside a Temporal workflow."""
+
+    def __init__(
+        self,
+        client: Client,
+        registered_servers: Mapping[str, str],
+        *,
+        name: str = "nexus-tools",
+        allowed_servers: frozenset[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            NexusToolResolver(
+                registered_servers,
+                StandaloneNexusExecutor(client),
+                name=name,
+                allowed_servers=allowed_servers,
+            ),
+            **kwargs,
+        )
+
+    @classmethod
+    def for_service(
+        cls,
+        client: Client,
+        service: str,
+        endpoint: str,
+        **kwargs: Any,
+    ) -> Self:
+        """Create an adapter for one Nexus service."""
+        kwargs.setdefault("name", service)
+        return cls(client, {service: endpoint}, **kwargs)
+
+
+class WorkflowNexusMCPServer(_ResolverBackedMCPServer):
+    """Expose Nexus tools to an OpenAI agent in a Temporal workflow."""
+
+    def __init__(
+        self,
+        registered_servers: Mapping[str, str],
+        *,
+        name: str = "nexus-tools",
+        allowed_servers: frozenset[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            NexusToolResolver(
+                registered_servers,
+                WorkflowNexusExecutor(),
+                name=name,
+                allowed_servers=allowed_servers,
+            ),
+            **kwargs,
+        )
+
+    @classmethod
+    def for_service(
+        cls,
+        service: str,
+        endpoint: str,
+        **kwargs: Any,
+    ) -> Self:
+        """Create an adapter for one Nexus service."""
+        kwargs.setdefault("name", service)
+        return cls({service: endpoint}, **kwargs)
+
+
+__all__ = [
+    "NexusMCPServer",
+    "RequestContextFactory",
+    "WorkflowNexusMCPServer",
+]

--- a/nexus/mcp/nexus_mcp/integrations/pydantic_ai.py
+++ b/nexus/mcp/nexus_mcp/integrations/pydantic_ai.py
@@ -1,0 +1,239 @@
+"""Public Pydantic AI adapters for Nexus tools.
+
+Use ``NexusToolset`` outside a Temporal workflow. Pass it a connected Temporal
+``Client``, and add it to ``Agent.toolsets``.
+
+Use ``ResolverBackedToolset`` when you create the ``NexusToolResolver``.
+
+Use ``RequestContextFactory`` as the callback type for creating Nexus request
+metadata and headers.
+
+Example::
+
+    from pydantic_ai import Agent
+
+    nexus_tools = NexusToolset.for_service(
+        temporal_client,
+        "weather",
+        "weather-endpoint",
+    )
+    agent = Agent("openai:gpt-5.1", toolsets=[nexus_tools])
+"""
+
+from __future__ import annotations
+
+import base64
+import inspect
+import json
+from collections.abc import Awaitable, Callable, Mapping
+from typing import TYPE_CHECKING, Any
+
+from mcp import types as mcp_types
+from pydantic_ai import RunContext
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.messages import BinaryContent, BinaryImage
+from pydantic_ai.tools import ToolDefinition
+from pydantic_ai.toolsets import AbstractToolset, ToolsetTool
+from pydantic_core import SchemaValidator, core_schema
+
+from nexus_mcp.execution import StandaloneNexusExecutor
+from nexus_mcp.resolver import NexusToolResolver, RequestContext, UnknownToolError
+
+if TYPE_CHECKING:
+    from temporalio.client import Client
+
+RequestContextFactory = Callable[
+    [RunContext[Any], str | None, dict[str, Any] | None],
+    RequestContext | Awaitable[RequestContext],
+]
+
+_TOOL_ARGUMENTS_VALIDATOR = SchemaValidator(
+    schema=core_schema.dict_schema(
+        core_schema.str_schema(),
+        core_schema.any_schema(),
+    )
+)
+
+
+def _tool_metadata(tool: mcp_types.Tool) -> dict[str, Any]:
+    return {
+        "meta": tool.meta,
+        "annotations": (
+            tool.annotations.model_dump(mode="json", by_alias=True, exclude_none=True)
+            if tool.annotations
+            else None
+        ),
+    }
+
+
+def _map_content(part: mcp_types.ContentBlock) -> Any:
+    if isinstance(part, mcp_types.TextContent):
+        if part.text.startswith(("[", "{")):
+            try:
+                return json.loads(part.text)
+            except ValueError:
+                pass
+        return part.text
+    if isinstance(part, mcp_types.ImageContent):
+        return BinaryImage(data=base64.b64decode(part.data), media_type=part.mime_type)
+    if isinstance(part, mcp_types.AudioContent):
+        return BinaryContent(
+            data=base64.b64decode(part.data), media_type=part.mime_type
+        )
+    if isinstance(part, mcp_types.ResourceLink):
+        return str(part.uri)
+    if isinstance(part, mcp_types.EmbeddedResource):
+        resource = part.resource
+        if isinstance(resource, mcp_types.TextResourceContents):
+            return resource.text
+        return BinaryContent(
+            data=base64.b64decode(resource.blob),
+            media_type=resource.mime_type or "application/octet-stream",
+        )
+    raise TypeError(f"Unsupported MCP content type: {type(part).__name__}")
+
+
+def _error_message(result: mcp_types.CallToolResult) -> str:
+    messages = [
+        part.text for part in result.content if isinstance(part, mcp_types.TextContent)
+    ]
+    return "\n".join(messages) or "The Nexus tool call failed."
+
+
+def _map_result(result: mcp_types.CallToolResult) -> Any:
+    if result.is_error:
+        raise ModelRetry(_error_message(result))
+    if result.structured_content is not None:
+        return result.structured_content
+    content = [_map_content(part) for part in result.content]
+    if len(content) == 1:
+        return content[0]
+    return content
+
+
+class ResolverBackedToolset(AbstractToolset[Any]):
+    """Adapt a Nexus tool resolver to Pydantic AI."""
+
+    def __init__(
+        self,
+        resolver: NexusToolResolver,
+        *,
+        id: str | None = None,
+        max_retries: int | None = None,
+        include_return_schema: bool | None = None,
+        request_context_factory: RequestContextFactory | None = None,
+    ) -> None:
+        self._resolver = resolver
+        self._id = id or resolver.name
+        self._max_retries = max_retries
+        self._include_return_schema = include_return_schema
+        self._request_context_factory = request_context_factory
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def resolver(self) -> NexusToolResolver:
+        return self._resolver
+
+    async def get_tools(
+        self,
+        ctx: RunContext[Any],
+    ) -> dict[str, ToolsetTool[Any]]:
+        max_retries = (
+            self._max_retries if self._max_retries is not None else ctx.max_retries
+        )
+        request_context = await self._make_request_context(ctx, None, None)
+        tools = await self._resolver.list_tools(request_context)
+        return {
+            tool.name: ToolsetTool(
+                toolset=self,
+                tool_def=ToolDefinition(
+                    name=tool.name,
+                    description=tool.description,
+                    parameters_json_schema=tool.input_schema,
+                    metadata=_tool_metadata(tool),
+                    return_schema=tool.output_schema,
+                    include_return_schema=self._include_return_schema,
+                ),
+                max_retries=max_retries,
+                args_validator=_TOOL_ARGUMENTS_VALIDATOR,
+            )
+            for tool in tools
+        }
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[Any],
+        tool: ToolsetTool[Any],
+    ) -> Any:
+        request_context = await self._make_request_context(ctx, name, tool_args)
+        try:
+            result = await self._resolver.call_tool(
+                name,
+                tool_args,
+                context=request_context,
+            )
+        except UnknownToolError as error:
+            raise ModelRetry(str(error)) from error
+        return _map_result(result)
+
+    async def _make_request_context(
+        self,
+        ctx: RunContext[Any],
+        name: str | None,
+        tool_args: dict[str, Any] | None,
+    ) -> RequestContext:
+        if self._request_context_factory is None:
+            return RequestContext()
+        request_context = self._request_context_factory(ctx, name, tool_args)
+        if inspect.isawaitable(request_context):
+            return await request_context
+        return request_context
+
+
+class NexusToolset(ResolverBackedToolset):
+    """Expose Nexus tools to Pydantic AI outside a Temporal workflow."""
+
+    def __init__(
+        self,
+        client: Client,
+        registered_servers: Mapping[str, str],
+        *,
+        name: str = "nexus-tools",
+        allowed_servers: frozenset[str] | None = None,
+        id: str | None = None,
+        max_retries: int | None = None,
+        include_return_schema: bool | None = None,
+        request_context_factory: RequestContextFactory | None = None,
+    ) -> None:
+        super().__init__(
+            NexusToolResolver(
+                registered_servers,
+                StandaloneNexusExecutor(client),
+                name=name,
+                allowed_servers=allowed_servers,
+            ),
+            id=id,
+            max_retries=max_retries,
+            include_return_schema=include_return_schema,
+            request_context_factory=request_context_factory,
+        )
+
+    @classmethod
+    def for_service(
+        cls,
+        client: Client,
+        service: str,
+        endpoint: str,
+        **kwargs: Any,
+    ) -> NexusToolset:
+        """Create a toolset for one Nexus service."""
+        kwargs.setdefault("name", service)
+        return cls(client, {service: endpoint}, **kwargs)
+
+
+__all__ = ["NexusToolset", "RequestContextFactory", "ResolverBackedToolset"]

--- a/nexus/mcp/nexus_mcp/resolver.py
+++ b/nexus/mcp/nexus_mcp/resolver.py
@@ -14,6 +14,9 @@ from mcp import types
 
 from nexus_mcp.authoring import LIST_TOOLS_OPERATION
 
+# MCP uses reverse-DNS names for application metadata.
+IDEMPOTENCY_KEY_META_KEY = "io.temporal/idempotencyKey"
+
 
 @dataclass(frozen=True)
 class RequestContext:

--- a/nexus/mcp/pyproject.toml
+++ b/nexus/mcp/pyproject.toml
@@ -18,6 +18,18 @@ dependencies = [
     "temporalio>=1.15.0",
 ]
 
+[project.optional-dependencies]
+openai-agents = [
+    "openai-agents>=0.22.0",
+]
+pydantic-ai = [
+    "pydantic-ai-slim>=2.13",
+]
+integrations = [
+    "openai-agents>=0.22.0",
+    "pydantic-ai-slim>=2.13",
+]
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
@@ -31,6 +43,8 @@ asyncio_mode = "auto"
 
 [dependency-groups]
 dev = [
+    "openai-agents>=0.22.0",
+    "pydantic-ai-slim>=2.13",
     "pytest>=8.0",
     "pytest-asyncio>=1.0",
 ]

--- a/nexus/mcp/uv.lock
+++ b/nexus/mcp/uv.lock
@@ -93,6 +93,121 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/61/2cb6ad133dbbb449fa2d37ccae973232f4827e799af258d15e589a3d1e9e/charset_normalizer-3.5.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:4f298bdadb8f0b9e5672877f647d1be9373ef5320c9e2f049795e26cad28b6a9", size = 211584, upload-time = "2026-08-15T08:17:33.597Z" },
+    { url = "https://files.pythonhosted.org/packages/18/57/a305c968be1ca13f3dd1b32f445877e97addf55d80b65c7cb35fac82b777/charset_normalizer-3.5.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:88ca277405c2d3b71c4e1c2ee0e7966e807bcba86a69d11e19ba199d18ae4491", size = 223359, upload-time = "2026-08-15T08:17:35.022Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/d3646670292ce8d8f8cc11ac067d44885e697a5591f57a9221128da5e7b3/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9362dd90aa7dab48c0054a21187791ccf05473f7dba5d92b8033ae62164675e7", size = 194464, upload-time = "2026-08-15T08:17:36.452Z" },
+    { url = "https://files.pythonhosted.org/packages/de/93/d51ec556e01042fed6f993ea859311bc7917b466684182fbbceb6ca24762/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:977cdbd483a9cff38179bea4fd754289a6f2195c7abd414aba85410b3e66cc5e", size = 197676, upload-time = "2026-08-15T08:17:37.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d", size = 340473, upload-time = "2026-08-15T08:17:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a", size = 240156, upload-time = "2026-08-15T08:17:40.66Z" },
+    { url = "https://files.pythonhosted.org/packages/09/53/27923ce5cc6cbccb832037b27dca98882d9c53e9b69e866bbbef4aae7fc8/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d59b75732e9b6f27388e10c14b0259cc5f2e48c78627d185e6a177b58ad3cffe", size = 228246, upload-time = "2026-08-15T08:17:42.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5a97e84d63af1d55c07439cb80e56d99a8efb4295700eb4e18c0d1615d2c/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0d929fc574b4d6fd9e7c0f5c2ede8716a41911923aa7fa5fce38e0818aa4a1ac", size = 263660, upload-time = "2026-08-15T08:17:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/071575791dcc88316c0a9a65ce38897a82e4cfe4a325f0f7fe1b1ac47bcf/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:394fea06235c8543390050ed5f529187074b029fb027213f6c46ac11ab5d950e", size = 260354, upload-time = "2026-08-15T08:17:45.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/66/70dfad64f15be09c15ccfee81330a7e515895dbe296dd23114e9a231268a/charset_normalizer-3.5.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa48b1b63d639f9483e0633e092f5851e2348c352f1f9bb6c8182f87884ef876", size = 244583, upload-time = "2026-08-15T08:17:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/24/ef36367d38b9ddd4bccbf72888c342e8de1f5ae506fa0b2dcf970e2732a1/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c71fb0d56c920c269cd3e2e3fe7c610e3f1fdb21a6ce60efa6430ff63676cea6", size = 242038, upload-time = "2026-08-15T08:17:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ab/55e683ba0fff2e43adafc10daa3001eac90fdaa419a97227d5a7067eedde/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:485a0d363cafefcd2538a73c7c838daa2035f09b2c9f9b5e3133f80c6aeb84c2", size = 233677, upload-time = "2026-08-15T08:17:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/67/0f40eaf8d1b6e7cf15e82382a2965efaca787fc1c2794b7021d37aaf5036/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0ea61a470e070686aa30892fed79e297d2c8d0ab46b8bcdf027d38c51da591", size = 264491, upload-time = "2026-08-15T08:17:52.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/64/12b4c2a11ee8df4fcc518c78b0d93e3a92bd3d5253d1617ce74ff0e8c7ef/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90b7481fb62fbe172c558bc6fd1c4c98d82004a54a7551f20e11ac9bf0b8708c", size = 245196, upload-time = "2026-08-15T08:17:54.023Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2e/651d910af6d0fba325eee1cda37ec5443462ed25360e666c144166eb6091/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:35fe081843b35aad20ffeccec3eeffbe637b15d14f3fb22cc1b59cd8ec17e93c", size = 261660, upload-time = "2026-08-15T08:17:55.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d4/703be739b26acce318bd29eb3b25b7209e1b1f527f9eae3d1f1f01fdde2b/charset_normalizer-3.5.1-cp313-cp313-win32.whl", hash = "sha256:d63600d620ad0064c3a748b950ac5ea38a80190e5498532efefa4b7b3f1da1f3", size = 177755, upload-time = "2026-08-15T08:18:00.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6", size = 199295, upload-time = "2026-08-15T08:18:01.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/75/5b20dd1e6573a01a08158fe104104fa2c8abf941745596954185726cd46c/charset_normalizer-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0", size = 179856, upload-time = "2026-08-15T08:18:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/29/cd/2b812ce5e888f1ce69a5350281e58aab07ae64a958ecae8912f30865718e/charset_normalizer-3.5.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:774d157f112367ff4abd29019f38f023c24e00e56edc7829c20e358a5a913ad8", size = 212318, upload-time = "2026-08-15T08:18:04.403Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/a6ee107430768a5334e6d63f31f148a04a1a491ef161a1ac9415a73f2fa8/charset_normalizer-3.5.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:26422d45fd13551cf564c58932f7d72b4f58b93b0fcf18c35ba6be12b46bb102", size = 224897, upload-time = "2026-08-15T08:18:05.997Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/35ae3f64f29d0179c35c3baefe575904df2913dde519129c7f75995a2b1d/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:09a7bba9f739468c8e78c36a75c33768e53cb1959fc638f510454c14683f00d5", size = 194848, upload-time = "2026-08-15T08:18:07.397Z" },
+    { url = "https://files.pythonhosted.org/packages/74/76/f2fc7380f056cc273a53af37f50d08ad54b2c59f61078f31432edcf1c2bd/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4c9548dc78002099910abaebc0a72ac58b7d30931869e0351c09b507dff4ece3", size = 198163, upload-time = "2026-08-15T08:18:08.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/40/095ce62fa078483cccc1fa2b36e6bc9580b85422a20ee9f925341c50e44f/charset_normalizer-3.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c428c6c31eb5f4277d7f8eccaf767fbd548ddd5ce3c8b4f4cbbfab3d96b5904c", size = 341823, upload-time = "2026-08-15T08:18:10.458Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/5a/0e58b1c04a1596e0256f407274a92d5fb2ee21324409d1fab1da48a65b5b/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f06b7eae9dbe77fe1d644ca244dad508de8d302870a43f3c559b521270938a0", size = 242458, upload-time = "2026-08-15T08:18:11.989Z" },
+    { url = "https://files.pythonhosted.org/packages/22/95/b4618ce912e6db0b1aae89ba788e38e8a7eba0f3025cc66e8c0699f977b2/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b7430cf5728e68f6c462254009a6ef4086e1bea43cf2f57aa9c55fb4f50ff96", size = 226717, upload-time = "2026-08-15T08:18:13.401Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/76/c681192bbda3d55356db5dadd64381d5202b37c6b598fcda5282e88b5d3d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab743e9bc90c1f73552ec33e10e3331315acd2c397b36065b591b0181de533cc", size = 266111, upload-time = "2026-08-15T08:18:14.961Z" },
+    { url = "https://files.pythonhosted.org/packages/88/be/55127bfca72c0cff6c022488d140d7c5b04c771e3b72e9bdb4836d54979d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6f7deae3feb4edfa2efaf7c574fe88cbf055038a6abdb40188e4fff66d5699f", size = 263128, upload-time = "2026-08-15T08:18:16.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/91/39c3af510b0aa32bbda03374259200f28430febfd1bf5e511fe765282ce5/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15f024313246a4ed976c60f440bb8d257815513a681d212ff74fd46f7d715a90", size = 251240, upload-time = "2026-08-15T08:18:18.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a5/cbe418bbc6ecdfc3e05a0116002897c4b403a5e838d697e64c78e9f0190d/charset_normalizer-3.5.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:823f82903d189af463d7df250ef1f7f696f3cee08cc8d91deb565e8d425f6506", size = 245282, upload-time = "2026-08-15T08:18:19.625Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a4/689bb42e8e7cd492f3cb64907c6bc00ad247ec9a3628cd3f8eed126e8ae1/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:01e93745f7f219b703b60ba7afead36cfc4242782be5af484673fc500df12da5", size = 244597, upload-time = "2026-08-15T08:18:21.121Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/9962938e179cf9f699d3f1e7b3114b5d7642dee6a893745229f9dd04f274/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329fc3ccb63ad22d867d84c2adea759a64079a37ba4a343433b02c7a2816871e", size = 231376, upload-time = "2026-08-15T08:18:22.57Z" },
+    { url = "https://files.pythonhosted.org/packages/85/54/46000450ada53bd9eac5429a2c8c54cd2d9b39c0c255f229aea9af0948a5/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:bb57753e36e4855b8ca375069482250a6246372331a3e4f3407eaebb007443f5", size = 266715, upload-time = "2026-08-15T08:18:24.235Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bb/618749d70f792b44252a777bf89bfb86823b9bbc1ea13fe8ce759b07f38a/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fce8cbd4997efeb450bd298b54f755dcdff18d496f7a5ddbb4867c6d7c88fdc3", size = 245848, upload-time = "2026-08-15T08:18:25.726Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3f/ffb64458527c7668031d5eb095d978de561958dc9f5b53f8e488a533e603/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6c9cdde8becb25a7fde49924511aa2644d6f8081cc8df8e9452724303348d8e3", size = 264521, upload-time = "2026-08-15T08:18:27.193Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ab/74a55fd803916a35ac461daf002708191aac19b546b80dc8cabfedc63d98/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9ac4444d8d4fd4c4bd08bf451ed3167aa9e7ec6cdb41b648794f1d1103652e36", size = 253054, upload-time = "2026-08-15T08:18:28.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2a/6a9034b7d3c60b17499afb482df5878bf9fa20b50cc3887d5ef017a833db/charset_normalizer-3.5.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f03ac127268b43ef4fe9e6ab6794a6794b49485a0cc0c1db79876d2f33f75bc7", size = 140580, upload-time = "2026-08-15T08:18:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/46/1d362e1a00d035d66b9869e1281eee115907f7e390a16a07824ab5737360/charset_normalizer-3.5.1-cp314-cp314-win32.whl", hash = "sha256:1f5883d77fd409a261abb5dc8ccbe335720d798b1de4abb3b1d47ccbbc76b53b", size = 180325, upload-time = "2026-08-15T08:18:31.877Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7c/4938c329b6a9d446f6a59aa2092ff7118f274209b5ed0e26893d1d30a63c/charset_normalizer-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:c658c50ac0c98cd755a2dd50b7977d3bca7df401dcc47fbdfa87db53ef7d4e8b", size = 204175, upload-time = "2026-08-15T08:18:33.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/eeb384dbd8dec570661354592f4f2e1b2fcc92585624d146a000caf53841/charset_normalizer-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:4bea7f8ebe90bbd7f0e4a2de42ca6924ba23e3e76418c408ff82f1d46fabd687", size = 184123, upload-time = "2026-08-15T08:18:34.913Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/6c/c73fa9d5a85f6ab05395de61c5f6984e0a9ff40bb5ff888d46dff02526c6/charset_normalizer-3.5.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbc597639158fd7c14d55e808718848319540f51b0e6746e3eefa59723a4a348", size = 381682, upload-time = "2026-08-15T08:18:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c7/63565f860921457feba93bae6c86fb7746deb4cffeed2f375cb845318146/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71c909f353863b2b89c83de2ebed71ea6d0df8a6ef65a128193c5e650766bef", size = 240826, upload-time = "2026-08-15T08:18:37.887Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ae/7ae8807410dfa33f8e6f1715740adeaafa8a816cc4cb33508f54b1f7c896/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7ac76cf9afd34929d76eb7fcb63be476a4853d8a96f0dcf2d0db68a0cbdf9885", size = 227861, upload-time = "2026-08-15T08:18:39.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a3/887c1642f0da26000b0e0652d91071113c0e72cea33952e225cf589f49a9/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a3a370082ce34d0612f421e15fe011c53bb1feff21a26d06ad4fb244dab5a375", size = 260758, upload-time = "2026-08-15T08:18:40.88Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/e6f5b9a3d0e55b0ef7505cd3765cdd48f22db89994c947b316f52f801fd8/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:256dd4d85d9e4dc595e2bc983c980e73f62ddeb3165c58b4c3dfe78c5c8548c1", size = 259950, upload-time = "2026-08-15T08:18:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ee/e4e10a94d51cd1ee638aa7e00b65399e6b2a4e8376ab6d2eac9f95586671/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58d4aa13a59c969dbfdf9e6a9560e242cbfd9e8a8f50c2747714df1a423adf65", size = 249329, upload-time = "2026-08-15T08:18:43.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/25/d5f4198819e6059735a84e8d0bfb72dc33976da67b97adcd3fb5a5e07ec6/charset_normalizer-3.5.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0c6dfb5ca6723eeed15aa8e564a014d69fcb8812f94eef11fe3631e0508199f5", size = 243137, upload-time = "2026-08-15T08:18:45.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e925ca7569cf9fb9701fd82503fee73eea5268fdb856bdd64947092d3daa/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c010f5581d9c612804cc59fcf7b524b707fbcb72828551237ab545bb5c7034af", size = 242820, upload-time = "2026-08-15T08:18:46.842Z" },
+    { url = "https://files.pythonhosted.org/packages/34/17/672c251a888ed2aebcdd2fe830ad0104e25ff83c43f5c4f9c15e9fc6853c/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:52ec005752a56ae79547a05c0139ca2501a0c866390b6115008456b9f0e7cde1", size = 230504, upload-time = "2026-08-15T08:18:48.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/fc/f6a85abebd42ce4da2f1db0aa56cc6a0df1995e318b3875d14401b8381d1/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2bced4061f000f7187254a02ad3433ae17eaf991747ceea2f478422590a5bba9", size = 263087, upload-time = "2026-08-15T08:18:49.859Z" },
+    { url = "https://files.pythonhosted.org/packages/98/66/7c42677e739ba66746b297e2046918d793078094dc239e1e72768cffccc6/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9eea3ab2597a5e65fe65296e2d6a84570845a6b55532d90333d740d48bbc850a", size = 243269, upload-time = "2026-08-15T08:18:51.601Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/a50b79237f417af10f8c2a501ce8d1ca87829a22e69117891ca4ba20a69e/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:496846868fea80e479324862fa877f02411f2fd0f83b79ccee2607aa68b2a032", size = 258766, upload-time = "2026-08-15T08:18:53.23Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1d/0fc91aeaeb3c83b748f532399ce67cf84604b48297405d740000f7a9e786/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:85d5855daafc240cc045c026d7a15fd198a09b0fc8ff6f5ecbb5297b509cb11e", size = 250814, upload-time = "2026-08-15T08:18:54.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/10/3d8c777cf9024615295aa1b808324ad5b4a77855869c00824bad74ffaf8a/charset_normalizer-3.5.1-cp314-cp314t-win32.whl", hash = "sha256:58d3e12c88e0950bca850ae1f7c256055c097639c2edb9eb123af9807d8b15e4", size = 191074, upload-time = "2026-08-15T08:18:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/81/ae557d3c44d1a1d688696d60563413a0866a91b7ebc50f20df838be3d8c8/charset_normalizer-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:acaf604462bf330b0d07e7a07c1d6e4adac79e5fb13e9c5140590542cafacc00", size = 216476, upload-time = "2026-08-15T08:18:57.889Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e9/61c01fb8b804692569c036b3fc50495814502dcf13a60649c6055390b02c/charset_normalizer-3.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:fdb8a068947befafba9952162645dc2fecaeb400e64584829ed5e9b2fbe21a7f", size = 194115, upload-time = "2026-08-15T08:18:59.418Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4e/8544831ef59d8f27ce92c80871380fdacc8076a8a56ed62f82e54f991333/charset_normalizer-3.5.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9085f87b0e38a2b92b8923059b4e8789fe40d9279712d15dcc670048d77079af", size = 342048, upload-time = "2026-08-15T08:19:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a6/e3b46852424246065355644f4fb6dbccc0239a42a2eee27ecfc8957f0bcd/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2679de311c7946dde5d3b6f44941844133ff5c7cb86099c0061ab1e8901c20a8", size = 242997, upload-time = "2026-08-15T08:19:02.492Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3b/0cc9a26777334ab2f2e3089b948bbf4e4fe72ea70b897715ef6415043ec8/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:baf3775a2635e5a11fbd5e4e64ee69c7e86875d224a5c72aca4c141064589a90", size = 237014, upload-time = "2026-08-15T08:19:03.943Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c2/027335f0aa337a2a2e121bac1ad88c4f02ba6053ea0926802784f3db11af/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac8c94b6539074e0f40899301273ac8402b9b3e01c7b7ba269ff30340aaaf20", size = 266174, upload-time = "2026-08-15T08:19:05.598Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d3/e367787febe4e74769dec0f406f2c3c8d1b955fce5aee1fd0f94e8367a45/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8fe532b3c966d1fb794e0698e4589d0444017ae77fc0b31edea13c0e35bcc449", size = 263361, upload-time = "2026-08-15T08:19:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3d/391b193eb9f3e84b02f9314088c386debdc0debee843535aaea2e2c6715d/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c84bec0ab5ae0c64bfe73a7d2adcb5ce73b467523fc27fd6a28ab2aa6cbe35a", size = 252143, upload-time = "2026-08-15T08:19:08.816Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/57/de221f1745a90d418199761967e2776bfe2c275a1194220985e8c1d37833/charset_normalizer-3.5.1-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:854066be00447fa8de2ccbbe893e2ffc4b123ef16d897af794c1e18bd4a714b0", size = 252086, upload-time = "2026-08-15T08:19:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/d119f86a01f9331e8186175f24873b1d74a7ee9e2e4b4d68f9947dae5afd/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:21b82d8082f6f5e7f456ef0bd16323d08de1266efbfeb476e64b2a91d1471a4e", size = 245231, upload-time = "2026-08-15T08:19:11.807Z" },
+    { url = "https://files.pythonhosted.org/packages/26/de/d8e48c135ae480879539cdb179c8d3b50c7879497d75dd899b5763b69cee/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:838648accb3a7fd9803fd45c87bce8509648eb0c11bc34e216141300977244f2", size = 241546, upload-time = "2026-08-15T08:19:13.416Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c4/217755fd1abc50d326c252922cd642002758095a81ff45010337b8b3ef65/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:195ce897c6153c0700078142cf8efe3e6454ca4cf4357499e4078dfd83396626", size = 267033, upload-time = "2026-08-15T08:19:14.981Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/34d8e404e358d2adcc5a228c2134643af00104c8fb0bf525f3688d756f05/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:978eab16f55b4ab2c2a745be9a0a840bf8f09a7f227d9c76eb30214d078865a5", size = 252045, upload-time = "2026-08-15T08:19:16.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fa/40414471acf0aa0692ca77305aa00e434fcd8288f0941c93c30e9a5f8f2f/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:cc0329df4caaceb950d2f580b5ac716a377f7059624a0bafaeaf8a218c6ed774", size = 264866, upload-time = "2026-08-15T08:19:18.101Z" },
+    { url = "https://files.pythonhosted.org/packages/32/90/fcc850bae791abd2e0c041847f13e270aa08692a79f3e00de6d2dce1cb50/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:687c9ca3035544b113bea2055e180af96fb63c0c476e22a9180f51925186e7b7", size = 253932, upload-time = "2026-08-15T08:19:19.734Z" },
+    { url = "https://files.pythonhosted.org/packages/af/af/53afe99068b3c10b4cbae592a52ef72a7c92c0188440e83ee3a078fd8f75/charset_normalizer-3.5.1-cp315-cp315-win32.whl", hash = "sha256:706bfd38730a5ac7a365793269a00f4e988178cec121391f4248d84ad8c972e9", size = 180320, upload-time = "2026-08-15T08:19:21.37Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/bc/f46a132041b29e4a8779ed712d3df1bf112e94ca8de58b66d7ec2c0cf8b9/charset_normalizer-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:92caef967d287a407085d61176fce4012b1dd62daed4eb6d5ceb26d3d2538712", size = 204174, upload-time = "2026-08-15T08:19:23.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5d/9ed554480eda8e447b673648628fdc29574d23dbad01fe11837adedd1cae/charset_normalizer-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:5fc45d653ea8c9a20479167e11d4a0f8cb2fa3470737ab6f9c827532313187b7", size = 184126, upload-time = "2026-08-15T08:19:24.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/32/9b8929bf384061ee1fe5d9c27c6f9776d3d824039ad4e14c88ec00c7808e/charset_normalizer-3.5.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:59171c6e45bf07d0d5cab3b0bf81d945035530f6873398b3b531c31184d46663", size = 381441, upload-time = "2026-08-15T08:19:26.038Z" },
+    { url = "https://files.pythonhosted.org/packages/96/10/e9aa7923d3ddac652c99a1c5f7be494e737e151566a44abe018daf757f2c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9dbdd9205662134957cf0c324f639bdc5031c0ca056e2369e238db75187c0f11", size = 241742, upload-time = "2026-08-15T08:19:27.532Z" },
+    { url = "https://files.pythonhosted.org/packages/28/53/a2d249ebddf47b889a100c0bdcb61a2f9dbb8bc24ef325cc062e4f476877/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e4b018dc5a0eee4676e38fe84a47a427816c590b93b55d9025274ec4d6ffc2dc", size = 235298, upload-time = "2026-08-15T08:19:29.274Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/07/469f78af590f7d5cd48e20d8dbfa3d66deeff9ba37768c04d886b5afd45c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced3fdd71aaa83ce593746c2edb42b7a59cb4c19c8b5c407781c72e493aae55a", size = 262500, upload-time = "2026-08-15T08:19:30.955Z" },
+    { url = "https://files.pythonhosted.org/packages/55/66/3bb56a47f7dcba014055b1a1d33c6f08bbe9c1e74dba154cfa25f90ae885/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:19a3dd5aa73cef1c99687c4fc57db016a9c17104ae1185da88ba566a5d3bebe4", size = 258888, upload-time = "2026-08-15T08:19:32.458Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c1/2adc2800903fb013210349313b710a5376856578d9e33e6b9a1d8b36714a/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc5d36d96478aa9c60654bd932525bf32964c62a7281eafdf16d85003a8d6004", size = 250243, upload-time = "2026-08-15T08:19:33.94Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/a18d0dd1157ab655cc2cb14a545f4a4784bbad70ab3502412e36097502d9/charset_normalizer-3.5.1-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:04368edf83514385ffc3e1cfd4546e595f4f1272dd23ba437a93a9cc3741d47b", size = 249871, upload-time = "2026-08-15T08:19:35.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c3/525f508cd1e58d0450ac55ed40ac75bc3a97482c59def5278456a5fbf03c/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:9b5db6052055d34d41230fb78d7c439c23dc536a9896f6cb039e8dd92cfc1263", size = 243580, upload-time = "2026-08-15T08:19:36.886Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c1/49a91fe7e97c8140094ca5c64161ab623a70d9f636bf834eace14048acb5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:252d099029bcbea642f2a06c4ed5046bdf8b5a8150b64afa5e027e88b106e5ee", size = 239807, upload-time = "2026-08-15T08:19:38.392Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/58/56a48c296601274c4689b864a8e2dfb209b81dfcb39472753ce95eea662b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:6199d5606e2bbf2b096cf64d03f8b6790c91081d5ac866b8e7bb6422738cc60c", size = 264083, upload-time = "2026-08-15T08:19:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/4c/dc48409274a1817ff349711d26c62aa0c597df865d4d69ef79160c859193/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:77efcff2b23071c349402ac1066667a3d011f62398d81408c9b88ad991747c9e", size = 250317, upload-time = "2026-08-15T08:19:41.53Z" },
+    { url = "https://files.pythonhosted.org/packages/81/58/d325912115caec62d6bdd77bbab5e0b7da5d234a9f20affdffcbcb530d0b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:a5cbd90ecf0fc62e64726917ad083b73001f0563657a87ec3c0b504e277dc90d", size = 258173, upload-time = "2026-08-15T08:19:43.07Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/b13b1ccae2c8ec63980d13be1890eb73f8aeabbfce02a24aabc0908788f5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:4d26f14f041e83dd8edfd61f4cd4fa7285d31798b5bf1f28e70c367ba6c41d61", size = 251960, upload-time = "2026-08-15T08:19:44.587Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/25/ed3f9919c5aef8cc818be1f972f565f7610d7b2076b8ebb98839516ffc3c/charset_normalizer-3.5.1-cp315-cp315t-win32.whl", hash = "sha256:ac13b004224fb341e1e25a1ed5e19d32f57cdb2a403e01f003b46f051a550f6f", size = 191186, upload-time = "2026-08-15T08:19:46.293Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/43c2b3e9d8267092b913eb8b0603f0f71993c395632886bd37a7223f96cf/charset_normalizer-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:35aea775dc2bd5f54cd84a1cd2696cc3207c479cb9cf0bd346f0d343e4300ddb", size = 215947, upload-time = "2026-08-15T08:19:47.853Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/9aad3e9c8865e5e0efa9a7f6f81c37a67635a985145ecd44528a81e088ee/charset_normalizer-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:fb78f6e7fcd8ad785d28cd577168bc1aaee827b25bb8755638f694794ea98f0a", size = 193909, upload-time = "2026-08-15T08:19:49.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -164,6 +279,28 @@ wheels = [
 ]
 
 [[package]]
+name = "genai-prices"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/16/e5a507d42c0eb629b48ebe6c278f2d8c3f929bb6b28f18108bdd66d8ae12/genai_prices-0.1.6.tar.gz", hash = "sha256:802c1e4cc3ed5e70a09083b83af441a58d91f62e12768f7f1b6b26c98a33fcac", size = 111810, upload-time = "2026-09-02T14:53:54.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/a1/43fa2a4c5557cd977e83eecec265b0b77b726b0c7b9f2f180b46c6fdb458/genai_prices-0.1.6-py3-none-any.whl", hash = "sha256:35ac8043dbcf2958488129413bfecba7304fe12a68ad4a78c5b0d15281e82814", size = 118834, upload-time = "2026-09-02T14:53:53.758Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/af/018c10bc9edd42b6ef6db2e96b09542050d5253f9b195e74bc910b2d13ab/griffelib-2.3.0.tar.gz", hash = "sha256:7b0952caf5bca6afa4bb5ee8c6a2d183fe3f21b62efc5f6c7243cb2b26d2d115", size = 234534, upload-time = "2026-09-04T15:08:17.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/63/e876e789525063c840ccfa8857febdabd6523bcef9ce7eb979b9305ea895/griffelib-2.3.0-py3-none-any.whl", hash = "sha256:1b8f9cd525681c26b1d6d574faa1371651e8459ca51d209684f50b8096ae06e0", size = 169423, upload-time = "2026-09-04T15:08:12.956Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -173,40 +310,41 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
     { name = "h11" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
     { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2-jsfetch"
+version = "1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -225,6 +363,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
 ]
 
 [[package]]
@@ -255,16 +443,25 @@ wheels = [
 ]
 
 [[package]]
+name = "logfire-api"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/bb/3ee615e089eae6b11c61bc3a34d58256942210f81aa4884962ef1b9bde01/logfire_api-5.0.0.tar.gz", hash = "sha256:c018a16cd36a8ec20c6c6c316d3822788573ccb573e1b29a8be7a78d778e7775", size = 95611, upload-time = "2026-09-04T18:44:53.935Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/67/282646935c5af564ca89447f745aa292e2d36b554fac3d1effe5c75495ca/logfire_api-5.0.0-py3-none-any.whl", hash = "sha256:a95cc00c679ddcb98fb53c425bdebb6008a9498fb989e89f280283cb00a58a74", size = 145861, upload-time = "2026-09-04T18:44:50.673Z" },
+]
+
+[[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -274,9 +471,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/31/ac54fb0fdd5b37de704486e288bba4fbbb463f24cfcfedbede407b854513/mcp-2.2.0.tar.gz", hash = "sha256:2dc37ecb1974becdcebdbf7561e7c15a07dbbf20ba21ba16c3593b3038b3afbd", size = 4084129, upload-time = "2026-09-07T16:06:23.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ff/8e7eade68b8a28f7da0ed1085544341b51f9c935dbf6b95c76b7edfea6a0/mcp-2.2.0-py3-none-any.whl", hash = "sha256:bde982589473a060ae145e3406e9a5333fe538c97229ba841f5a7f92be004f81", size = 365656, upload-time = "2026-09-07T16:06:19.711Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/91/762d7755d971aff8a28d75f7961656148edf27875c8026e6385aaab08ae7/mcp_types-2.2.0.tar.gz", hash = "sha256:d3ed53703ddd10d9c6399f29d322bb66f3f67ab41348ac8556ba23e07fedefad", size = 65892, upload-time = "2026-09-07T16:06:25.187Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/6ffba5d8cd5dd9b8a19478875c50e04945314ba5074e84d749283f27f62d/mcp_types-2.2.0-py3-none-any.whl", hash = "sha256:ea476b73ee86709ab5abc9452385ed36cc05907e582355622e294595c9a04f13", size = 69106, upload-time = "2026-09-07T16:06:21.461Z" },
 ]
 
 [[package]]
@@ -289,6 +499,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
+]
+
+[[package]]
+name = "openai"
+version = "3.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/31/cacdcba6fb96dae7df9b24573b73904464561e17a77b78c5a4e330a6da89/openai-3.11.0.tar.gz", hash = "sha256:1ee0114c218bba9ffdea1927b974b4ddeee5f173000b0930aab53efc7c349989", size = 1487330, upload-time = "2026-09-09T15:32:16.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/c4/d23c3f86e280e09a001dc9ad7330e882531baca2e598e42b0d7d1eb693c4/openai-3.11.0-py3-none-any.whl", hash = "sha256:2fc169442feafd535f4959605b42d47bc922216385a6d2473b0d47956691d9fd", size = 1749391, upload-time = "2026-09-09T15:32:14.854Z" },
+]
+
+[[package]]
+name = "openai-agents"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mcp" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/a4/b9996e8044b53eab2d78f1ebb37e77f74dea316b3d9a53fdeab3e1c83314/openai_agents-0.22.2.tar.gz", hash = "sha256:12e22d8e8468c097856d664ca82fe8a0298c3c666cfdcf2a6e03c950df93b45b", size = 6552876, upload-time = "2026-09-09T12:37:25.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/77/ee12f3de6449f3cd50cba76fb9ddee1d5992e608e3b8739106371334ab04/openai_agents-0.22.2-py3-none-any.whl", hash = "sha256:685ae918878be4cf52b62d9c732a6d7b8fae7b634268945a20e1a6d2107bd31e", size = 1144460, upload-time = "2026-09-09T12:37:23.612Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -349,6 +606,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-ai-slim"
+version = "2.42.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "genai-prices" },
+    { name = "griffelib" },
+    { name = "httpx2" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pydantic-graph" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/ec/59161f7aa44251775afec888615b84905634252b7dac6f0acf2f430ffadf/pydantic_ai_slim-2.42.0.tar.gz", hash = "sha256:045c788b1636e0ed79542f2b7562d2688a3e3701744ed7379a928fceec446336", size = 1453904, upload-time = "2026-09-09T03:48:51.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/d5/5f9489b6d8583366c32c76671f4d5c3a91cf7e0e0a7073269d9fee756f28/pydantic_ai_slim-2.42.0-py3-none-any.whl", hash = "sha256:a042b73551470c40a2ab7cd532e26c20f592b5731ae544ff3eecbcdf6ceebcc4", size = 1714452, upload-time = "2026-09-09T03:48:43.81Z" },
+]
+
+[[package]]
 name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
@@ -405,17 +681,18 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
+name = "pydantic-graph"
+version = "2.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
+    { name = "logfire-api" },
     { name = "pydantic" },
-    { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/f14d82d10c7f4e4e4d20c880593745e05686b176ac397fe52a5ec40959a9/pydantic_graph-2.42.0.tar.gz", hash = "sha256:eb6c416dee9e3415195194c44ca3abeeae8853bff095d38ac798c7c3395f815d", size = 45189, upload-time = "2026-09-09T03:48:53.398Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c7/eafabe22e04e4e8dfb8e01725e051feed75d3cda937054a727cffc525497/pydantic_graph-2.42.0-py3-none-any.whl", hash = "sha256:25c47047ac1bbad2fdc6dace23958c6ec700a6366abc18d67dccd41411185df7", size = 52700, upload-time = "2026-09-09T03:48:46.931Z" },
 ]
 
 [[package]]
@@ -470,15 +747,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
@@ -514,6 +782,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -612,6 +895,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -648,8 +940,22 @@ dependencies = [
     { name = "temporalio" },
 ]
 
+[package.optional-dependencies]
+integrations = [
+    { name = "openai-agents" },
+    { name = "pydantic-ai-slim" },
+]
+openai-agents = [
+    { name = "openai-agents" },
+]
+pydantic-ai = [
+    { name = "pydantic-ai-slim" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "openai-agents" },
+    { name = "pydantic-ai-slim" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -657,14 +963,21 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.0.0" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=2.1.1,<3" },
     { name = "nexus-rpc", specifier = ">=1.1.0" },
+    { name = "openai-agents", marker = "extra == 'integrations'", specifier = ">=0.22.0" },
+    { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.22.0" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic-ai-slim", marker = "extra == 'integrations'", specifier = ">=2.13" },
+    { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=2.13" },
     { name = "temporalio", specifier = ">=1.15.0" },
 ]
+provides-extras = ["openai-agents", "pydantic-ai", "integrations"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "openai-agents", specifier = ">=0.22.0" },
+    { name = "pydantic-ai-slim", specifier = ">=2.13" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=1.0" },
 ]
@@ -686,6 +999,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/71/a13f427089b54de4e11f347b2043934d693baffda569c4b4914e588a6074/temporalio-1.29.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd02a107c3f5fa088ed5e4aeda9af91d11afbc53dfd5b28d730776354b159297", size = 14602055, upload-time = "2026-06-17T21:18:08.704Z" },
     { url = "https://files.pythonhosted.org/packages/73/6a/3ee32775c9b5172560add2ec69c554f476bc6c51ea7a3c24206e03f08cc5/temporalio-1.29.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:950b42e05793762eb7b4b3809e78c9e9dcdf2f23f797aa939ac17eca8ad9b3d3", size = 15075878, upload-time = "2026-06-17T21:18:11.499Z" },
     { url = "https://files.pythonhosted.org/packages/f5/92/24ef16052075a08e7ed071311704a244944485bc8581d82313f0c3d1b385/temporalio-1.29.0-cp310-abi3-win_amd64.whl", hash = "sha256:8969718f947c6b9df3b51ab4a71bad67abfce81a1023aa1a598a224b712b713a", size = 15333733, upload-time = "2026-06-17T21:18:14.201Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]
@@ -719,6 +1041,15 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
@@ -729,4 +1060,64 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/f7/bc3a25c5ec26ce62ce487690becc2f3710bbc7b33338f005ad390db0b986/websockets-16.1.1.tar.gz", hash = "sha256:db234eda965dcce15df96bb9709f587cd87d4d52aaf0e80e2f34ec04c7670c57", size = 182204, upload-time = "2026-07-17T22:51:05.858Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/fd/6ec6c6d2850aea25b1b2aa9901a016980bb87d01e89b3eb00470b1b5d471/websockets-16.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ab59169ace05dcb49a1d4118f0bde139557adf45091bd85747e36bf5de984dd1", size = 179587, upload-time = "2026-07-17T22:49:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d8/1d299d2dd34087db39831a34cc645ef8a6f89d78efada6983093513cd81c/websockets-16.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5e3b7d601f6f84156b08cc4a5e541c2b50ad7b36cfc302b657a12477c904a5df", size = 177272, upload-time = "2026-07-17T22:49:40.293Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/86/0a70d3ae2f0f2256bb41302d9804dbca65d4360281e7feb3e1f94102ac46/websockets-16.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cd2ca96a082a36964aca83e992f72abeb61b7306c1a6cba4c7d06a7b93750cac", size = 177530, upload-time = "2026-07-17T22:49:41.786Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c2/c676c69444d9db448b3f0a55a98dcc534affce0bce961d9d2f0b8499b10a/websockets-16.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f5d497865f05bb222cab7016c6034542e84e5f29f49c6fd3f4939cda7197b5b8", size = 187197, upload-time = "2026-07-17T22:49:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/13/88137fbaf726ebe29d62c1117fa11fa2bbb6209dc79d4ad738efbe36a2aa/websockets-16.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bae954c382e013d5ea5b190d2830526bfa45ad121c326da0049b8c769f185db6", size = 188433, upload-time = "2026-07-17T22:49:45.147Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/46c2f2ce6751cb26f39293e1ecbf8544cb01321397cd476c2756b98c216d/websockets-16.1.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e09f753a169951eb4f28c2c774f71069304f66e7277e0f5a2892423599cfa854", size = 189868, upload-time = "2026-07-17T22:49:46.581Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2b/170a9e8097636cfde4dc3c592b6e00b18a44a2f5407606d96ca542dd5838/websockets-16.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:024193f8551a2b0eafbdd160911012c4e6c228c28430c84433253299a9e42d6a", size = 189059, upload-time = "2026-07-17T22:49:47.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/48/f0d4ebc9ab4b473b8861b9e20fdb663d515d42f7befdf62cdb60fee7a1ec/websockets-16.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:aabe464bfd13bd25f4821faf111da6fefdc389f870265a53105580e45b0a2e49", size = 187814, upload-time = "2026-07-17T22:49:49.344Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ba/39a41d3ae8e72696a9492581900611c5a91e2b07563b0bcd2523adea9854/websockets-16.1.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a28fcbc9b6baf54a2e23f8655f308e4ccc6afdd7266f8fe7954f320dcda0f785", size = 185229, upload-time = "2026-07-17T22:49:50.787Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/ac15b604f850d1907f0a85ed721cefe47cd45034b3620069b829746cccbe/websockets-16.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:79eace538c6a97e96d0d03d4f9d314f9677f5ed85a8a984992ffd90b13cb8a56", size = 187874, upload-time = "2026-07-17T22:49:52.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/3fbd5d71d59299c3770faa5884d4f45070236ca5a35ab3a61830812c409a/websockets-16.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:496af849a472b531f758dbd4d61338f5000538cb1a7b3d20d9d32a264517f509", size = 186469, upload-time = "2026-07-17T22:49:53.776Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/fc/dd90349bba58af2a53ef2ddd9c32716c81eb6d59a0687939fff561860878/websockets-16.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5283810d2646741a0d8da2aa733d6aefa0545809afccb2a5d105a26bc45125f1", size = 188347, upload-time = "2026-07-17T22:49:55.202Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f3/f73ba86427682da59b78c11d77ba56d5b801c32e84afe79b274bbd6a9bb2/websockets-16.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4e3b680b1e0a27457e727a0d572fd81dffa87b6dbf8b228ab57da64f7d85aead", size = 185903, upload-time = "2026-07-17T22:49:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7c/f95eb20e80104173b3a0a092291f89ea4047ef6e608e0a57ca06eb14eecb/websockets-16.1.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:69159730a823dde3ea8d08783e8d47ef135a6d7e8d44eb127e32b321c9db8e3e", size = 186855, upload-time = "2026-07-17T22:49:58.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/35/dd875b3e050ff232d60fa377707f890e369f74d134f1be32e8f68879747c/websockets-16.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ed5bb271084b46530ee2ddc0410537a9961152c5ccba2fc98c5276d992ccba87", size = 187140, upload-time = "2026-07-17T22:50:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/dc/5cbfcb41824502f6af93b8f3943a4d06c67c23c7d2e31eb18748c4a5b2a7/websockets-16.1.1-cp313-cp313-win32.whl", hash = "sha256:cfb70b4eb56cac4da0a83588f3ad50d46beb0690391082f3d4e2d488c70b68ea", size = 179928, upload-time = "2026-07-17T22:50:01.685Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c1/71e5deb5b7f8f226997ab64908c184ac3105c0155ce2d486f318e5dd08a8/websockets-16.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:d9531d9cbeac99af6f038fb1bc351403531f7d634a2c2e10e2f7c854c6ed5b68", size = 180242, upload-time = "2026-07-17T22:50:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a2/ba78a164eeea4620df4a4df4bd2ed6017438c4655cc0f36f2c0bc0432355/websockets-16.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:443aefe96b7fdb132e2a70806cca1f2af49bb3f28e47abcd7c2e9dcf4d8fa1b8", size = 179635, upload-time = "2026-07-17T22:50:05.001Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/08/d26d7a7628cd4ac34cbbdb63ac80914ca842ed8e42938c40a53567806df3/websockets-16.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6456ff333092d509127d75a638cb411afae8ff17f092635015d1902efec8a293", size = 177320, upload-time = "2026-07-17T22:50:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/45/ebec83e6269536aa5932533c67b0af5c781f3e73fdbcd68672dcf43f4f44/websockets-16.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fce6c48559c86d1ac3632ccb1bebc7d5442fbe79bd9bb0e40379ee54be2a4051", size = 177544, upload-time = "2026-07-17T22:50:07.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d5/abc614d2297f6c1c3e01e61260364457a47c25cc1cf6a879038902bc6aa8/websockets-16.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:92b820d345f7a3fc7b8163949ee92df910f290c3fc517b3d5301c78065adafe1", size = 187270, upload-time = "2026-07-17T22:50:09.275Z" },
+    { url = "https://files.pythonhosted.org/packages/52/71/4c99af3b87dff1b2927981f6876607d4acb45338c665242168d3982f7758/websockets-16.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a606d9c24035242a3e256e9d5b77ed9cd6bccfcb7cf993e5ca3c0f6f68fb6a7", size = 188509, upload-time = "2026-07-17T22:50:10.722Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5c8ca14b0df7eb84ed0524165c5359150210140817a3312aee57bf62a1cf/websockets-16.1.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:414e596c75f74e0994084694189d7dc9229fb278e33064d6784b73ffbba3ca31", size = 189882, upload-time = "2026-07-17T22:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c1/bedfba9e70557129cb8083748d167bdcc01483dedf0f0df143676df05cbe/websockets-16.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:536676848fc5961aca9d20389951f59169508f765637a172403dc5434d722fa0", size = 189114, upload-time = "2026-07-17T22:50:13.789Z" },
+    { url = "https://files.pythonhosted.org/packages/df/09/aa835b2787835aebd839114be5de51b797cb480b63ba42b26d34dfe147cb/websockets-16.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:97fd3a0e8b53efa41970ac1dff3d8cf0d2884cadeb4caaf95db7ad1526926ee3", size = 187861, upload-time = "2026-07-17T22:50:15.179Z" },
+    { url = "https://files.pythonhosted.org/packages/20/26/f6408330694dbc9830857d9d23bc14ac4f6875127a480cfdda8d5ca21198/websockets-16.1.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7b1b19636af86a3c7995d4d028dbe376f39b4bf31541146f9c123582a6c94562", size = 185286, upload-time = "2026-07-17T22:50:16.741Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9a/e0675e70dd8a80762cf35bb18799d3f290a4890ffe6439bc51d222796083/websockets-16.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:41c8e77f17294c0ac18008a7309b99b34ee72247ef10b6dff4c3f8b5ac29896b", size = 187935, upload-time = "2026-07-17T22:50:18.213Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c1/3234cfb86afde01b81e9bddcc6e534c440975d60a13991259e833069ab3e/websockets-16.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:9f63bcef7f4b02b06b35fc01c93b96c43b5e88e1e8868676caacf493d5a31f3a", size = 186444, upload-time = "2026-07-17T22:50:19.67Z" },
+    { url = "https://files.pythonhosted.org/packages/89/87/9c15206e1d778923d8daa9657de07aa62ea815e13448319c98458c37b281/websockets-16.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dab9eb87869da2d6ed3af3f3adf28414baae6ec9d4df355ffc18889132f3436c", size = 188409, upload-time = "2026-07-17T22:50:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/cf5de5c67676de2d3eef8b2a518f168f6796595447a5b7161ba0d012915c/websockets-16.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:43e3a9fdd7cbf7ba6040c31fae0faf84ca1474fef777c4e37912f1540f854499", size = 185958, upload-time = "2026-07-17T22:50:22.719Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c0/731b6ddede2e4136912ec4cff2cffbda35af73546be4762c3d7bd3bd79af/websockets-16.1.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:056ae37939ed7e9974f364f5864e76e49182622d8f9751ac1903c0d09b013985", size = 186911, upload-time = "2026-07-17T22:50:24.108Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/7f/39c634472c4469a24a7c09cecddffb08fac6d0e74f73881a94ee8a40a196/websockets-16.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a0eadbbf2c30f01efa58e1f110eb6fa293261f6b0b1aa38f7f48707107690af9", size = 187204, upload-time = "2026-07-17T22:50:25.548Z" },
+    { url = "https://files.pythonhosted.org/packages/26/89/9667c256c256dafcc62d21328ce7a40067da857969b68ee9af375b0aaf72/websockets-16.1.1-cp314-cp314-win32.whl", hash = "sha256:195c978b065fa40910582464f99d6b15c8b314c68e0546549a55ed83f4735328", size = 179603, upload-time = "2026-07-17T22:50:27.086Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/dd/1c099d6c0fc5deb6b46ccdbb6981fdb4b12c917869cb3952408409dc18db/websockets-16.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:4e8d01cc3bcae7bbf8167f944aeafefed590fae5693552bba9794a9df68371cc", size = 179948, upload-time = "2026-07-17T22:50:28.521Z" },
+    { url = "https://files.pythonhosted.org/packages/35/25/9956b2d5e0529d5d23924f21bba1440d4c5c88a562e4f08550871ffa97a7/websockets-16.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0ffd3031ea8bda8d61762e84220186105ba3b748b3c8da2ae4f7816fac03e573", size = 179963, upload-time = "2026-07-17T22:50:29.982Z" },
+    { url = "https://files.pythonhosted.org/packages/17/06/55ffc976c488b6aee9ea05761ff7c4e88e7c1fd82818c8ca7b556ad2f90c/websockets-16.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:84a2cef8deffbd9ab8ee0ea546a2a6a7030c28f44e6cdd4547dbfeb489eb8999", size = 177497, upload-time = "2026-07-17T22:50:31.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/f7dac2e980bacc92bdc26cebae4ae4d50cae5380732c50980598fc0bbae4/websockets-16.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3df13f73af9b3b38ab1195eb299ecb67a4330c911c97ae04043ff74085728abe", size = 177698, upload-time = "2026-07-17T22:50:32.829Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/39/26762f734113e22da2b942c3aca85798e0c0405d64c256549540ff31e5a1/websockets-16.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:23253dd5bcae3f9aaee0a1d30967a8dbd52e5d3cff93a2e5b84df57b77d4750d", size = 187561, upload-time = "2026-07-17T22:50:34.24Z" },
+    { url = "https://files.pythonhosted.org/packages/11/94/c3f330851806b9b02138b774d593478323e73c99238681b4b93efe64e02d/websockets-16.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c1c5705e314449e3308872fe084b8571ce078ee4fc55a98a769bdefe5917392", size = 188732, upload-time = "2026-07-17T22:50:36.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f2/eb2c450f052de334ae33cf200ece6e87b0e14d186807074e4eb1cd2cdea2/websockets-16.1.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:69e52d175a0a7d1e13b4b67ad41c560b7d98e8c6f6126eb0bda496c784faf8c7", size = 190872, upload-time = "2026-07-17T22:50:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/70/31/2ac8cecf3a74f7fed9132129fc3d90b3998a1554570c11a69b2a8c20332d/websockets-16.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1f79c89b5eb034d1722938a891916582f8f7f503f58ca22518a63c3f2cd18499", size = 189305, upload-time = "2026-07-17T22:50:39.53Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/cf/8ab19650d3c0d4562c92e70ab47c257c4aa5c6a713ed87fe63766b31fefc/websockets-16.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39f2a024af5c345ffe8fcf1ee18c049c024c94df393bb09b044a6917c77bde43", size = 188033, upload-time = "2026-07-17T22:50:40.912Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d7/a49a38a6127a4acb134fb1912b215d900cc657605cff32445bf519f3acc4/websockets-16.1.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:952303a7318d4cbe1011400839bb2051c9f84fa0a35923267f5daba34b15d458", size = 185748, upload-time = "2026-07-17T22:50:42.559Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3e/ad1fa40388c7f2e0bb2c7930d0090b6c5498594bd1cdaec18864df3d9e97/websockets-16.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:249116b4a76063d930a46391ad56e135c286e4562a18309029fc2c73f4ed4c62", size = 188285, upload-time = "2026-07-17T22:50:43.974Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b8/d5db28ca264b9104f82196f92dc8843e35fd391f763d42e4ad358f5bc97e/websockets-16.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:61922544a0587a13fd3f53e4c0e5e606510c7b0d9d22c8444e5fae22a06b38cb", size = 186777, upload-time = "2026-07-17T22:50:45.474Z" },
+    { url = "https://files.pythonhosted.org/packages/42/9c/726cb39d0cc43ae848dce4aa2acb04eecc6738b1264ec6d700bf6bcfb9f8/websockets-16.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:46dcaa042cd1de6c59e7d9269fa63ff7572b6df40510600b678f0826b3c7af51", size = 188682, upload-time = "2026-07-17T22:50:46.973Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c7/1168704de8c2dd483edabe4a22cbe4465dd8be8dd95561d214f9fe092871/websockets-16.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:38565aca3e01ea8734e578fb2118dade0ecb0250533f29e22b8d1a7a196cf4d0", size = 186377, upload-time = "2026-07-17T22:50:48.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/40/f9ff2d630ffce4e7dfea0b2288e1caf9ebbf9ff8a9ec9396136ce8b94935/websockets-16.1.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:42f599f4d48c7e1a3338fdaac3acd075be3b3cf02d4b274f3bf2767aedd3d217", size = 187148, upload-time = "2026-07-17T22:50:49.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/e177c8299f78d7cbe2d14df228643c10c70c0e86e108e092056bbcc16e46/websockets-16.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dcc04fedf83effaeb9cce98abc9469bb1b42ef85f03e01c8c1f4438ef7555737", size = 187578, upload-time = "2026-07-17T22:50:51.619Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/b6987faf330f5af5c787a2610124c2e8403d51724f9001ec4fff6311fe7a/websockets-16.1.1-cp314-cp314t-win32.whl", hash = "sha256:8483c2096363120eea8b07c06ae7304d520f686665fffd4811fad423930a65d7", size = 179729, upload-time = "2026-07-17T22:50:53.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6e/fbac6ed878dd362fbad7d415fa4f84d38e3e33fed8cde45c64e783acf826/websockets-16.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bcce07e23e5769375158f5efdcdafa8d5cd014b93c6683865b840ed65b96f231", size = 180072, upload-time = "2026-07-17T22:50:54.969Z" },
+    { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
 ]

--- a/temporal_agent_harness/ai_sdks/openai_agents/_nexus_mcp.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_nexus_mcp.py
@@ -1,8 +1,7 @@
-"""OpenAI Agents MCP server adapters backed by Nexus."""
+"""Expose Durable Tools Gateway tools to the OpenAI Agents SDK."""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from agents.mcp import MCPServer
@@ -28,10 +27,7 @@ try:
             ListAgentEntriesInput,
             RegistryService,
         )
-        from nexus_mcp.execution import WorkflowNexusExecutor
         from nexus_mcp.resolver import (
-            NexusToolResolver,
-            UnknownToolError,
             coerce_call_tool_result,
         )
 except ModuleNotFoundError as exc:
@@ -73,40 +69,6 @@ class _BaseNexusMCPServer(MCPServer):  # type: ignore[misc]
         self, name: str, arguments: dict[str, Any] | None = None
     ) -> GetPromptResult:
         raise NotImplementedError(f"MCP server {self.name!r} does not support prompts.")
-
-
-class _NexusNativeMCPServer(_BaseNexusMCPServer):
-    """Expose native Nexus tools through the OpenAI Agents MCP interface."""
-
-    def __init__(
-        self,
-        registered_servers: Mapping[str, str],
-        name: str | None = None,
-        allowed_servers: frozenset[str] | None = None,
-        **kwargs: Any,
-    ) -> None:
-        MCPServer.__init__(self, **kwargs)
-        self._resolver = NexusToolResolver(
-            registered_servers,
-            WorkflowNexusExecutor(),
-            name=name or "nexus-native",
-            allowed_servers=allowed_servers,
-        )
-
-    @property
-    def name(self) -> str:
-        return self._resolver.name
-
-    async def list_tools(self, run_context: Any = None, agent: Any = None) -> list[MCPTool]:
-        return await self._resolver.list_tools()
-
-    async def call_tool(
-        self, tool_name: str, arguments: dict[str, Any] | None, meta: dict[str, Any] | None = None
-    ) -> CallToolResult:
-        try:
-            return await self._resolver.call_tool(tool_name, arguments)
-        except UnknownToolError as exc:
-            return _error_result(exc)
 
 
 class NexusGateway:

--- a/temporal_agent_harness/ai_sdks/openai_agents/_openai_runner.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/_openai_runner.py
@@ -136,8 +136,12 @@ class TemporalOpenAIRunner(AgentRunner):
             )
             from temporal_agent_harness.ai_sdks.openai_agents._nexus_mcp import (
                 _NexusGatewayMCPServer,
-                _NexusNativeMCPServer,
             )
+
+            with workflow.unsafe.imports_passed_through():
+                from nexus_mcp.integrations.openai_agents import (
+                    WorkflowNexusMCPServer,
+                )
 
             for s in starting_agent.mcp_servers:
                 if not isinstance(
@@ -145,7 +149,7 @@ class TemporalOpenAIRunner(AgentRunner):
                     (
                         _StatelessMCPServerReference,
                         _StatefulMCPServerReference,
-                        _NexusNativeMCPServer,
+                        WorkflowNexusMCPServer,
                         _NexusGatewayMCPServer,
                     ),
                 ):

--- a/temporal_agent_harness/ai_sdks/openai_agents/workflow.py
+++ b/temporal_agent_harness/ai_sdks/openai_agents/workflow.py
@@ -4,7 +4,7 @@ import functools
 import inspect
 import json
 import typing
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from datetime import timedelta
 from typing import Any
@@ -370,11 +370,10 @@ def nexus_native_mcp_server(
             nexus_native_mcp_server("demo-nexus", "nexus-hello-demo-endpoint"),
         ])
     """
-    from temporal_agent_harness.ai_sdks.openai_agents._nexus_mcp import (
-        _NexusNativeMCPServer,
-    )
+    with temporal_workflow.unsafe.imports_passed_through():
+        from nexus_mcp.integrations.openai_agents import WorkflowNexusMCPServer
 
-    return _NexusNativeMCPServer({name: endpoint}, name=name, **kwargs)
+    return WorkflowNexusMCPServer.for_service(name, endpoint, **kwargs)
 
 
 def nexus_tools_gateway(

--- a/tests/nexus_mcp/test_ai_sdk_integrations.py
+++ b/tests/nexus_mcp/test_ai_sdk_integrations.py
@@ -1,0 +1,206 @@
+"""Test the in-process AI SDK integrations."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from agents import Agent as OpenAIAgent
+from agents import Runner
+from mcp import types
+from nexus_mcp.integrations.openai_agents import (
+    WorkflowNexusMCPServer,
+    _ResolverBackedMCPServer,
+)
+from nexus_mcp.integrations.pydantic_ai import ResolverBackedToolset
+from nexus_mcp.resolver import NexusToolResolver, RequestContext
+from pydantic_ai import Agent as PydanticAIAgent
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.models.test import TestModel as PydanticAITestModel
+
+from temporal_agent_harness.ai_sdks.openai_agents.testing import (
+    ResponseBuilders,
+    TestModel,
+)
+from temporal_agent_harness.ai_sdks.openai_agents.workflow import (
+    nexus_native_mcp_server,
+)
+
+
+class _Executor:
+    def __init__(self, result: Any = None) -> None:
+        self.contexts: list[RequestContext] = []
+        self.result = result if result is not None else {"answer": 42}
+
+    async def execute(self, **kwargs: Any) -> Any:
+        self.contexts.append(kwargs["context"])
+        if kwargs["operation"] == "list_tools":
+            return {
+                "tools": [
+                    {
+                        "name": "weather_forecast",
+                        "description": "Get a forecast.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                        "outputSchema": {
+                            "type": "object",
+                            "properties": {"answer": {"type": "integer"}},
+                        },
+                        "annotations": {"readOnlyHint": True},
+                        "_meta": {"source": "test"},
+                    }
+                ],
+                "routes": {"weather_forecast": "forecast"},
+            }
+        return self.result
+
+
+def _resolver(executor: _Executor) -> NexusToolResolver:
+    return NexusToolResolver(
+        {"weather": "weather-endpoint"},
+        executor,
+        name="weather",
+    )
+
+
+async def test_openai_adapter_lists_and_calls_tools() -> None:
+    executor = _Executor()
+    server = _ResolverBackedMCPServer(_resolver(executor))
+
+    tools = await server.list_tools()
+    result = await server.call_tool(
+        "weather_forecast",
+        {"city": "Boston"},
+        meta={"io.temporal/idempotencyKey": "forecast-1"},
+    )
+
+    assert [tool.name for tool in tools] == ["weather_forecast"]
+    assert result.structured_content == {"answer": 42}
+    assert executor.contexts[-1].idempotency_key == "forecast-1"
+
+
+async def test_openai_adapter_returns_an_unknown_tool_error() -> None:
+    server = _ResolverBackedMCPServer(_resolver(_Executor()))
+
+    result = await server.call_tool("missing", {})
+
+    assert result.is_error is True
+    assert result.content[0].text == "Tool 'missing' is not registered."
+
+
+def test_workflow_openai_adapter_has_a_distinct_type() -> None:
+    server = WorkflowNexusMCPServer.for_service("weather", "weather-endpoint")
+
+    assert isinstance(server, _ResolverBackedMCPServer)
+    assert server.name == "weather"
+
+
+def test_agent_harness_factory_uses_the_shared_workflow_adapter() -> None:
+    server = nexus_native_mcp_server("weather", "weather-endpoint")
+
+    assert isinstance(server, WorkflowNexusMCPServer)
+
+
+async def test_openai_agent_uses_the_server_in_process() -> None:
+    server = _ResolverBackedMCPServer(_resolver(_Executor()))
+    model = TestModel.returning_responses(
+        [
+            ResponseBuilders.tool_call(
+                '{"city":"Boston"}',
+                "weather_forecast",
+            ),
+            ResponseBuilders.output_message("42"),
+        ]
+    )
+    agent = OpenAIAgent(
+        name="weather-agent",
+        model=model,
+        mcp_servers=[server],
+    )
+
+    result = await Runner.run(agent, "Get the forecast.")
+
+    assert result.final_output == "42"
+
+
+async def test_pydantic_ai_toolset_lists_and_calls_tools() -> None:
+    executor = _Executor()
+    toolset = ResolverBackedToolset(_resolver(executor), include_return_schema=True)
+    ctx = MagicMock(max_retries=3)
+
+    tools = await toolset.get_tools(ctx)
+    tool = tools["weather_forecast"]
+    result = await toolset.call_tool(
+        "weather_forecast",
+        {"city": "Boston"},
+        ctx,
+        tool,
+    )
+
+    assert tool.max_retries == 3
+    assert tool.tool_def.parameters_json_schema["required"] == ["city"]
+    assert tool.tool_def.return_schema is not None
+    assert tool.tool_def.metadata == {
+        "meta": {"source": "test"},
+        "annotations": {"readOnlyHint": True},
+    }
+    assert result == {"answer": 42}
+
+
+async def test_pydantic_ai_toolset_maps_tool_errors_to_model_retry() -> None:
+    error = types.CallToolResult(
+        content=[types.TextContent(type="text", text="Forecast failed.")],
+        is_error=True,
+    )
+    toolset = ResolverBackedToolset(_resolver(_Executor(error)))
+    ctx = MagicMock(max_retries=1)
+    tool = (await toolset.get_tools(ctx))["weather_forecast"]
+
+    with pytest.raises(ModelRetry, match="Forecast failed"):
+        await toolset.call_tool("weather_forecast", {}, ctx, tool)
+
+
+async def test_pydantic_ai_toolset_accepts_an_async_context_factory() -> None:
+    executor = _Executor()
+
+    async def context_factory(
+        ctx: Any,
+        name: str | None,
+        arguments: dict[str, Any] | None,
+    ) -> RequestContext:
+        if name is None or arguments is None:
+            return RequestContext(nexus_headers={"authorization": "test"})
+        return RequestContext(idempotency_key=f"{name}-{arguments['city']}")
+
+    toolset = ResolverBackedToolset(
+        _resolver(executor),
+        request_context_factory=context_factory,
+    )
+    ctx = MagicMock(max_retries=1)
+    tool = (await toolset.get_tools(ctx))["weather_forecast"]
+
+    await toolset.call_tool(
+        "weather_forecast",
+        {"city": "Boston"},
+        ctx,
+        tool,
+    )
+
+    assert executor.contexts[-1].idempotency_key == "weather_forecast-Boston"
+    assert executor.contexts[0].nexus_headers == {"authorization": "test"}
+
+
+async def test_pydantic_ai_agent_uses_the_toolset_in_process() -> None:
+    toolset = ResolverBackedToolset(_resolver(_Executor()))
+    agent = PydanticAIAgent(
+        PydanticAITestModel(call_tools=["weather_forecast"]),
+        toolsets=[toolset],
+    )
+
+    result = await agent.run("Get the forecast.")
+
+    assert result.output == '{"weather_forecast":{"answer":42}}'

--- a/uv.lock
+++ b/uv.lock
@@ -3071,12 +3071,19 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.0.0" },
     { name = "mcp", specifier = ">=2.1.1,<3" },
     { name = "nexus-rpc", specifier = ">=1.1.0" },
+    { name = "openai-agents", marker = "extra == 'integrations'", specifier = ">=0.22.0" },
+    { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.22.0" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic-ai-slim", marker = "extra == 'integrations'", specifier = ">=2.13" },
+    { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=2.13" },
     { name = "temporalio", specifier = ">=1.15.0" },
 ]
+provides-extras = ["openai-agents", "pydantic-ai", "integrations"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "openai-agents", specifier = ">=0.22.0" },
+    { name = "pydantic-ai-slim", specifier = ">=2.13" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=1.0" },
 ]


### PR DESCRIPTION
## What changed

Tease out the package structure of nexus_mcp a bit more:
* Further teased out the composable pieces (MCP<->Nexus bridge, Nexus service-endpoint resolver, executor for Temporal/non-Temporal caller).
* Added an `integrations/...` dir that shows how to compose MCP-server-shaped-modules to pass directly into AI SDKs that support that (for now added OpenAI and Pydantic AI)
* Separate README.md (for user) and ARCHITECTURE.md (for maintainer)

## Why

Make code easier to read and understand. Keep docs up to date.