### PR TITLE
Return the update-backed result directly in pollMessages

### DIFF
--- a/temporal_agent_harness/nexus_agent_adapter/handler.py
+++ b/temporal_agent_harness/nexus_agent_adapter/handler.py
@@ -14,7 +14,7 @@ from nexusrpc import HandlerError, HandlerErrorType
 from nexusrpc.handler import StartOperationContext, service_handler, sync_operation
 from temporalio import nexus
 from temporalio.client import Client
-from temporalio.contrib.workflow_streams import PollInput, PollResult
+from temporalio.contrib.workflow_streams import PollInput
 from temporalio.service import RPCError
 
 from temporal_agent_harness.harness.agent_client import (
@@ -57,7 +57,6 @@ from .generated import (
     QuerySessionInput,
     SendAgentMessageInput,
     SendMessageOutput,
-    StreamItem,
     SubagentInfo as NexusSubagentInfo,
 )
 from .generated import AgentService as AgentServiceDefinition
@@ -65,7 +64,6 @@ from .generated import AgentService as AgentServiceDefinition
 # WorkflowStream's private poll-update name (not part of its public API), hardcoded since
 # pollMessages must attach to it for any agent without importing that agent's workflow code.
 _WORKFLOW_STREAM_POLL_UPDATE = "__temporal_workflow_stream_poll"
-DEFAULT_POLL_TIMEOUT_SECONDS = 30.0
 _MAX_SEND_RETRIES = 5
 
 
@@ -344,38 +342,28 @@ class AgentServiceHandler:
         input: PollMessagesInput,
     ) -> nexus.TemporalOperationResult[PollMessagesOutput]:
         """Long-polls WorkflowStream via update-with-callback. Returns closed=True
-        synchronously if the target workflow has already completed."""
-        workflow_id = self._workflow_id(input.session_id)
-        timeout_seconds = input.timeout_seconds or DEFAULT_POLL_TIMEOUT_SECONDS
+        synchronously if the target workflow has already completed.
 
+        Note that this bypasses the WorkflowStream abstraction and directly calling the
+        update handler for the stream, since we haven't implemented Nexus + WorkflowStreamh
+        higher-level APIs.
+
+        TODO(long-nt-tran): implement + use higher level utils when available
+        """
         try:
-            result = await client.start_workflow_update(
-                workflow_id,
+            return await client.start_workflow_update(
+                self._workflow_id(input.session_id),
                 _WORKFLOW_STREAM_POLL_UPDATE,
                 PollInput(from_offset=input.cursor, topics=[TURN_EVENTS_TOPIC]),
-                result_type=PollResult,
+                result_type=PollMessagesOutput,
             )
         except RPCError as e:
-            if _is_workflow_already_completed(e):
-                return nexus.TemporalOperationResult.sync(
-                    PollMessagesOutput(
-                        items=[], more_ready=False, next_offset=input.cursor, closed=True
-                    )
+            if not _is_workflow_already_completed(e):
+                raise
+            # In case the workflow (aka the agent) is already closed, we can propagate
+            # this to the caller via the `closed=True` field.
+            return nexus.TemporalOperationResult.sync(
+                PollMessagesOutput(
+                    items=[], more_ready=False, next_offset=input.cursor, closed=True
                 )
-            raise
-
-        if result.token is not None:
-            return nexus.TemporalOperationResult.async_token(result.token)
-
-        poll_result: PollResult = result.value
-        return nexus.TemporalOperationResult.sync(
-            PollMessagesOutput(
-                items=[
-                    StreamItem(topic=item.topic, data=item.data, offset=item.offset)
-                    for item in poll_result.items
-                ],
-                more_ready=poll_result.more_ready,
-                next_offset=poll_result.next_offset,
-                closed=False,
             )
-        )

--- a/tests/nexus_agent_adapter/test_handler_unit.py
+++ b/tests/nexus_agent_adapter/test_handler_unit.py
@@ -4,14 +4,19 @@
 
 from __future__ import annotations
 
+import dataclasses
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from temporalio.contrib.workflow_streams import PollResult
+from temporalio.contrib.workflow_streams._types import _WorkflowStreamWireItem
 from temporalio.converter import DataConverter
 
 from temporal_agent_harness.harness.agent_protocol.agent_interface import CallbackResultAck
 from temporal_agent_harness.nexus_agent_adapter.generated import (
+    PollMessagesOutput,
     ProvideCallbackResultInput,
     ProvideCallbackResultInputResult,
+    StreamItem,
 )
 from temporal_agent_harness.nexus_agent_adapter.handler import (
     AgentServiceHandler,
@@ -87,3 +92,46 @@ def test_is_workflow_already_completed_false_for_unrelated_error() -> None:
     err = MagicMock()
     err.__str__.return_value = "deadline exceeded"
     assert _is_workflow_already_completed(err) is False
+
+
+# ---------------------------------------------------------------------------
+# pollMessages wire-shape mirror
+# ---------------------------------------------------------------------------
+#
+# poll_messages returns the SDK's TemporalOperationResult unchanged, so the poll
+# update's own result IS the operation's result -- decoded here on the sync path, and
+# decoded by the caller when the async callback delivers it. That only works while
+# PollMessagesOutput mirrors WorkflowStream's PollResult field for field. If the IDL
+# drifts, the async path breaks where nothing can catch it: the server delivers that
+# payload directly and the handler never runs. These tests fail first instead.
+
+
+def test_poll_result_decodes_as_poll_messages_output() -> None:
+    poll_result = PollResult(
+        items=[_WorkflowStreamWireItem(topic="turn_events", data="cGF5", offset=7)],
+        next_offset=8,
+        more_ready=True,
+    )
+
+    decoded = _round_trip(poll_result, PollMessagesOutput)
+
+    assert isinstance(decoded, PollMessagesOutput)
+    assert decoded.next_offset == 8
+    assert decoded.more_ready is True
+    assert [(i.topic, i.data, i.offset) for i in decoded.items] == [
+        ("turn_events", "cGF5", 7)
+    ]
+    # Absent on the wire: only the already-completed sync path sets it.
+    assert decoded.closed is None
+
+
+def test_poll_result_and_poll_messages_output_have_the_same_wire_fields() -> None:
+    # The mirror stated as a field-set equality, so an added PollResult field is caught
+    # even if no test happens to carry a value for it.
+    poll_result_fields = {f.name for f in dataclasses.fields(PollResult)}
+    output_fields = {f.name for f in dataclasses.fields(PollMessagesOutput)}
+
+    assert poll_result_fields == output_fields - {"closed"}
+    assert {f.name for f in dataclasses.fields(_WorkflowStreamWireItem)} == {
+        f.name for f in dataclasses.fields(StreamItem)
+    }


### PR DESCRIPTION
## What changed

No need to manually unpack the token for sync / async case. This is automatically done by SDK.

## Why

Less manual code.