### PR TITLE
Package the harness as a single Temporal plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,10 +29,3 @@ GEMINI_API_KEY=
 # Required by the OpenAI Agents example (examples/openai_hello) — its model activities call the
 # OpenAI API. Leave blank if you're only running the Gemini-backed examples.
 OPENAI_API_KEY=
-
-# --- Large-payload offload --------------------------------------------------------------------
-# Some payloads (e.g. Monty sandbox snapshots) can exceed Temporal's ~2 MB limit, so they're
-# offloaded to external storage. "local" (filesystem) is fine for single-host local dev; use "s3"
-# for multi-host deploys (then set LARGE_PAYLOAD_S3_BUCKET — see
-# temporal_agent_harness/utils/large_payload.py).
-LARGE_PAYLOAD_DRIVER=local

--- a/README.md
+++ b/README.md
@@ -90,10 +90,9 @@ want the built-in session manager and UI use `temporal_agent_harness.web`:
 
 ```python
 from temporalio.client import Client
-from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.envconfig import ClientConfig
 
-from temporal_agent_harness.utils.large_payload import with_large_payload_offload
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 from temporal_agent_harness.web import (
     create_agent_harness_app,
     create_session_manager_worker,
@@ -102,10 +101,7 @@ from temporal_agent_harness.web import (
 
 async def run_session_manager() -> None:
     connect_config = ClientConfig.load_client_connect_config()
-    client = await Client.connect(
-        **connect_config,
-        data_converter=await with_large_payload_offload(pydantic_data_converter),
-    )
+    client = await Client.connect(**connect_config, plugins=[AgentHarnessPlugin()])
     worker = create_session_manager_worker(client)
     await worker.run()
 
@@ -294,6 +290,40 @@ class TravelAgent:
         ...
 ```
 
+## Running a worker — one plugin
+
+An agent is a Temporal workflow, so it runs on a Temporal worker. `AgentHarnessPlugin` is the
+single registration that wires that worker (and its client) for the harness — you never
+assemble the harness's activity list or its data converter by hand:
+
+```python
+from temporalio.client import Client
+from temporalio.envconfig import ClientConfig
+from temporalio.worker import Worker
+
+from temporal_agent_harness.plugin import AgentHarnessPlugin
+
+client = await Client.connect(
+    **ClientConfig.load_client_connect_config(),
+    # Your AI SDK's plugin first, the harness plugin last.
+    plugins=[OpenAIAgentsPlugin(model_params=...), AgentHarnessPlugin(tools=MY_TOOLS)],
+)
+
+worker = Worker(client, task_queue="my-agent", workflows=[TravelAgent])
+await worker.run()
+```
+
+The worker declares only its workflows. Adding the plugin brings:
+
+- the harness's **data converter** (Pydantic + large-payload offload) — add the plugin to every
+  client, worker, and server in the deployment so they all agree on it;
+- the durable **activity body** of each `@agent.activity_tool_defn` tool in `tools=` (pass your
+  whole toolset — tools with no worker-side body are skipped);
+- the **subagent** and **Code Mode** activities.
+
+Order it last, after any AI SDK's plugin, so that SDK's payload converter wins. Registering it
+on the client is enough — Temporal applies a client's plugins to workers built from it.
+
 ## Code Mode
 
 Most agents call tools one at a time — a round-trip per call. **Code Mode** hands the model a
@@ -337,19 +367,15 @@ run_code = agent.code_mode_tool(
 - **Several per agent.** Give one agent multiple `code_mode_tool`s (distinct `name`s) over
   disjoint or overlapping tool sets.
 
-A worker that hosts a Code Mode agent registers the two sandbox-stepping activities (this needs
-the `code-mode` extra, which pulls in [`pydantic-monty`](https://pypi.org/project/pydantic-monty/),
-the sandbox scripts run in) alongside the durable bodies of any activity-backed host tools:
+A worker that hosts a Code Mode agent needs the two sandbox-stepping activities and the durable
+bodies of any activity-backed host tools. Both come from
+[`AgentHarnessPlugin`](#running-a-worker--one-plugin) — the stepping activities as soon as the
+`code-mode` extra (which pulls in [`pydantic-monty`](https://pypi.org/project/pydantic-monty/),
+the sandbox the scripts run in) is installed:
 
 ```python
-from temporal_agent_harness.harness.code_mode.activities import CODE_MODE_ACTIVITIES
-
-worker = Worker(
-    client,
-    task_queue=...,
-    workflows=[MyAgent],
-    activities=[*CODE_MODE_ACTIVITIES, *(agent.tool_activity(t) for t in my_activity_tools)],
-)
+client = await Client.connect(..., plugins=[AgentHarnessPlugin(tools=my_tools)])
+worker = Worker(client, task_queue=..., workflows=[MyAgent])
 ```
 
 See [`examples/monty`](examples/monty) for three agents all built on Code Mode: a no-model script

--- a/docs/internal/agents-as-subagents.md
+++ b/docs/internal/agents-as-subagents.md
@@ -374,6 +374,13 @@ already landed in A).
 > `agent_client.py` split into `_submit_message` / `_stream_turn` (both reused by the activity).
 > The only deferred piece is closing the residual double-submit window — that's Workstream B.
 
+> **Follow-up shipped (2026-09-10).** The "future harness worker plugin" the locked shape below
+> defers is now `temporal_agent_harness.plugin.AgentHarnessPlugin`: it instantiates
+> `SubagentActivities` from the worker's own client and registers `run_subagent_turn`, so the
+> manual wiring described below is no longer what agents write. (Binding to the worker's client
+> is precisely why the plugin overrides `configure_worker` rather than passing an `activities`
+> callable to `SimplePlugin` — that hook never sees the worker config.)
+
 > **Locked shape (2026-06-15).** The activity is a method of a small **class that closes
 > over a Temporal `Client`** (`SubagentActivities(client).run_subagent_turn`), NOT a
 > module-level `_TEMPORAL_CLIENT` global. The worker registers the **bound method** as the

--- a/examples/callback_tools/coding_agent/worker.py
+++ b/examples/callback_tools/coding_agent/worker.py
@@ -26,12 +26,11 @@ import sys
 
 from google.genai import Client as GeminiClient
 from temporalio.client import Client
-from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 from temporal_agent_harness.ai_sdks.google_genai_plugin import GoogleGenAIPlugin
-from temporal_agent_harness.utils.large_payload import with_large_payload_offload
 
 from .workflow import TASK_QUEUE, CodingAgentWorkflow
 
@@ -52,22 +51,21 @@ async def main() -> None:
         sys.exit("error: GEMINI_API_KEY env var not set")
     plugin = GoogleGenAIPlugin(GeminiClient(api_key=api_key))
 
-    # Match the session-manager worker + server converter (large-payload offload) so every
-    # process reads the same payloads.
+    # AgentHarnessPlugin last: it leaves the Gemini plugin's payload converter in place and
+    # adds the harness's large-payload offload, so this worker, the session-manager worker,
+    # and the web server all read the same payloads.
     connect_config = ClientConfig.load_client_connect_config()
     client = await Client.connect(
-        **connect_config,
-        plugins=[plugin],
-        data_converter=await with_large_payload_offload(pydantic_data_converter),
+        **connect_config, plugins=[plugin, AgentHarnessPlugin()]
     )
 
     worker = Worker(
         client,
         task_queue=task_queue,
         workflows=[CodingAgentWorkflow],
-        # No tool activities: the coding tools are callback tools fulfilled by the shim. The
-        # Gemini interactions activity is registered by the plugin above.
-        activities=[],
+        # No activities to declare: the coding tools are callback tools fulfilled by the shim,
+        # the Gemini interactions activity comes from the Gemini plugin, and the harness's own
+        # activities come from AgentHarnessPlugin.
     )
     print(
         f"Coding agent worker ready: "

--- a/examples/callback_tools/wiki_agent/worker.py
+++ b/examples/callback_tools/wiki_agent/worker.py
@@ -26,12 +26,11 @@ import sys
 
 from google.genai import Client as GeminiClient
 from temporalio.client import Client
-from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 from temporal_agent_harness.ai_sdks.google_genai_plugin import GoogleGenAIPlugin
-from temporal_agent_harness.utils.large_payload import with_large_payload_offload
 
 from .workflow import TASK_QUEUE, WikiAgentWorkflow
 
@@ -52,22 +51,21 @@ async def main() -> None:
         sys.exit("error: GEMINI_API_KEY env var not set")
     plugin = GoogleGenAIPlugin(GeminiClient(api_key=api_key))
 
-    # Match the session-manager worker + server converter (large-payload offload) so every
-    # process reads the same payloads.
+    # AgentHarnessPlugin last: it leaves the Gemini plugin's payload converter in place and
+    # adds the harness's large-payload offload, so this worker, the session-manager worker,
+    # and the web server all read the same payloads.
     connect_config = ClientConfig.load_client_connect_config()
     client = await Client.connect(
-        **connect_config,
-        plugins=[plugin],
-        data_converter=await with_large_payload_offload(pydantic_data_converter),
+        **connect_config, plugins=[plugin, AgentHarnessPlugin()]
     )
 
     worker = Worker(
         client,
         task_queue=task_queue,
         workflows=[WikiAgentWorkflow],
-        # No tool activities: the wiki tools are callback tools fulfilled by the client. The
-        # Gemini interactions activity is registered by the plugin above.
-        activities=[],
+        # No activities to declare: the wiki tools are callback tools fulfilled by the client,
+        # the Gemini interactions activity comes from the Gemini plugin, and the harness's own
+        # activities come from AgentHarnessPlugin.
     )
     print(
         f"Wiki agent worker ready: "

--- a/examples/monty/activities.py
+++ b/examples/monty/activities.py
@@ -10,8 +10,8 @@ Each is an ``@agent.activity_tool_defn``, so when the workflow dispatches it (vi
 ``run_tool``) the activity publishes its own ``tool_start``/``tool_end`` lifecycle events
 on the turn stream — each host call the script makes shows up as a distinct tool
 invocation, like any other harness tool. The decorated object is the in-workflow
-dispatcher; ``agent.tool_activity(tool)`` returns the activity body the worker registers
-(see ``ALL_ACTIVITIES``).
+dispatcher; the worker registers each one's durable activity body by handing ``ALL_TOOLS``
+to ``AgentHarnessPlugin(tools=...)``.
 
 No ``from __future__ import annotations`` here, for consistency with the rest of the
 agent's Temporal-facing modules (stringized annotations trip the pydantic converter).
@@ -237,16 +237,14 @@ async def get_trip_summary_activity(request: TripSummaryRequest) -> TripSummaryR
     return TripSummaryResponse(summary="\n".join(lines))
 
 
-# Convenience list for registering all activities with a Temporal worker — the durable
-# activity body of each tool (the module-level names above are the in-workflow dispatchers
-# the workflow calls via run_tool; tool_activity() returns the activity defn to register).
-ALL_ACTIVITIES = [
-    agent.tool_activity(t)
-    for t in (
-        search_flights_activity,
-        search_hotels_activity,
-        book_flight_activity,
-        book_hotel_activity,
-        get_trip_summary_activity,
-    )
+# The agent's toolset, declared once. The module-level names above are the in-workflow
+# dispatchers; each workflow wraps this list in a Code Mode tool (exposing them to the script
+# as host functions), and the worker hands the same list to ``AgentHarnessPlugin(tools=...)``,
+# which registers each one's durable activity body.
+ALL_TOOLS = [
+    search_flights_activity,
+    search_hotels_activity,
+    book_flight_activity,
+    book_hotel_activity,
+    get_trip_summary_activity,
 ]

--- a/examples/monty/conversational_workflow.py
+++ b/examples/monty/conversational_workflow.py
@@ -62,7 +62,7 @@ with workflow.unsafe.imports_passed_through():
 
 
 TASK_QUEUE = "monty-dynamic-agent"
-SUPPORTED_MODELS = ("gemini-3.5-flash", "gemini-3.1-flash-lite")
+SUPPORTED_MODELS = ("gemini-3.8-flash", "gemini-3.1-flash-lite")
 DEFAULT_MODEL = SUPPORTED_MODELS[0]
 
 
@@ -120,13 +120,7 @@ class MontyChatAgentWorkflow:
         # Python script that calls the travel operations as async host functions; each host call
         # runs as a durable, approval-gated activity via run_tool.
         self._code_tool = agent.code_mode_tool(
-            [
-                activities.search_flights_activity,
-                activities.search_hotels_activity,
-                activities.book_flight_activity,
-                activities.book_hotel_activity,
-                activities.get_trip_summary_activity,
-            ],
+            activities.ALL_TOOLS,
             name="run_travel_code",
         )
 

--- a/examples/monty/worker.py
+++ b/examples/monty/worker.py
@@ -30,15 +30,12 @@ import os
 import sys
 
 from google.genai import Client as GeminiClient
-from temporal_agent_harness.ai_sdks.google_genai_plugin import GoogleGenAIPlugin
-from temporal_agent_harness.utils.large_payload import with_large_payload_offload
 from temporalio.client import Client
-from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 
-from temporal_agent_harness.harness.code_mode.activities import CODE_MODE_ACTIVITIES
-from temporal_agent_harness.harness.subagent_activities import SubagentActivities
+from temporal_agent_harness.plugin import AgentHarnessPlugin
+from temporal_agent_harness.ai_sdks.google_genai_plugin import GoogleGenAIPlugin
 
 from . import activities
 from .conversational_subagent_workflow import MontyChatSubagentWorkflow
@@ -62,25 +59,31 @@ async def main() -> None:
 
     task_queue = os.environ.get("MONTY_AGENT_TASK_QUEUE", TASK_QUEUE)
 
-    # Match the session-manager worker + server: the large-payload offload codec. Monty
-    # snapshot bytes cross the activity boundary and land in workflow history, so they can
-    # exceed Temporal's payload limit; the codec offloads big payloads to external storage
-    # and stores a reference. Every process that reads these payloads uses the same codec, so
-    # the converters MUST match or offloaded payloads can't be read back.
-    # The conversational Monty agent (MontyChatAgent) drives the Gemini Interactions API,
-    # so this worker now needs the Gemini plugin (it auto-registers the interactions
-    # activity). The original script-only MontyDynamicAgent doesn't use it, but sharing one
-    # worker keeps the demo simple.
+    # The conversational Monty agent (MontyChatAgent) drives the Gemini Interactions API, so
+    # this worker needs the Gemini plugin (it auto-registers the interactions activity). The
+    # original script-only MontyDynamicAgent doesn't use it, but sharing one worker keeps the
+    # demo simple.
     api_key = os.environ.get("GEMINI_API_KEY")
     if not api_key:
         sys.exit("error: GEMINI_API_KEY env var not set")
-    plugin = GoogleGenAIPlugin(GeminiClient(api_key=api_key))
 
+    # Two plugins, harness LAST so the Gemini plugin's payload converter wins:
+    #   * GoogleGenAIPlugin  — the Gemini interactions activity.
+    #   * AgentHarnessPlugin — everything the harness itself needs on this worker: the
+    #     large-payload offload converter (Monty snapshot bytes cross the activity boundary
+    #     and land in workflow history, so they can exceed Temporal's payload limit — and
+    #     every process reading them must use the SAME converter, which is exactly what
+    #     adding this plugin everywhere guarantees), the Code Mode sandbox-stepping
+    #     activities (all three agents run their scripts through Code Mode), the
+    #     subagent-turn activity (drives the script-runner child for MontyChatSubagentAgent),
+    #     and the durable activity body of every travel tool in ALL_TOOLS.
     connect_config = ClientConfig.load_client_connect_config()
     client = await Client.connect(
         **connect_config,
-        plugins=[plugin],
-        data_converter=await with_large_payload_offload(pydantic_data_converter),
+        plugins=[
+            GoogleGenAIPlugin(GeminiClient(api_key=api_key)),
+            AgentHarnessPlugin(tools=activities.ALL_TOOLS),
+        ],
     )
 
     # All three Monty agents run here: the script-only MontyDynamicAgent, the inline
@@ -89,10 +92,8 @@ async def main() -> None:
     # session manager is hosted by its own worker, not here; it dispatches these agents
     # to this queue by name.
     #
-    # SubagentActivities closes over this worker's client so its run_subagent_turn activity can
-    # send updates to + stream the reply from the child MontyDynamicAgent workflow. It's the
-    # activity the subagent toolset's monty_run_script tool dispatches each turn.
-    subagents = SubagentActivities(client)
+    # No `activities=` at all: a client plugin is applied to the workers built from that
+    # client, so both plugins register their own activities here.
     worker = Worker(
         client,
         task_queue=task_queue,
@@ -100,16 +101,6 @@ async def main() -> None:
             MontyDynamicAgentWorkflow,
             MontyChatAgentWorkflow,
             MontyChatSubagentWorkflow,
-        ],
-        # The travel-booking activities (the host functions, dispatched by Code Mode) plus the
-        # Code Mode sandbox-stepping activities (shared by all three agents — every one runs its
-        # scripts through the harness Code Mode). Plus the subagent-turn activity (drives the
-        # script-runner child for MontyChatSubagentAgent). The Gemini interactions activity is
-        # registered by the plugin above.
-        activities=[
-            *activities.ALL_ACTIVITIES,
-            *CODE_MODE_ACTIVITIES,
-            subagents.run_subagent_turn,
         ],
     )
     print(

--- a/examples/monty/workflow.py
+++ b/examples/monty/workflow.py
@@ -55,13 +55,7 @@ class MontyDynamicAgentWorkflow:
         # Code Mode over the travel tools: one tool that runs a script calling them as host
         # functions. The run_script handler dispatches the caller's script straight through it.
         self._run_code = agent.code_mode_tool(
-            [
-                activities.search_flights_activity,
-                activities.search_hotels_activity,
-                activities.book_flight_activity,
-                activities.book_hotel_activity,
-                activities.get_trip_summary_activity,
-            ],
+            activities.ALL_TOOLS,
             name="run_travel_code",
         )
 

--- a/examples/nexus_hello/worker.py
+++ b/examples/nexus_hello/worker.py
@@ -25,6 +25,7 @@ from temporalio.client import Client
 from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 from temporal_agent_harness.ai_sdks.openai_agents import (
     ModelActivityParameters,
     OpenAIAgentsPlugin,
@@ -57,8 +58,12 @@ async def main() -> None:
         observer_factory=harness_observer_factory,
     )
 
+    # Harness plugin LAST so the OpenAI plugin's payload converter wins; it then adds the
+    # harness's data-converter requirements and activities on top.
     connect_config = ClientConfig.load_client_connect_config()
-    client = await Client.connect(**connect_config, plugins=[plugin])
+    client = await Client.connect(
+        **connect_config, plugins=[plugin, AgentHarnessPlugin()]
+    )
 
     worker = Worker(
         client,

--- a/examples/openai_hello/README.md
+++ b/examples/openai_hello/README.md
@@ -30,7 +30,7 @@ streaming activity, to the live turn stream the web UI consumes.
 | File | Role |
 |---|---|
 | `workflow.py` | `OpenAIHelloAgent` — the harness agent; one `ask` handler, one `get_weather` tool, driven by `Runner.run_streamed`. |
-| `worker.py` | Worker hosting the workflow; wires the plugin for the harness streaming seam. |
+| `worker.py` | Worker hosting the workflow; wires the OpenAI plugin for the harness streaming seam, plus `AgentHarnessPlugin` for the harness's own converter and activities. |
 | `agents.toml` | Registry entry that makes this agent selectable in the shared web UI. |
 
 There is **no per-example client**: like the Monty example, this agent is driven by the shared

--- a/examples/openai_hello/worker.py
+++ b/examples/openai_hello/worker.py
@@ -5,7 +5,8 @@ Run from the repo root with:
 
 Hosts only the OpenAIHelloAgent workflow. Its one tool (`get_weather`) is an inline workflow
 tool with no worker-side body, so there are no tool activities to register — the OpenAI Agents
-plugin registers the model activities (including the streaming one) itself.
+plugin registers the model activities (including the streaming one) itself, and
+`AgentHarnessPlugin` supplies the harness's data converter and activities.
 
 The plugin is wired for the HARNESS STREAMING PATH:
   * ``model_params.stream_to_provider=stream_to_provider`` — resolves each streamed model
@@ -32,6 +33,7 @@ from temporalio.client import Client
 from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 from temporal_agent_harness.ai_sdks.openai_agents import (
     ModelActivityParameters,
     OpenAIAgentsPlugin,
@@ -68,17 +70,21 @@ async def main() -> None:
         observer_factory=harness_observer_factory,
     )
 
-    # The plugin supplies its own (OpenAI-aware, pydantic-compatible) data converter.
+    # Two plugins, harness LAST so the OpenAI plugin's (OpenAI-aware, pydantic-compatible)
+    # payload converter wins; the harness plugin then adds the large-payload offload on top,
+    # matching the session-manager worker and the web server.
     connect_config = ClientConfig.load_client_connect_config()
-    client = await Client.connect(**connect_config, plugins=[plugin])
+    client = await Client.connect(
+        **connect_config, plugins=[plugin, AgentHarnessPlugin()]
+    )
 
     worker = Worker(
         client,
         task_queue=task_queue,
         workflows=[OpenAIHelloAgentWorkflow],
-        # No tool activities: get_weather is an inline workflow tool. The OpenAI model
-        # activities (incl. invoke_model_activity_streaming) are registered by the plugin.
-        activities=[],
+        # No activities to declare: get_weather is an inline workflow tool, the OpenAI model
+        # activities (incl. invoke_model_activity_streaming) come from the OpenAI plugin, and
+        # the harness's own activities come from AgentHarnessPlugin.
     )
     print(
         f"OpenAI hello agent worker ready: "

--- a/examples/pydantic_ai_hello/README.md
+++ b/examples/pydantic_ai_hello/README.md
@@ -39,7 +39,7 @@ harness needs. The harness only supplies a thin glue module.
 | File | Role |
 |---|---|
 | `workflow.py` | `PydanticAIHelloAgent` — the harness agent; one `ask` handler, one `get_weather` tool, driven by `TemporalAgent.run` + the harness event-stream handler. |
-| `worker.py` | Worker hosting the workflow; `PydanticAIPlugin` on the client, `AgentPlugin(agent)` on the worker. |
+| `worker.py` | Worker hosting the workflow; `PydanticAIPlugin` + `AgentHarnessPlugin` on the client, `AgentPlugin(agent)` on the worker. |
 | `agents.toml` | Registry entry that makes this agent selectable in the shared web UI. |
 
 There is **no per-example client**: like the other examples, this agent is driven by the shared

--- a/examples/pydantic_ai_hello/worker.py
+++ b/examples/pydantic_ai_hello/worker.py
@@ -8,9 +8,11 @@ tool with no worker-side body, so there are no harness tool activities to regist
 `AgentPlugin` registers the agent's activities (model request/stream, event_stream_handler, and the
 toolset's call_tool) itself.
 
-Two plugins, mirroring the upstream Pydantic AI Temporal setup:
+Three plugins — the upstream Pydantic AI Temporal setup plus the harness's own:
   * ``PydanticAIPlugin`` on the CLIENT — installs the Pydantic-compatible data converter and the
     workflow-sandbox passthroughs the SDK needs.
+  * ``AgentHarnessPlugin`` on the CLIENT, after it — the harness's data-converter requirements
+    and activities.
   * ``AgentPlugin(temporal_agent)`` on the WORKER — registers the durable agent's activities.
 
 The harness streaming path is wired on the agent itself (in workflow.py): its
@@ -36,6 +38,8 @@ from temporalio.client import Client
 from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 
+from temporal_agent_harness.plugin import AgentHarnessPlugin
+
 from .workflow import TASK_QUEUE, PydanticAIHelloAgentWorkflow, _TEMPORAL_AGENT
 
 
@@ -51,17 +55,20 @@ async def main() -> None:
     if not os.environ.get("OPENAI_API_KEY"):
         sys.exit("error: OPENAI_API_KEY env var not set")
 
-    # PydanticAIPlugin supplies the Pydantic-compatible data converter + sandbox passthroughs.
+    # PydanticAIPlugin supplies the Pydantic-compatible data converter + sandbox passthroughs;
+    # AgentHarnessPlugin (last) leaves that converter in place and adds the harness's own
+    # requirements — the large-payload offload plus its activities.
     connect_config = ClientConfig.load_client_connect_config()
-    client = await Client.connect(**connect_config, plugins=[PydanticAIPlugin()])
+    client = await Client.connect(
+        **connect_config, plugins=[PydanticAIPlugin(), AgentHarnessPlugin()]
+    )
 
     worker = Worker(
         client,
         task_queue=task_queue,
         workflows=[PydanticAIHelloAgentWorkflow],
-        # No harness tool activities: get_weather is an inline workflow tool. The durable agent's
-        # activities are registered by AgentPlugin.
-        activities=[],
+        # No activities to declare: get_weather is an inline workflow tool, the durable agent's
+        # activities come from AgentPlugin, and the harness's own come from AgentHarnessPlugin.
         plugins=[AgentPlugin(_TEMPORAL_AGENT)],
     )
     print(

--- a/examples/react_agent/README.md
+++ b/examples/react_agent/README.md
@@ -68,9 +68,9 @@ Ask it a question and it chains tools to find the answer:
 | File | Role |
 |---|---|
 | `workflow.py` | `ReactAgent` — the harness agent; one `ask` handler, local tools + `ask_user` adapted onto the SDK plus the F1 MCP server, driven by `Runner.run_streamed`. |
-| `tool_activities.py` | The four location/weather tools as `@agent.activity_tool_defn` activities (httpx), plus `ALL_TOOLS` / `ALL_ACTIVITIES`. |
+| `tool_activities.py` | The four location/weather tools as `@agent.activity_tool_defn` activities (httpx), plus `ALL_TOOLS` — the list the worker hands to `AgentHarnessPlugin(tools=...)`. |
 | `human_tools.py` | The `ask_user` human-in-the-loop **callback tool** (`@agent.callback_tool_defn`), plus `HUMAN_TOOLS`. No activity body — fulfilled by a client. |
-| `worker.py` | Worker hosting the workflow + the four tool activities; registers the F1 MCP provider and wires the plugin for the harness streaming seam. |
+| `worker.py` | Worker hosting the workflow. Declares no activities: `AgentHarnessPlugin(tools=...)` registers the four tool bodies (skipping the bodiless `ask_user`) and the OpenAI plugin registers the model activities. Also registers the F1 MCP provider and wires the harness streaming seam. |
 | `client.py` | A terminal client: a session picker that shows which sessions are **waiting on an `ask_user`**, then lets you answer open questions, chat, or create a session — all over HTTP. |
 | `agents.toml` | Registry entry that makes this agent selectable in the shared web UI. |
 

--- a/examples/react_agent/tool_activities.py
+++ b/examples/react_agent/tool_activities.py
@@ -5,7 +5,7 @@ over httpx. Because they do network I/O they run as Temporal activities, never i
 workflow. Each is adapted onto the OpenAI Agents SDK in ``workflow.py`` via
 ``as_openai_agent_tools``, so the harness still owns the approval gate and each tool's
 ``tool_start`` / ``tool_end`` / ``tool_error`` events; the worker registers each activity body
-with ``agent.tool_activity(...)`` (see ``worker.py``, which uses ``ALL_ACTIVITIES``).
+by handing ``ALL_TOOLS`` to ``AgentHarnessPlugin(tools=...)`` (see ``worker.py``).
 
 The tool schema the model sees (name, description, parameters) is derived from each function's
 signature and docstring, so the first docstring line becomes the tool description and the
@@ -97,7 +97,6 @@ async def get_weather(latitude: float, longitude: float) -> str:
 
 
 # The in-workflow tool dispatchers (what workflow.py adapts onto the SDK via
-# as_openai_agent_tools) and the matching @activity.defn bodies the worker registers.
-# tool_activity() returns the durable activity body for each dispatcher.
+# as_openai_agent_tools). The worker hands this same list to ``AgentHarnessPlugin(tools=...)``,
+# which registers each dispatcher's durable @activity.defn body.
 ALL_TOOLS = [get_ip_address, get_location_info, get_coordinates, get_weather]
-ALL_ACTIVITIES = [agent.tool_activity(t) for t in ALL_TOOLS]

--- a/examples/react_agent/worker.py
+++ b/examples/react_agent/worker.py
@@ -5,9 +5,9 @@ Run from the repo root with:
 
 Hosts the ReactAgent workflow and its four tool activities (get_ip_address,
 get_location_info, get_coordinates, get_weather). Each tool is a harness activity tool
-(`@agent.activity_tool_defn`) doing real HTTP, so its activity body is registered here via
-`agent.tool_activity(...)` (bundled as ALL_ACTIVITIES). The OpenAI Agents plugin registers the
-model activities (including the streaming one) itself.
+(`@agent.activity_tool_defn`) doing real HTTP; `AgentHarnessPlugin(tools=...)` registers each
+one's activity body, and the OpenAI Agents plugin registers the model activities (including
+the streaming one) — so this worker declares no activities of its own.
 
 The plugin is wired for the HARNESS STREAMING PATH:
   * ``model_params.stream_to_provider=stream_to_provider`` — reads each streamed model call's
@@ -38,6 +38,7 @@ from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 from agents.mcp import MCPServerStdio
 
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 from temporal_agent_harness.ai_sdks.openai_agents import (
     ModelActivityParameters,
     OpenAIAgentsPlugin,
@@ -48,7 +49,8 @@ from temporal_agent_harness.ai_sdks.openai_agents_harness import (
     stream_to_provider,
 )
 
-from .tool_activities import ALL_ACTIVITIES
+from .human_tools import HUMAN_TOOLS
+from .tool_activities import ALL_TOOLS
 from .workflow import TASK_QUEUE, ReactAgentWorkflow
 
 
@@ -109,19 +111,25 @@ async def main() -> None:
         observer_factory=harness_observer_factory,
     )
 
-    # The plugin supplies its own (OpenAI-aware, pydantic-compatible) data converter.
+    # Two plugins, harness LAST so the OpenAI plugin's (OpenAI-aware, pydantic-compatible)
+    # payload converter wins; the harness plugin then adds the large-payload offload on top,
+    # matching the session-manager worker and the web server.
+    #
+    # The harness plugin is handed the agent's WHOLE toolset: it registers the four
+    # location/weather activity bodies and skips ask_user, a callback tool with no worker-side
+    # body (the user's terminal client fulfills it). The OpenAI model activities (incl.
+    # invoke_model_activity_streaming) are registered by the OpenAI plugin — so the Worker
+    # below declares no activities at all.
     connect_config = ClientConfig.load_client_connect_config()
-    client = await Client.connect(**connect_config, plugins=[plugin])
+    client = await Client.connect(
+        **connect_config,
+        plugins=[plugin, AgentHarnessPlugin(tools=[*ALL_TOOLS, *HUMAN_TOOLS])],
+    )
 
     worker = Worker(
         client,
         task_queue=task_queue,
         workflows=[ReactAgentWorkflow],
-        # The four location/weather tool activity bodies. The OpenAI model activities
-        # (incl. invoke_model_activity_streaming) are registered by the plugin. The ask_user
-        # callback tool has no activity body — it's fulfilled by the client — so nothing to
-        # register for it here.
-        activities=ALL_ACTIVITIES,
     )
     print(
         f"ReAct agent worker ready: "

--- a/examples/session_manager_worker.py
+++ b/examples/session_manager_worker.py
@@ -17,10 +17,9 @@ import asyncio
 import logging
 
 from temporalio.client import Client
-from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.envconfig import ClientConfig
 
-from temporal_agent_harness.utils.large_payload import with_large_payload_offload
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 from temporal_agent_harness.web import (
     SESSION_MANAGER_TASK_QUEUE,
     create_session_manager_worker,
@@ -34,11 +33,13 @@ async def main() -> None:
         force=True,
     )
 
+    # The session manager hosts no agent workflows and no tools, so what it needs from the
+    # harness plugin is the shared data converter. That is the point — the manager, the web
+    # server, and every agent worker read the same payloads because they all add the same
+    # plugin. The harness activities come along too and are simply never called here (nothing
+    # schedules a tool, a Code Mode step, or a subagent turn on this queue).
     connect_config = ClientConfig.load_client_connect_config()
-    client = await Client.connect(
-        **connect_config,
-        data_converter=await with_large_payload_offload(pydantic_data_converter),
-    )
+    client = await Client.connect(**connect_config, plugins=[AgentHarnessPlugin()])
 
     worker = create_session_manager_worker(client)
     print(

--- a/nexus/mcp/nexus_mcp/durable_tools_gateway/worker.py
+++ b/nexus/mcp/nexus_mcp/durable_tools_gateway/worker.py
@@ -26,7 +26,10 @@ from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.envconfig import ClientConfig
 from temporalio.worker import Worker
 
-from temporal_agent_harness.utils.large_payload import with_large_payload_offload
+from temporal_agent_harness.utils.large_payload import (
+    local_payload_storage,
+    with_large_payload_offload,
+)
 
 from .registry import (
     REGISTRY_TASK_QUEUE,
@@ -66,7 +69,12 @@ async def main(
     connect_config = ClientConfig.load_client_connect_config()
     client = await Client.connect(
         **connect_config,
-        data_converter=await with_large_payload_offload(pydantic_data_converter),
+        # The gateway isn't an agent, so it builds its converter by hand rather than adding
+        # AgentHarnessPlugin — but it exchanges payloads with agents, so the offload backend
+        # must match theirs (AgentHarnessPlugin's default is this same local storage).
+        data_converter=with_large_payload_offload(
+            pydantic_data_converter, local_payload_storage()
+        ),
     )
 
     await client.start_workflow(

--- a/temporal_agent_harness/__init__.py
+++ b/temporal_agent_harness/__init__.py
@@ -9,4 +9,7 @@ Subpackages:
     the agent/subagent protocol, tool definitions, and human-in-the-loop tool approvals.
   * :mod:`temporal_agent_harness.ai_sdks`  — integrations that make AI SDK calls durable
     Temporal activities (currently the Google Gemini SDK).
+  * :mod:`temporal_agent_harness.plugin`   — ``AgentHarnessPlugin``, the one Temporal plugin
+    that wires a client + worker for all of the above: it supplies the harness's data
+    converter and registers its activities, so a worker declares only its workflows.
 """

--- a/temporal_agent_harness/harness/code_mode/__init__.py
+++ b/temporal_agent_harness/harness/code_mode/__init__.py
@@ -12,10 +12,16 @@ the sandbox engine (the optional ``code-mode`` extra):
   * Workflow-safe (this ``__init__`` and the ``batch_models`` / ``stubs`` / ``driver`` / ``tool``
     modules): safe to import anywhere, including inside a workflow. ``code_mode_tool`` and
     ``CodeModeStubError`` are the public surface, re-exported here.
-  * Worker-side (:mod:`.activities`): imports ``pydantic_monty`` and defines the sandbox-stepping
-    activities. A worker registers them via ``from ...code_mode.activities import
-    CODE_MODE_ACTIVITIES``; nothing here imports that module, so the workflow-safe surface stays
-    free of the engine dependency.
+  * Worker-side (:mod:`.activities`): the two sandbox-stepping activities.
+    ``AgentHarnessPlugin`` registers them on every worker (a worker can also register
+    ``CODE_MODE_ACTIVITIES`` from that module by hand); nothing here imports that module, so
+    the workflow-safe surface stays free of it. It imports no Monty itself — it checks that
+    the ``code-mode`` extra is installed and then delegates — so it loads without the extra
+    and a misconfigured worker fails a Code Mode call with an actionable, non-retryable error
+    instead of leaving the activity names unregistered, which Temporal retries forever.
+  * Worker-side engine (:mod:`.monty_stepper`): the stepping logic, and the only module that
+    imports ``pydantic_monty``. Kept separate purely so it can import Monty normally and be
+    type-checked against it; import it only after that extra check.
 """
 
 from .stubs import CodeModeStubError

--- a/temporal_agent_harness/harness/code_mode/activities.py
+++ b/temporal_agent_harness/harness/code_mode/activities.py
@@ -1,29 +1,37 @@
-"""Worker-side activities that step the Monty sandbox, surfacing host calls for the workflow.
+"""The two worker-side activities that step the Monty sandbox, surfacing host calls to the workflow.
 
-The core of the suspend-at-external-call design. Monty's *synchronous* stepping API
-(``Monty(code).start()`` / ``snapshot.resume(...)``) runs the sandboxed script until it
-calls a function the sandbox doesn't define — at which point it SUSPENDS and hands the host
-the pending call. The host does the real work, then ``resume(...)`` continues from exactly
-that point. Host functions are ``async`` (scripts ``await`` them), so concurrency is
-expressed naturally with ``asyncio.gather`` — see the driver section below.
+Thin Temporal wrappers. Each checks that the optional ``code-mode`` extra is installed, then
+delegates to :mod:`.monty_stepper`, which holds the actual stepping logic — see that module for
+the suspend-at-external-call protocol and the async/concurrent batch driver.
 
-Why this lives in activities (not the workflow):
+Why the stepping lives in an activity (not the workflow):
   * Monty's *async* API (``acreate``/``run_async``) cannot run in a Temporal workflow at
     all — its Rust↔asyncio bridge needs ``loop.call_soon_threadsafe``, which the
     deterministic workflow loop forbids (it raises NotImplementedError). The synchronous
     ``start``/``resume`` API sidesteps that entirely — no event loop, no threads. (The
     async *concurrency* the script sees does NOT use Monty's async API; it's the
-    defer-future / FutureSnapshot protocol over this synchronous stepping API.)
+    defer-future / FutureSnapshot protocol over that synchronous stepping API.)
   * Even so, executing arbitrary (sandboxed) user code is not something to do inside a
     workflow. So the workflow stays the pure orchestrator: it calls ``code_start_batch``
     once, then alternates running each awaited batch of host calls (durable activities,
     concurrently) with ``code_resume_batch`` until the script completes.
 
-This module imports ``pydantic_monty`` (the optional ``code-mode`` extra). It is WORKER-SIDE
-only — never import it from workflow code or from ``harness.agent``. The workflow-side driver
-dispatches these activities by NAME (``CODE_START_BATCH_ACTIVITY`` /
-``CODE_RESUME_BATCH_ACTIVITY`` in :mod:`.batch_models`), so it never imports this module and
-thus never requires ``pydantic_monty`` to be installed.
+This module is WORKER-SIDE — never import it from workflow code or from ``harness.agent``.
+The workflow-side driver dispatches these activities by NAME (``CODE_START_BATCH_ACTIVITY`` /
+``CODE_RESUME_BATCH_ACTIVITY`` in :mod:`.batch_models`), so it never imports this module.
+
+Why the extra is checked HERE, per call, rather than at import: this module deliberately does
+not import ``pydantic_monty``, so it loads with or without the ``code-mode`` extra and a worker
+can always register these two activities. That matters because the driver dispatches by NAME —
+with nothing registered under these names Temporal answers with
+``ApplicationError(type="NotFoundError")``, which is RETRYABLE, so a worker missing the extra
+would retry "is not registered on this worker" forever and the turn would just hang. Checking
+inside the activity turns that into one immediate, non-retryable failure naming the extra to
+install. The check cannot live in the workflow instead: ``agent.code_mode_tool(...)`` runs in
+the workflow sandbox, where the installed-package question is both unanswerable (imports are
+restricted) and the wrong question — the answer depends on the worker process, not on workflow
+history, so branching on it would be nondeterministic across a replay. So a deploy that
+accidentally drops the extra costs some failed tool calls, never a broken workflow.
 
 The snapshot crosses the activity boundary as bytes (``FutureSnapshot.dump()`` /
 ``load_snapshot``). Those bytes can be large and end up in workflow history, which is why
@@ -31,34 +39,8 @@ every client/worker must connect with the large-payload offload data converter.
 
 No ``from __future__ import annotations`` — the models crossing Temporal's pydantic converter
 require concrete annotations (see :mod:`.batch_models`).
-
-=== Async / concurrent driver (FutureSnapshot batches) ===
-
-Host functions are ``async`` (the stubs declare ``async def``; scripts ``await`` them), so
-a script runs host calls CONCURRENTLY with ``await asyncio.gather(search_flights(...),
-search_hotels(...))``. Monty's async-host-function protocol over the synchronous stepping
-API makes that work:
-
-  * When the script calls an ``async def`` host function, Monty yields a FunctionSnapshot.
-    Instead of resolving it, we resume with ``{"future": ...}`` (an ExternalFuture) — "this
-    call is pending, keep running" — and record its name/args by ``call_id``.
-  * The script keeps issuing host calls (each deferred) until it ``await``s them. At that
-    point Monty yields a FutureSnapshot whose ``pending_call_ids`` is the batch the script
-    is blocked on. We hand that whole batch to the workflow, which runs every call
-    CONCURRENTLY as its own durable activity (``asyncio.gather`` over ``execute_activity``)
-    and resumes the FutureSnapshot with ``{call_id: {"return_value": ...}}`` for all of them.
-
-So concurrency is real and durable: one Temporal activity per host call, all in flight at
-once, orchestrated by the workflow. The defer loop (resuming ExternalFutures) does no host
-work, so it runs entirely inside the activity — only the awaited batch crosses to the
-workflow. A purely sequential script (``await`` one call at a time) just produces
-single-call batches; a synchronous (non-awaited) script is not supported — host functions
-are async by contract.
 """
 
-from typing import Any
-
-import pydantic_monty as monty
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
@@ -66,138 +48,76 @@ from .batch_models import (
     CODE_RESUME_BATCH_ACTIVITY,
     CODE_START_BATCH_ACTIVITY,
     CodeBatchStep,
-    PendingCall,
     ResumeBatchInput,
 )
 
+# The error type an operator (or an agent's error handling) can match on to tell a worker
+# missing the `code-mode` extra apart from a script that genuinely failed.
+CODE_MODE_MISSING_EXTRA_ERROR = "CodeModeExtraMissing"
 
-def _drive_to_batch(snap: Any, stdout: monty.CollectString) -> CodeBatchStep:
-    """Run Monty forward, deferring each external call as a future, until it awaits a batch.
 
-    Loops: a FunctionSnapshot (an ``async`` host call) is recorded and resumed with
-    ``{"future": ...}`` so execution continues; a FutureSnapshot means the script is now
-    awaiting — return its ``pending_call_ids`` (resolved to the recorded calls) for the
-    workflow to run; MontyComplete means done. Any ``snapshot.resume`` may raise a
-    MontyError if the script errors mid-run — the callers translate that to ``error``."""
-    seen: dict[int, PendingCall] = {}
-    while True:
-        if isinstance(snap, monty.MontyComplete):
-            return CodeBatchStep(
-                done=True, stdout=stdout.output, output_json=snap.output_json()
-            )
-        if isinstance(snap, monty.FunctionSnapshot):
-            seen[snap.call_id] = PendingCall(
-                call_id=snap.call_id,
-                function_name=str(snap.function_name),
-                args=list(snap.args),
-                kwargs=dict(snap.kwargs),
-            )
-            # ExternalFuture: "pending, keep going" — does no host work, so stay in-activity.
-            snap = snap.resume({"future": ...})
-            continue
-        if isinstance(snap, monty.FutureSnapshot):
-            ids = list(snap.pending_call_ids)
-            missing = [i for i in ids if i not in seen]
-            if missing:
-                # A call deferred in a PRIOR activity run and only awaited now: this driver
-                # records calls per-run, so it can't name them. Model-generated gather code
-                # issues+awaits together, so this shouldn't arise; fail loudly if it does.
-                raise ApplicationError(
-                    f"FutureSnapshot awaits call_ids {missing} not seen in this run "
-                    f"(cross-batch deferral is unsupported)",
-                    type="UnsupportedMontyFuture",
-                    non_retryable=True,
-                )
-            return CodeBatchStep(
-                done=False,
-                stdout=stdout.output,
-                snapshot=snap.dump(),
-                pending=[seen[i] for i in ids],
-            )
-        # NameLookupSnapshot (unknown bare name) — unsupported by this driver.
+def _require_code_mode_extra() -> None:
+    """Fail the call with an actionable error unless the ``code-mode`` extra is installed.
+
+    Called at the top of each activity, before importing :mod:`.monty_stepper` (which imports
+    Monty at module scope and would otherwise raise a bare ImportError). Probing
+    ``pydantic_monty`` itself, rather than wrapping the stepper import in ``except
+    ImportError``, keeps the diagnosis honest: only Monty's actual absence produces this
+    error, while an ImportError from a bug inside the stepper still surfaces as itself.
+
+    Cheap enough to pay on every call — after the first one it is a ``sys.modules`` lookup.
+
+    Non-retryable on purpose: the call fails once and the agent sees a failed tool call rather
+    than a turn that stalls indefinitely. It does NOT self-heal — a call that failed during a
+    bad deploy stays failed; calls made after the extra is restored succeed.
+    """
+    try:
+        import pydantic_monty  # noqa: F401  (presence probe only)
+    except ImportError as e:
         raise ApplicationError(
-            f"unsupported Monty suspension: {type(snap).__name__}",
-            type="UnsupportedMontySuspension",
+            "Code Mode ran on a worker without the harness's `code-mode` extra, which "
+            "provides pydantic-monty — the sandbox Code Mode scripts run in. Install "
+            "temporal-agent-harness[code-mode] on this worker and redeploy it.",
+            type=CODE_MODE_MISSING_EXTRA_ERROR,
             non_retryable=True,
-        )
+        ) from e
 
 
 @activity.defn(name=CODE_START_BATCH_ACTIVITY)
 async def code_start_batch(
     script: str, type_check_stubs: str | None = None
 ) -> CodeBatchStep:
-    """Compile + start ``script`` (async driver), running to the first awaited batch or done.
+    """Compile + start ``script``, running to the first awaited batch of host calls or done.
 
-    Type-checks against ``type_check_stubs`` when provided (Code Mode always passes the
-    auto-generated host-function stubs). See the module's async-driver section for the
-    defer-future / FutureSnapshot protocol."""
-    activity.logger.info(
-        "code_start_batch: compiling + starting (script_len=%d, type_check=%s)",
-        len(script),
-        type_check_stubs is not None,
-    )
-    stdout = monty.CollectString()
-    try:
-        instance = monty.Monty(
-            script,
-            type_check=type_check_stubs is not None,
-            type_check_stubs=type_check_stubs,
-        )
-        snap = instance.start(print_callback=stdout)
-        step = _drive_to_batch(snap, stdout)
-    except monty.MontyError as e:
-        activity.logger.warning("code_start_batch: %s: %s", type(e).__name__, e)
-        return CodeBatchStep(
-            done=True, stdout=stdout.output, error=f"{type(e).__name__}: {e}"
-        )
-    activity.logger.info(
-        "code_start_batch: %s",
-        "done"
-        if step.done
-        else f"awaiting {[c.function_name for c in step.pending]}",
-    )
-    return step
+    See :func:`.monty_stepper.start_batch`."""
+    _require_code_mode_extra()
+    from .monty_stepper import start_batch
+
+    return start_batch(script, type_check_stubs)
 
 
 @activity.defn(name=CODE_RESUME_BATCH_ACTIVITY)
 async def code_resume_batch(input: ResumeBatchInput) -> CodeBatchStep:
     """Resume a FutureSnapshot with the workflow-computed results, then run to the next batch.
 
-    ``input.results`` carries one :class:`CallResult` per call the workflow ran (the batch
-    that was awaited). Resumes the FutureSnapshot with ``{call_id: {"return_value": ...}}``
-    for all of them, then drives forward to the next awaited batch or completion."""
-    stdout = monty.CollectString()
-    snap = monty.load_snapshot(input.snapshot, print_callback=stdout)
-    if not isinstance(snap, monty.FutureSnapshot):
-        raise ApplicationError(
-            f"code_resume_batch expected a FutureSnapshot, got {type(snap).__name__}",
-            type="MontyResumeKind",
-            non_retryable=True,
-        )
-    results_map: dict[int, Any] = {
-        r.call_id: {"return_value": r.return_value} for r in input.results
-    }
-    try:
-        resumed = snap.resume(results_map)
-        step = _drive_to_batch(resumed, stdout)
-    except monty.MontyError as e:
-        activity.logger.warning("code_resume_batch: %s: %s", type(e).__name__, e)
-        return CodeBatchStep(
-            done=True, stdout=stdout.output, error=f"{type(e).__name__}: {e}"
-        )
-    activity.logger.info(
-        "code_resume_batch: %s",
-        "done"
-        if step.done
-        else f"awaiting {[c.function_name for c in step.pending]}",
-    )
-    return step
+    See :func:`.monty_stepper.resume_batch`."""
+    _require_code_mode_extra()
+    from .monty_stepper import resume_batch
+
+    return resume_batch(input)
 
 
 # The two sandbox-stepping activities every Code Mode worker registers, regardless of which
 # tools its Code Mode tools expose (they are tool-agnostic — the tools are dispatched through the
-# runner as their own activities). Register the durable bodies of any activity-backed host tools
-# separately, the same way you register any @agent.activity_tool_defn (via agent.tool_activity)::
+# runner as their own activities). ``AgentHarnessPlugin`` registers these unconditionally — the
+# extra is checked per call by _require_code_mode_extra(), not at registration — alongside the
+# durable bodies of the host tools passed to its ``tools=``, so a Code Mode worker normally
+# names neither::
+#
+#     client = await Client.connect(..., plugins=[AgentHarnessPlugin(tools=my_tools)])
+#     Worker(client, task_queue=..., workflows=[MyAgent])
+#
+# Use this list directly only when assembling a worker's activity list by hand::
 #
 #     Worker(..., activities=[*CODE_MODE_ACTIVITIES, agent.tool_activity(my_tool), ...])
 CODE_MODE_ACTIVITIES = [code_start_batch, code_resume_batch]

--- a/temporal_agent_harness/harness/code_mode/monty_stepper.py
+++ b/temporal_agent_harness/harness/code_mode/monty_stepper.py
@@ -1,0 +1,176 @@
+"""The Monty stepping logic: run a sandboxed script forward to each awaited batch of host calls.
+
+This is the body of the two Code Mode activities, split out from :mod:`.activities` for ONE
+reason: it is the only part that touches ``pydantic_monty`` (the optional ``code-mode`` extra),
+so keeping it here lets it import Monty normally, at module scope, and be type-checked against
+the real package like any other module — while :mod:`.activities` stays importable on a worker
+that doesn't have the extra and can report its absence as an actionable activity failure.
+
+**Import this module only after checking that the extra is installed** — importing it without
+``pydantic_monty`` raises ImportError. :func:`.activities._require_code_mode_extra` is that
+check, and the two activities call it before importing anything from here.
+
+=== Async / concurrent driver (FutureSnapshot batches) ===
+
+Monty's *synchronous* stepping API (``Monty(code).start()`` / ``snapshot.resume(...)``) runs the
+sandboxed script until it calls a function the sandbox doesn't define — at which point it
+SUSPENDS and hands the host the pending call. The host does the real work, then ``resume(...)``
+continues from exactly that point.
+
+Host functions are ``async`` (the stubs declare ``async def``; scripts ``await`` them), so a
+script runs host calls CONCURRENTLY with ``await asyncio.gather(search_flights(...),
+search_hotels(...))``. Monty's async-host-function protocol over the synchronous stepping API
+makes that work:
+
+  * When the script calls an ``async def`` host function, Monty yields a FunctionSnapshot.
+    Instead of resolving it, we resume with ``{"future": ...}`` (an ExternalFuture) — "this
+    call is pending, keep running" — and record its name/args by ``call_id``.
+  * The script keeps issuing host calls (each deferred) until it ``await``s them. At that
+    point Monty yields a FutureSnapshot whose ``pending_call_ids`` is the batch the script
+    is blocked on. We hand that whole batch to the workflow, which runs every call
+    CONCURRENTLY as its own durable activity (``asyncio.gather`` over ``execute_activity``)
+    and resumes the FutureSnapshot with ``{call_id: {"return_value": ...}}`` for all of them.
+
+So concurrency is real and durable: one Temporal activity per host call, all in flight at
+once, orchestrated by the workflow. The defer loop (resuming ExternalFutures) does no host
+work, so it runs entirely inside the activity — only the awaited batch crosses to the
+workflow. A purely sequential script (``await`` one call at a time) just produces single-call
+batches; a synchronous (non-awaited) script is not supported — host functions are async by
+contract.
+
+No ``from __future__ import annotations`` — matching :mod:`.batch_models` and the rest of the
+agent's Temporal-facing modules, whose annotations must stay runtime-resolvable.
+"""
+
+from typing import Any
+
+import pydantic_monty as monty
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+
+from .batch_models import (
+    CodeBatchStep,
+    PendingCall,
+    ResumeBatchInput,
+)
+
+
+def _drive_to_batch(snap: Any, stdout: monty.CollectString) -> CodeBatchStep:
+    """Run Monty forward, deferring each external call as a future, until it awaits a batch.
+
+    Loops: a FunctionSnapshot (an ``async`` host call) is recorded and resumed with
+    ``{"future": ...}`` so execution continues; a FutureSnapshot means the script is now
+    awaiting — return its ``pending_call_ids`` (resolved to the recorded calls) for the
+    workflow to run; MontyComplete means done. Any ``snapshot.resume`` may raise a
+    MontyError if the script errors mid-run — the callers translate that to ``error``."""
+    seen: dict[int, PendingCall] = {}
+    while True:
+        if isinstance(snap, monty.MontyComplete):
+            return CodeBatchStep(
+                done=True, stdout=stdout.output, output_json=snap.output_json()
+            )
+        if isinstance(snap, monty.FunctionSnapshot):
+            seen[snap.call_id] = PendingCall(
+                call_id=snap.call_id,
+                function_name=str(snap.function_name),
+                args=list(snap.args),
+                kwargs=dict(snap.kwargs),
+            )
+            # ExternalFuture: "pending, keep going" — does no host work, so stay in-activity.
+            snap = snap.resume({"future": ...})
+            continue
+        if isinstance(snap, monty.FutureSnapshot):
+            ids = list(snap.pending_call_ids)
+            missing = [i for i in ids if i not in seen]
+            if missing:
+                # A call deferred in a PRIOR activity run and only awaited now: this driver
+                # records calls per-run, so it can't name them. Model-generated gather code
+                # issues+awaits together, so this shouldn't arise; fail loudly if it does.
+                raise ApplicationError(
+                    f"FutureSnapshot awaits call_ids {missing} not seen in this run "
+                    f"(cross-batch deferral is unsupported)",
+                    type="UnsupportedMontyFuture",
+                    non_retryable=True,
+                )
+            return CodeBatchStep(
+                done=False,
+                stdout=stdout.output,
+                snapshot=snap.dump(),
+                pending=[seen[i] for i in ids],
+            )
+        # NameLookupSnapshot (unknown bare name) — unsupported by this driver.
+        raise ApplicationError(
+            f"unsupported Monty suspension: {type(snap).__name__}",
+            type="UnsupportedMontySuspension",
+            non_retryable=True,
+        )
+
+
+def start_batch(script: str, type_check_stubs: str | None = None) -> CodeBatchStep:
+    """Compile + start ``script`` (async driver), running to the first awaited batch or done.
+
+    Type-checks against ``type_check_stubs`` when provided (Code Mode always passes the
+    auto-generated host-function stubs). See this module's async-driver section for the
+    defer-future / FutureSnapshot protocol. The body of
+    :func:`.activities.code_start_batch`."""
+    activity.logger.info(
+        "code_start_batch: compiling + starting (script_len=%d, type_check=%s)",
+        len(script),
+        type_check_stubs is not None,
+    )
+    stdout = monty.CollectString()
+    try:
+        instance = monty.Monty(
+            script,
+            type_check=type_check_stubs is not None,
+            type_check_stubs=type_check_stubs,
+        )
+        snap = instance.start(print_callback=stdout)
+        step = _drive_to_batch(snap, stdout)
+    except monty.MontyError as e:
+        activity.logger.warning("code_start_batch: %s: %s", type(e).__name__, e)
+        return CodeBatchStep(
+            done=True, stdout=stdout.output, error=f"{type(e).__name__}: {e}"
+        )
+    activity.logger.info(
+        "code_start_batch: %s",
+        "done"
+        if step.done
+        else f"awaiting {[c.function_name for c in step.pending]}",
+    )
+    return step
+
+
+def resume_batch(input: ResumeBatchInput) -> CodeBatchStep:
+    """Resume a FutureSnapshot with the workflow-computed results, then run to the next batch.
+
+    ``input.results`` carries one :class:`CallResult` per call the workflow ran (the batch
+    that was awaited). Resumes the FutureSnapshot with ``{call_id: {"return_value": ...}}``
+    for all of them, then drives forward to the next awaited batch or completion. The body of
+    :func:`.activities.code_resume_batch`."""
+    stdout = monty.CollectString()
+    snap = monty.load_snapshot(input.snapshot, print_callback=stdout)
+    if not isinstance(snap, monty.FutureSnapshot):
+        raise ApplicationError(
+            f"code_resume_batch expected a FutureSnapshot, got {type(snap).__name__}",
+            type="MontyResumeKind",
+            non_retryable=True,
+        )
+    results_map: dict[int, Any] = {
+        r.call_id: {"return_value": r.return_value} for r in input.results
+    }
+    try:
+        resumed = snap.resume(results_map)
+        step = _drive_to_batch(resumed, stdout)
+    except monty.MontyError as e:
+        activity.logger.warning("code_resume_batch: %s: %s", type(e).__name__, e)
+        return CodeBatchStep(
+            done=True, stdout=stdout.output, error=f"{type(e).__name__}: {e}"
+        )
+    activity.logger.info(
+        "code_resume_batch: %s",
+        "done"
+        if step.done
+        else f"awaiting {[c.function_name for c in step.pending]}",
+    )
+    return step

--- a/temporal_agent_harness/harness/subagent_activities.py
+++ b/temporal_agent_harness/harness/subagent_activities.py
@@ -26,9 +26,11 @@
 # DESIGN — Temporal Client: the activity needs a ``Client`` to talk to
 # the *child* (both the ``send_agent_message`` update and the stream subscribe). It can't use
 # ``WorkflowStreamClient.from_within_activity()`` (that targets the activity's own parent).
-# So this is a CLASS that closes over the worker's client; register the bound method as the
-# activity (``activities=[SubagentActivities(client).run_subagent_turn]``). A future harness
-# worker plugin will instantiate it from the worker's client automatically.
+# So this is a CLASS that closes over the worker's client; the bound method is what gets
+# registered as the activity. ``AgentHarnessPlugin`` does that instantiation from the worker's
+# own client (it is why the plugin overrides ``configure_worker``), so agents normally never
+# touch this class — reach for it directly only when hand-building a worker's activity list
+# (``activities=[SubagentActivities(client).run_subagent_turn]``).
 
 from __future__ import annotations
 
@@ -81,15 +83,15 @@ class _TurnProgress(BaseModel):
 class SubagentActivities:
     """Harness activities for driving subagents, bound to a Temporal :class:`Client`.
 
-    Construct with the worker's client (closed over so the activity can talk to *child*
-    workflows) and register the bound activity method on the worker::
+    ``AgentHarnessPlugin`` constructs this from the worker's own client and registers the
+    bound activity method, so agents normally never name this class. Do it by hand only when
+    assembling a worker's activity list yourself::
 
         subagents = SubagentActivities(client)
         Worker(..., activities=[subagents.run_subagent_turn, ...])
 
     Kept a class (rather than a module-level client global) so the client is an explicit
-    construction dependency; a future harness worker plugin instantiates this from the
-    worker's client automatically.
+    construction dependency — which is what lets the plugin supply the worker's own.
     """
 
     def __init__(self, client: Client) -> None:

--- a/temporal_agent_harness/plugin.py
+++ b/temporal_agent_harness/plugin.py
@@ -1,0 +1,255 @@
+# ABOUTME: ``AgentHarnessPlugin`` — the single Temporal plugin that wires a worker (and its
+# client) for the agent harness. Add the plugin and you get the harness's capabilities; you
+# never hand-assemble its activity list or its data converter again.
+#
+# Before::
+#
+#     subagents = SubagentActivities(client)
+#     client = await Client.connect(
+#         **connect_config,
+#         plugins=[GoogleGenAIPlugin(gemini)],
+#         data_converter=await with_large_payload_offload(pydantic_data_converter),
+#     )
+#     Worker(
+#         client,
+#         task_queue=...,
+#         workflows=[MyAgent],
+#         activities=[
+#             *(agent.tool_activity(t) for t in MY_TOOLS),
+#             *CODE_MODE_ACTIVITIES,
+#             subagents.run_subagent_turn,
+#         ],
+#     )
+#
+# After::
+#
+#     client = await Client.connect(
+#         **connect_config,
+#         plugins=[GoogleGenAIPlugin(gemini), AgentHarnessPlugin(tools=MY_TOOLS)],
+#     )
+#     Worker(client, task_queue=..., workflows=[MyAgent])
+#
+# DESIGN — why a plugin and not a ``create_agent_worker(...)`` helper: Temporal's plugin
+# protocol is the composition seam the AI-SDK integrations already use
+# (``GoogleGenAIPlugin``, ``OpenAIAgentsPlugin``, Pydantic AI's ``AgentPlugin``). A plugin
+# layers onto whichever of those an agent uses instead of competing with them for ownership
+# of the ``Client``/``Worker`` constructor, and it applies to the client and the worker from
+# one registration — which matters because the harness's data-converter requirements are a
+# CLIENT concern while its activities are a WORKER concern.
+#
+# DESIGN — ORDER the harness plugin LAST: ``plugins=[<ai_sdk_plugin>, AgentHarnessPlugin()]``.
+# Plugins configure the client in list order, and an AI-SDK plugin installs its own payload
+# converter (``OpenAIAgentsPlugin`` installs ``OpenAIPayloadConverter`` and REJECTS a converter
+# it doesn't recognize). This plugin therefore only fills in a payload converter that is still
+# the SDK default and otherwise leaves the AI SDK's in place — so it composes when it runs
+# last, and would trip the AI SDK's own check if it ran first. See :func:`_data_converter`.
+#
+# DESIGN — client-bound activities: ``SubagentActivities.run_subagent_turn`` must close over
+# the worker's ``Client`` (it talks to CHILD workflows, which
+# ``WorkflowStreamClient.from_within_activity()`` cannot reach). ``SimplePlugin``'s
+# ``activities`` hook only sees the existing activity list, not the worker config, so this
+# plugin overrides :meth:`AgentHarnessPlugin.configure_worker` to read ``config["client"]``
+# and bind there. That is the reason this is a ``SimplePlugin`` SUBCLASS rather than a
+# ``SimplePlugin`` instance.
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from temporalio.contrib.pydantic import PydanticPayloadConverter
+from temporalio.converter import DataConverter, DefaultPayloadConverter, ExternalStorage
+from temporalio.plugin import SimplePlugin
+from temporalio.worker import WorkerConfig
+
+from temporal_agent_harness.harness.code_mode.activities import CODE_MODE_ACTIVITIES
+from temporal_agent_harness.utils.large_payload import DEFAULT_PAYLOAD_STORAGE
+
+
+def _activity_name(fn: Callable[..., Any]) -> str | None:
+    """The registered Temporal activity name of ``fn``, or ``None`` if it isn't an activity."""
+    return getattr(getattr(fn, "__temporal_activity_definition", None), "name", None)
+
+
+def _tool_activities(
+    tools: Sequence[Callable[..., Any]],
+) -> list[Callable[..., Any]]:
+    """The durable activity bodies of the ``@agent.activity_tool_defn`` tools in ``tools``.
+
+    Takes an agent's whole toolset, not a pre-filtered one: inline (``@agent.tool_defn``) and
+    callback (``@agent.callback_tool_defn``) tools have no worker-side body and are skipped, as
+    are the inline tools returned by ``agent.subagent_toolset(...)``. Anything that is not a
+    harness tool at all is a mistake (a plain function, or a tool whose decorator was forgotten)
+    and raises rather than being silently dropped.
+    """
+    bodies: list[Callable[..., Any]] = []
+    for tool in tools:
+        activity_fn = getattr(tool, "activity", None)
+        if getattr(tool, "__agent_activity_tool__", False) and activity_fn is not None:
+            bodies.append(activity_fn)
+        elif getattr(tool, "__agent_tool__", False):
+            # Inline or callback tool: runs in the workflow (or on an attached client), so
+            # there is no activity to register.
+            continue
+        else:
+            name = getattr(tool, "__name__", None) or repr(tool)
+            raise TypeError(
+                f"AgentHarnessPlugin(tools=...) got {name}, which is not a harness tool. "
+                "Pass the tools declared with @agent.activity_tool_defn / @agent.tool_defn / "
+                "@agent.callback_tool_defn (the activity-backed ones are registered; the "
+                "others are skipped)."
+            )
+    return bodies
+
+
+class AgentHarnessPlugin(SimplePlugin):
+    """One plugin that gives a client + worker every agent-harness capability.
+
+    Register it on the client alongside whichever AI-SDK plugin the agent uses — **last**, so
+    the AI SDK's own payload converter wins (see the module notes) — and the worker needs
+    nothing but its workflows::
+
+        client = await Client.connect(
+            **ClientConfig.load_client_connect_config(),
+            plugins=[
+                OpenAIAgentsPlugin(model_params=...),
+                AgentHarnessPlugin(tools=MY_TOOLS),
+            ],
+        )
+        worker = Worker(client, task_queue="my-agent", workflows=[MyAgent])
+
+    What it configures:
+
+    * **Data converter** — a Pydantic payload converter (the harness's events, tool payloads,
+      and Code Mode batch models are Pydantic models with discriminated unions) plus
+      large-payload offload to external storage. The offload matters across processes, not just
+      within one: every client, worker, and server that reads a harness payload must use the
+      same converter or an offloaded payload can't be read back, and this plugin is how they
+      agree. Only filled in where it isn't already set, so an AI-SDK plugin's converter and a
+      hand-passed ``data_converter=`` both survive.
+    * **Subagent activity** — ``run_subagent_turn``, bound to the worker's own ``Client`` so it
+      can drive child agents. Every agent built with ``agent.subagent_toolset(...)`` needs it.
+    * **Code Mode activities** — the two sandbox-stepping activities, registered
+      unconditionally. Whether the optional ``code-mode`` extra is installed is checked per
+      call, inside the activity, so a worker without it fails a Code Mode call with an
+      actionable non-retryable error rather than leaving the activity names unregistered —
+      which Temporal answers with a *retryable* error, hanging the turn (see
+      :func:`temporal_agent_harness.harness.code_mode.activities._require_code_mode_extra`).
+    * **Tool activities** — the durable body of each ``@agent.activity_tool_defn`` tool in
+      ``tools``.
+
+    Args:
+        tools: The agent's tools. The activity-backed ones get their durable bodies
+            registered; inline and callback tools are skipped (they have no worker-side
+            body), so an agent's whole toolset can be passed as-is.
+        large_payload_offload: Where the data converter offloads oversized payloads —
+            Code Mode snapshots and large tool results routinely exceed Temporal's ~2 MB
+            limit. Defaults to :func:`~temporal_agent_harness.utils.large_payload.local_payload_storage`,
+            which is single-host only; pass
+            :func:`~temporal_agent_harness.utils.large_payload.s3_payload_storage` (or any
+            ``ExternalStorage`` of your own) for a multi-host deploy, reading whatever env
+            vars your deployment uses in your own startup code. Every client, worker, and
+            server must end up with the same backend, or a payload offloaded by one is
+            unreadable by another. ``None`` disables offloading entirely.
+    """
+
+    def __init__(
+        self,
+        *,
+        tools: Sequence[Callable[..., Any]] = (),
+        # Defaulting to the shared local storage rather than to ``None`` keeps ``None`` free
+        # to mean the one other thing a caller might want: no offloading at all.
+        large_payload_offload: ExternalStorage | None = DEFAULT_PAYLOAD_STORAGE,
+    ) -> None:
+        # Resolved eagerly so a bad `tools` entry surfaces at plugin construction, next to the
+        # developer's own call, rather than deep inside Worker() where the traceback points at
+        # SDK internals.
+        self._worker_activities: list[Callable[..., Any]] = [
+            *_tool_activities(tools),
+            *CODE_MODE_ACTIVITIES,
+        ]
+
+        def data_converter(converter: DataConverter | None) -> DataConverter:
+            return _data_converter(converter, offload=large_payload_offload)
+
+
+
+        super().__init__(
+            name="AgentHarnessPlugin",
+            data_converter=data_converter,
+            activities=self._append_activities,
+        )
+
+    def configure_worker(self, config: WorkerConfig) -> WorkerConfig:
+        """See base class.
+
+        Extends ``SimplePlugin`` to add the activities that must close over the worker's
+        ``Client`` — ``run_subagent_turn`` talks to CHILD agent workflows, so it cannot use
+        the activity's own parent (see the module notes).
+        """
+        config = super().configure_worker(config)
+        client = config.get("client")
+        if client is None:  # pragma: no cover - Worker always supplies its client
+            return config
+
+        from temporal_agent_harness.harness.subagent_activities import (
+            SubagentActivities,
+        )
+
+        config["activities"] = _merge_activities(
+            config.get("activities"),
+            [SubagentActivities(client).run_subagent_turn],
+        )
+        return config
+
+    def _append_activities(
+        self, activities: Sequence[Callable[..., Any]] | None
+    ) -> Sequence[Callable[..., Any]]:
+        return _merge_activities(activities, self._worker_activities)
+
+
+def _merge_activities(
+    existing: Sequence[Callable[..., Any]] | None,
+    added: Sequence[Callable[..., Any]],
+) -> list[Callable[..., Any]]:
+    """``existing`` plus the entries of ``added`` whose activity names aren't already present.
+
+    Temporal rejects a worker with two activities of the same name, and the harness's
+    activities are exactly the ones a worker written before this plugin registered by hand —
+    so a half-migrated worker (or one that passes ``CODE_MODE_ACTIVITIES`` explicitly) keeps
+    working instead of failing at startup. Registration is first-one-wins: an explicitly
+    passed activity is never displaced by the plugin's copy of it.
+    """
+    merged = list(existing or [])
+    seen = {name for name in (_activity_name(fn) for fn in merged) if name is not None}
+    for fn in added:
+        name = _activity_name(fn)
+        if name is not None and name in seen:
+            continue
+        if name is not None:
+            seen.add(name)
+        merged.append(fn)
+    return merged
+
+
+def _data_converter(
+    converter: DataConverter | None, *, offload: ExternalStorage | None
+) -> DataConverter:
+    """Fill in the harness's data-converter requirements without displacing anything set.
+
+    A Pydantic payload converter is installed only when the converter is still the SDK
+    default: an AI-SDK plugin's converter is already Pydantic-compatible (OpenAI's
+    ``OpenAIPayloadConverter`` wraps a Pydantic JSON converter), and overwriting it would
+    break that SDK. Likewise ``offload`` is applied only when the converter has no external
+    storage of its own, so a caller who built their own keeps it.
+    """
+    if converter is None:
+        converter = DataConverter(payload_converter_class=PydanticPayloadConverter)
+    elif converter.payload_converter_class is DefaultPayloadConverter:
+        converter = dataclasses.replace(
+            converter, payload_converter_class=PydanticPayloadConverter
+        )
+    if offload is not None and converter.external_storage is None:
+        converter = dataclasses.replace(converter, external_storage=offload)
+    return converter

--- a/temporal_agent_harness/utils/large_payload.py
+++ b/temporal_agent_harness/utils/large_payload.py
@@ -2,8 +2,9 @@
 (https://docs.temporal.io/develop/python/best-practices/data-handling/external-storage).
 
 Temporal caps a single payload at ~2 MB (activity results, workflow /
-continue-as-new inputs, signals, query results). Some of our data may not fit
-within this limit, so we enable external storage offload.
+continue-as-new inputs, signals, query results). Some harness data doesn't fit —
+Code Mode sandbox snapshots most of all — so oversized payloads are offloaded to
+external storage.
 
 The SDK implements the "claim check" pattern natively: a ``StorageDriver``
 registered on the ``DataConverter`` via ``ExternalStorage`` offloads any payload
@@ -11,24 +12,36 @@ over ``payload_size_threshold`` to external storage, replacing it on the wire
 with a small reference; retrieval is automatic on decode. This is transparent to
 workflow/activity code — they just pass the data.
 
-The backend is chosen by the ``LARGE_PAYLOAD_DRIVER`` env var ("local" — the
-default, filesystem-backed for development — or "s3" for multi-host deploys).
+This module reads NO environment variables: which backend to use is deployment
+configuration, so it is passed in. Build an ``ExternalStorage`` with one of the two
+factories here and hand it to ``AgentHarnessPlugin(large_payload_offload=...)``::
+
+    # single-host dev (the plugin's default)
+    plugin = AgentHarnessPlugin(large_payload_offload=local_payload_storage())
+
+    # multi-host deploy
+    plugin = AgentHarnessPlugin(
+        large_payload_offload=await s3_payload_storage(bucket=os.environ["MY_BUCKET"]),
+    )
+
+Read whatever env vars your deployment uses in your own worker/server startup and
+pick the factory there. Every client, worker, and server in a deployment must use
+the SAME backend, or a payload offloaded by one is unreadable by another.
 
 # ===========================================================================
-# DEPLOY NOTE: the default LocalFileStorageDriver writes to the LOCAL
-# FILESYSTEM, so an offloaded payload can only be retrieved by a process sharing
-# that filesystem — fine for local dev (single host: launchers, agent worker, 
-# and server all see the same /tmp), but NOT across hosts. For multi-host deploys
-# set LARGE_PAYLOAD_DRIVER=s3 (the SDK's built-in S3 driver, wired in 
-# _s3_storage_driver() below). Operational checklist:
-#   * Provision an S3 bucket + IAM for the workers; set LARGE_PAYLOAD_S3_BUCKET
-#     and supply region/credentials via the standard AWS chain.
+# DEPLOY NOTE: LocalFileStorageDriver writes to the LOCAL FILESYSTEM, so an
+# offloaded payload can only be retrieved by a process sharing that filesystem —
+# fine for local dev (single host: launchers, agent worker, and server all see the
+# same /tmp), but NOT across hosts. For multi-host deploys use
+# s3_payload_storage(). Operational checklist:
+#   * Provision an S3 bucket + IAM for the workers; pass the bucket name to
+#     s3_payload_storage() and supply region/credentials via the standard AWS chain.
 #   * Set a bucket lifecycle/TTL policy to GC offloaded objects — they are keyed
 #     by content hash and never deleted by the driver (the local driver has no
 #     GC either; offloaded files just accumulate).
-#   * Every worker/launcher/server must use LARGE_PAYLOAD_DRIVER=s3 with access
-#     to the same bucket, so any offloaded payload is retrievable wherever it's
-#     consumed (the cross-host gap the local driver can't span).
+#   * Every worker/launcher/server must use the same bucket, so any offloaded
+#     payload is retrievable wherever it's consumed (the cross-host gap the local
+#     driver can't span).
 # ===========================================================================
 """
 from __future__ import annotations
@@ -49,13 +62,14 @@ from temporalio.converter import (
     StorageDriverStoreContext,
 )
 
-# Where local payloads live; override via env for tests/deploys.
-_BASE_DIR = Path(os.environ.get("LARGE_PAYLOAD_DIR", "/tmp/temporal-large-payloads"))
+# Where the local driver keeps payloads when no directory is given. A dev default:
+# see the DEPLOY NOTE above before relying on it beyond one host.
+DEFAULT_LOCAL_PAYLOAD_DIR = Path("/tmp/temporal-large-payloads")
 
 # Offload anything at/above this size. Kept just under Temporal's ~2 MB hard
-# limit so only genuinely oversized payloads leave the Event History; 
+# limit so only genuinely oversized payloads leave the Event History;
 # ordinary payloads (configs, query results) stay inline.
-_THRESHOLD_BYTES = 1_500_000
+DEFAULT_PAYLOAD_SIZE_THRESHOLD = 1_500_000
 
 
 def _safe_key(key: str) -> str:
@@ -68,14 +82,18 @@ def _safe_key(key: str) -> str:
 class LocalFileStorageDriver(StorageDriver):
     """Filesystem-backed ``StorageDriver``. Payloads are keyed by a SHA-256 of
     their serialized bytes (so identical bytes dedupe to one file), mirroring the
-    SDK's S3 driver. Intended for local development only — see the module TODO."""
+    SDK's S3 driver. Intended for single-host development — see the module's
+    DEPLOY NOTE. Prefer :func:`local_payload_storage`, which wraps this in the
+    ``ExternalStorage`` the plugin wants."""
 
     def __init__(
         self,
-        base_dir: Path | None = None,
+        base_dir: Path | str | None = None,
         driver_name: str = "local-file",
     ) -> None:
-        self._base = Path(base_dir) if base_dir is not None else _BASE_DIR
+        self._base = (
+            Path(base_dir) if base_dir is not None else DEFAULT_LOCAL_PAYLOAD_DIR
+        )
         self._name = driver_name
 
     def name(self) -> str:
@@ -132,60 +150,78 @@ class LocalFileStorageDriver(StorageDriver):
         return out
 
 
-# Selects the storage backend. "local" (default) writes to the local filesystem;
-# "s3" is the multi-host deploy target (not yet wired — see _s3_storage_driver).
-_DRIVER_KIND = os.environ.get("LARGE_PAYLOAD_DRIVER", "local").strip().lower()
+def local_payload_storage(
+    *,
+    base_dir: Path | str | None = None,
+    payload_size_threshold: int = DEFAULT_PAYLOAD_SIZE_THRESHOLD,
+) -> ExternalStorage:
+    """Offload oversized payloads to the local filesystem. For SINGLE-HOST use only.
+
+    The default for local development, and the harness plugin's default. Only a process
+    sharing this filesystem can read back what it stores, so use
+    :func:`s3_payload_storage` for anything multi-host (see the module's DEPLOY NOTE).
+
+    Args:
+        base_dir: Directory to write offloaded payloads to. Defaults to
+            :data:`DEFAULT_LOCAL_PAYLOAD_DIR`.
+        payload_size_threshold: Offload payloads at or above this many bytes.
+    """
+    return ExternalStorage(
+        drivers=[LocalFileStorageDriver(base_dir)],
+        payload_size_threshold=payload_size_threshold,
+    )
 
 
-async def _build_storage_driver() -> StorageDriver:
-    """Return the active storage driver, selected by the ``LARGE_PAYLOAD_DRIVER``
-    env var ("local" — default — or "s3"). Async because the s3 backend creates
-    an aioboto3 client, which must be entered from an async context."""
-    match _DRIVER_KIND:
-        case "local":
-            return LocalFileStorageDriver()
-        case "s3":
-            return await _s3_storage_driver()
-        case _:
-            raise ValueError(
-                f"unknown LARGE_PAYLOAD_DRIVER={_DRIVER_KIND!r}; expected 'local' or 's3'"
-            )
+# The default offload target, built once. An ``ExternalStorage`` is a frozen dataclass over a
+# stateless driver, so one instance is safely shared by every plugin, client, worker, and
+# server in a process — and sharing it is the point: they must all agree on the backend.
+DEFAULT_PAYLOAD_STORAGE = local_payload_storage()
 
 
-async def _s3_storage_driver() -> StorageDriver:
-    """The multi-host S3 backend, built on the SDK's out-of-the-box
-    ``S3StorageDriver`` (it keys objects by content hash and integrity-checks on
-    retrieve — no custom driver to write). Requires the ``temporalio[aioboto3]``
-    extra and ``LARGE_PAYLOAD_S3_BUCKET``; region/credentials come from the
-    standard AWS chain (and ``AWS_ENDPOINT_URL_S3`` overrides the endpoint, e.g.
-    for MinIO in tests)."""
+async def s3_payload_storage(
+    *,
+    bucket: str,
+    payload_size_threshold: int = DEFAULT_PAYLOAD_SIZE_THRESHOLD,
+) -> ExternalStorage:
+    """Offload oversized payloads to an S3 bucket. The multi-host deploy target.
+
+    Built on the SDK's out-of-the-box ``S3StorageDriver`` (it keys objects by content hash
+    and integrity-checks on retrieve — no custom driver to write). Requires the harness's
+    ``s3`` extra; region and credentials come from the standard AWS chain (and
+    ``AWS_ENDPOINT_URL_S3`` overrides the endpoint, e.g. for MinIO in tests).
+
+    Async because the aioboto3 client it wraps must be created from a running event loop —
+    so call it from your ``async`` startup, before constructing the plugin.
+
+    Args:
+        bucket: Name of the S3 bucket to store offloaded payloads in. Every process in the
+            deployment must use the same one.
+        payload_size_threshold: Offload payloads at or above this many bytes.
+    """
     import aioboto3
     from temporalio.contrib.aws.s3driver import S3StorageDriver
     from temporalio.contrib.aws.s3driver.aioboto3 import new_aioboto3_client
 
-    bucket = os.environ.get("LARGE_PAYLOAD_S3_BUCKET")
-    if not bucket:
-        raise RuntimeError(
-            "LARGE_PAYLOAD_DRIVER=s3 requires LARGE_PAYLOAD_S3_BUCKET to be set"
-        )
     # aioboto3's client is an async context manager; enter it and hold it open
     # for the process lifetime (no matching __aexit__ — the connection pool is
     # reclaimed on process exit, mirroring a long-lived service client).
     s3_client = await aioboto3.Session().client("s3").__aenter__()
-    return S3StorageDriver(client=new_aioboto3_client(s3_client), bucket=bucket)
+    return ExternalStorage(
+        drivers=[S3StorageDriver(client=new_aioboto3_client(s3_client), bucket=bucket)],
+        payload_size_threshold=payload_size_threshold,
+    )
 
 
-async def with_large_payload_offload(base: DataConverter) -> DataConverter:
-    """Return ``base`` configured to offload oversized payloads to external
-    storage. Apply at every Client.connect site so offloaded payloads can be
-    read back wherever they're consumed. Async because the s3 backend builds an
-    aioboto3-backed driver."""
+def with_large_payload_offload(
+    base: DataConverter, storage: ExternalStorage
+) -> DataConverter:
+    """Return ``base`` configured to offload oversized payloads to ``storage``.
+
+    For assembling a ``DataConverter`` by hand — a service that talks to harness agents but
+    isn't one itself. Agent clients and workers should add ``AgentHarnessPlugin`` instead,
+    which applies the same offload alongside the rest of the harness's wiring. Whichever you
+    use, every process in the deployment must end up with the same backend.
+    """
     if base.external_storage is not None:
         raise ValueError("data converter already has external_storage configured")
-    return dataclasses.replace(
-        base,
-        external_storage=ExternalStorage(
-            drivers=[await _build_storage_driver()],
-            payload_size_threshold=_THRESHOLD_BYTES,
-        ),
-    )
+    return dataclasses.replace(base, external_storage=storage)

--- a/temporal_agent_harness/web/app.py
+++ b/temporal_agent_harness/web/app.py
@@ -19,7 +19,7 @@ from temporalio.api.enums.v1 import EventType
 from temporalio.api.history.v1 import HistoryEvent
 from temporalio.client import Client, WorkflowExecutionStatus, WorkflowHandle
 from temporalio.common import WorkflowIDConflictPolicy
-from temporalio.contrib.pydantic import pydantic_data_converter
+from temporalio.converter import ExternalStorage
 from temporalio.envconfig import ClientConfig
 from temporalio.exceptions import WorkflowAlreadyStartedError
 from temporalio.service import RPCError, RPCStatusCode
@@ -44,8 +44,9 @@ from temporal_agent_harness.harness.agent_protocol import (
     OperatorCommandResult,
     SEND_AGENT_MESSAGE_UPDATE,
 )
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 from temporal_agent_harness.ui import packaged_ui_dist
-from temporal_agent_harness.utils.large_payload import with_large_payload_offload
+from temporal_agent_harness.utils.large_payload import DEFAULT_PAYLOAD_STORAGE
 from temporal_agent_harness.web.registry import load_agent_registry
 from temporal_agent_harness.web.session_manager import (
     SESSION_MANAGER_ID,
@@ -113,6 +114,7 @@ def create_agent_harness_app(
     static_dir: Path | str | None = None,
     index_file: str = "index.html",
     states_file: str | None = None,
+    large_payload_offload: ExternalStorage | None = DEFAULT_PAYLOAD_STORAGE,
 ) -> FastAPI:
     """Create the reusable harness web API.
 
@@ -125,6 +127,12 @@ def create_agent_harness_app(
             the packaged Vite UI is served if it is present in the installed package.
         index_file: File in ``static_dir`` served from ``/``.
         states_file: Optional file in ``static_dir`` served from ``/states``.
+        large_payload_offload: Where oversized payloads are offloaded, forwarded to
+            ``AgentHarnessPlugin``. Must match what every agent worker and the
+            session-manager worker use, or this server can't read their payloads. The
+            default is single-host only; build
+            :func:`~temporal_agent_harness.utils.large_payload.s3_payload_storage` in your
+            own async startup and pass it for a multi-host deploy.
     """
 
     static_path = Path(static_dir) if static_dir is not None else packaged_ui_dist()
@@ -132,9 +140,14 @@ def create_agent_harness_app(
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         connect_config = ClientConfig.load_client_connect_config()
+        # The harness plugin is where the data converter is DEFINED — the same one every agent
+        # worker and the session-manager worker get by adding the same plugin. An offloaded
+        # payload is only readable by a process using the matching converter, so this app must
+        # not spell one out of its own. The plugin's activity registration is a WORKER concern
+        # and this app hosts no worker, so it simply doesn't apply here.
         app.state.temporal = await Client.connect(
             **connect_config,
-            data_converter=await with_large_payload_offload(pydantic_data_converter),
+            plugins=[AgentHarnessPlugin(large_payload_offload=large_payload_offload)],
         )
 
         resolved_registry = _resolve_registry(registry, registry_path)

--- a/tests/examples/monty/test_code_mode_e2e.py
+++ b/tests/examples/monty/test_code_mode_e2e.py
@@ -17,7 +17,6 @@ from temporalio.contrib.workflow_streams import WorkflowStreamClient
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
-from temporal_agent_harness.harness import agent
 from temporal_agent_harness.harness.agent_protocol import (
     SEND_AGENT_MESSAGE_UPDATE,
     TURN_EVENTS_TOPIC,
@@ -27,7 +26,7 @@ from temporal_agent_harness.harness.agent_protocol import (
     AgentMessage,
     AgentMessageReply,
 )
-from temporal_agent_harness.harness.code_mode.activities import CODE_MODE_ACTIVITIES
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 
 from ._code_mode_e2e_parent import CODE_MODE_TOOLS, CodeModeE2EParentWorkflow
 
@@ -42,12 +41,9 @@ async def client_and_queue():
         env.client,
         task_queue=task_queue,
         workflows=[CodeModeE2EParentWorkflow],
-        # The generic Code Mode stepping activities + the durable bodies of the host tools
-        # (registered the normal way, like any @agent.activity_tool_defn).
-        activities=[
-            *CODE_MODE_ACTIVITIES,
-            *(agent.tool_activity(t) for t in CODE_MODE_TOOLS),
-        ],
+        # One plugin supplies both the generic Code Mode stepping activities and the durable
+        # bodies of the host tools.
+        plugins=[AgentHarnessPlugin(tools=CODE_MODE_TOOLS)],
     ):
         try:
             yield env.client, task_queue

--- a/tests/examples/monty/test_subagent_e2e.py
+++ b/tests/examples/monty/test_subagent_e2e.py
@@ -31,11 +31,9 @@ from temporal_agent_harness.harness.agent_protocol import (
     AgentMessage,
     AgentMessageReply,
 )
-from temporal_agent_harness.harness.subagent_activities import SubagentActivities
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 
 from temporal_agent_harness.harness.agent_client import AgentClient
-
-from temporal_agent_harness.harness.code_mode.activities import CODE_MODE_ACTIVITIES
 
 from examples.monty import activities
 from examples.monty.workflow import MontyDynamicAgentWorkflow
@@ -52,9 +50,9 @@ async def client_and_queue():
     )
     task_queue = f"subagent-e2e-{uuid.uuid4()}"
     # One worker hosts BOTH the parent and the child agent (the parent starts the child on this
-    # same queue), the Monty batch + host activities the child needs, and the subagent-turn
-    # activity the parent's runner dispatches — closed over the env client so it can talk to the
-    # child workflow.
+    # same queue). The harness plugin supplies everything else: the Monty batch + host
+    # activities the child needs, and the subagent-turn activity the parent's runner dispatches
+    # — the latter bound to this worker's client so it can talk to the child workflow.
     async with Worker(
         env.client,
         task_queue=task_queue,
@@ -63,11 +61,7 @@ async def client_and_queue():
             ApprovalGatedSubagentParentWorkflow,
             MontyDynamicAgentWorkflow,
         ],
-        activities=[
-            *activities.ALL_ACTIVITIES,
-            *CODE_MODE_ACTIVITIES,
-            SubagentActivities(env.client).run_subagent_turn,
-        ],
+        plugins=[AgentHarnessPlugin(tools=activities.ALL_TOOLS)],
     ):
         try:
             yield env.client, task_queue

--- a/tests/examples/monty/test_workflow.py
+++ b/tests/examples/monty/test_workflow.py
@@ -29,7 +29,7 @@ from temporal_agent_harness.harness.agent_protocol import (
     AgentMessageReply,
 )
 
-from temporal_agent_harness.harness.code_mode.activities import CODE_MODE_ACTIVITIES
+from temporal_agent_harness.plugin import AgentHarnessPlugin
 
 from examples.monty import activities
 from examples.monty.workflow import MontyDynamicAgentWorkflow
@@ -41,11 +41,14 @@ async def client_and_queue():
         data_converter=pydantic_data_converter
     )
     task_queue = f"monty-agent-test-{uuid.uuid4()}"
+    # Mirrors examples/monty/worker.py: the harness plugin registers the travel tools' activity
+    # bodies and the Code Mode stepping activities. (Passed to the Worker rather than the
+    # client because the test env's client is already connected.)
     async with Worker(
         env.client,
         task_queue=task_queue,
         workflows=[MontyDynamicAgentWorkflow],
-        activities=[*activities.ALL_ACTIVITIES, *CODE_MODE_ACTIVITIES],
+        plugins=[AgentHarnessPlugin(tools=activities.ALL_TOOLS)],
     ):
         try:
             yield env.client, task_queue

--- a/tests/harness/test_code_mode.py
+++ b/tests/harness/test_code_mode.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import inspect
 
 import pytest
+from temporalio.exceptions import ApplicationError
 
 from temporal_agent_harness.harness import agent
 from temporal_agent_harness.harness.code_mode.stubs import (
@@ -112,3 +113,76 @@ def test_distinct_names_allow_multiple_code_mode_tools_over_overlapping_sets():
     assert a.__name__ == "run_a"
     assert b.__name__ == "run_b"
     assert a is not b
+
+
+# ---------------------------------------------------------------- activities module typing
+
+
+def test_the_stepper_keeps_real_monty_annotations():
+    """The stepping logic must stay typed against the real Monty package.
+
+    ``monty_stepper`` exists so the monty-touching code can import Monty normally, at module
+    scope, and be type-checked like anything else — the ``code-mode`` extra is optional only
+    at the :mod:`activities` boundary. Resolving an annotation here is what a type checker
+    does, so this fails if a monty type is ever softened to ``Any``.
+    """
+    import typing
+
+    pytest.importorskip("pydantic_monty")
+    import pydantic_monty
+
+    from temporal_agent_harness.harness.code_mode import monty_stepper
+
+    hints = typing.get_type_hints(monty_stepper._drive_to_batch)
+    assert hints["stdout"] is pydantic_monty.CollectString
+
+
+def test_the_activities_module_imports_without_the_code_mode_extra():
+    """``activities`` must load on a worker with no ``code-mode`` extra installed.
+
+    That is what lets a worker register the two activity NAMES either way, so a misconfigured
+    worker gets one actionable non-retryable failure instead of Temporal retrying an
+    unregistered activity name forever. Binding ``pydantic_monty`` to ``None`` in
+    ``sys.modules`` is the documented way to make its import fail.
+    """
+    import importlib
+    import sys
+
+    module = "temporal_agent_harness.harness.code_mode.activities"
+    saved = sys.modules.pop(module, None)
+    sys.modules["pydantic_monty"] = None  # type: ignore[assignment]
+    try:
+        activities = importlib.import_module(module)
+        assert len(activities.CODE_MODE_ACTIVITIES) == 2
+        with pytest.raises(ApplicationError) as caught:
+            activities._require_code_mode_extra()
+        assert caught.value.type == activities.CODE_MODE_MISSING_EXTRA_ERROR
+        assert caught.value.non_retryable
+        assert "temporal-agent-harness[code-mode]" in str(caught.value)
+    finally:
+        del sys.modules["pydantic_monty"]
+        sys.modules.pop(module, None)
+        if saved is not None:
+            sys.modules[module] = saved
+        else:
+            importlib.import_module(module)
+
+
+def test_the_stepping_activity_signatures_resolve_without_monty():
+    """Temporal resolves an activity's own type hints, so those must not mention monty.
+
+    ``@activity.defn`` registration runs ``get_type_hints`` on each activity; if a monty type
+    leaked into one of these signatures it would have to be quoted, and then registration on a
+    worker without the extra would fail before the actionable error could ever be raised.
+    """
+    import typing
+
+    from temporal_agent_harness.harness.code_mode import activities
+
+    for fn in activities.CODE_MODE_ACTIVITIES:
+        resolved = typing.get_type_hints(fn)
+        assert resolved, f"{fn.__name__} should have resolvable hints"
+        assert not any(
+            getattr(hint, "__module__", "").startswith("pydantic_monty")
+            for hint in resolved.values()
+        ), f"{fn.__name__} must not expose a monty type in its activity signature"

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -1,0 +1,399 @@
+# ABOUTME: Tests for AgentHarnessPlugin — the one plugin that wires a client + worker for the
+# harness. Covers what it registers (subagent, Code Mode, and tool activities), what it
+# refuses (a non-harness "tool"), how its data converter composes with an AI-SDK plugin's, and
+# that it never double-registers an activity a worker already passed by hand.
+#
+# Lives in a subdirectory, not at the tests/ root: pytest prepends a test file's basedir to
+# sys.path, and a file directly under tests/ would put `tests/` there — where the namespace
+# directory tests/examples shadows the repo-root `examples` package the example tests import.
+#
+# Run with: `uv run pytest tests/plugin/test_plugin.py -v`
+
+from __future__ import annotations
+
+import sys
+from datetime import timedelta
+
+import pytest
+from temporalio import activity, workflow
+from temporalio.client import WorkflowFailureError
+from temporalio.contrib.pydantic import PydanticPayloadConverter, pydantic_data_converter
+from temporalio.converter import DataConverter
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+from temporalio.workflow import ActivityConfig
+
+from temporal_agent_harness.harness import agent
+from temporal_agent_harness.harness.agent_protocol import RUN_SUBAGENT_TURN_ACTIVITY
+from temporal_agent_harness.harness.code_mode.batch_models import (
+    CODE_RESUME_BATCH_ACTIVITY,
+    CODE_START_BATCH_ACTIVITY,
+)
+from temporal_agent_harness.harness.code_mode.activities import (
+    CODE_MODE_ACTIVITIES,
+    CODE_MODE_MISSING_EXTRA_ERROR,
+)
+from temporal_agent_harness.plugin import AgentHarnessPlugin
+from temporal_agent_harness.utils.large_payload import (
+    DEFAULT_PAYLOAD_STORAGE,
+    local_payload_storage,
+)
+
+_CODE_MODE_NAMES = {CODE_START_BATCH_ACTIVITY, CODE_RESUME_BATCH_ACTIVITY}
+
+
+@agent.activity_tool_defn(
+    activity_config=ActivityConfig(start_to_close_timeout=timedelta(seconds=5)),
+)
+async def durable_tool(city: str) -> str:
+    """A durable, activity-backed tool."""
+    return city
+
+
+@agent.tool_defn()
+async def inline_tool(text: str) -> str:
+    """An inline tool that runs in the workflow."""
+    return text
+
+
+@agent.callback_tool_defn()
+async def callback_tool(path: str) -> str:
+    """A tool fulfilled by an attached client."""
+    ...
+
+
+async def plain_function(x: int) -> int:
+    return x
+
+
+@workflow.defn(name="PluginCodeModeStepWorkflow")
+class _CodeModeStepWorkflow:
+    """Dispatches one Code Mode sandbox step exactly as ``CodeModeDriver`` does — by NAME.
+
+    Standing in for a full Code Mode agent on purpose: the name-based dispatch IS the seam the
+    plugin's registration has to satisfy, and everything else an agent brings (a runner, turns,
+    approvals, the tool lifecycle) is unchanged and already covered by
+    tests/examples/monty/test_code_mode_e2e.py. Note the deliberate absence of a retry policy:
+    the default is unlimited attempts, so this workflow only fails fast if the error really is
+    non-retryable.
+    """
+
+    @workflow.run
+    async def run(self) -> object:
+        return await workflow.execute_activity(
+            CODE_START_BATCH_ACTIVITY,
+            args=["1 + 1", None],
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+
+
+@workflow.defn(name="PluginTestWorkflow")
+class _StubWorkflow:
+    """A placeholder so ``Worker`` has something to host (it rejects an empty worker)."""
+
+    @workflow.run
+    async def run(self) -> None: ...
+
+
+def _pretend_extra_missing(monkeypatch) -> None:
+    """Make the engine unavailable exactly as it is on a worker without the extra.
+
+    Binding the name to ``None`` in ``sys.modules`` is the documented way to make ``import
+    pydantic_monty`` raise ImportError; monkeypatch undoes it afterwards. Uninstalling the
+    extra for one test isn't an option on a dev machine that legitimately has it.
+
+    Also drops any already-imported ``monty_stepper``, since that module imports Monty at
+    module scope: without this, an earlier test's successful import would still be cached in
+    ``sys.modules`` and the activity's local import would succeed anyway.
+    """
+    monkeypatch.setitem(sys.modules, "pydantic_monty", None)
+    monkeypatch.delitem(
+        sys.modules,
+        "temporal_agent_harness.harness.code_mode.monty_stepper",
+        raising=False,
+    )
+
+
+def _plugin_activity_names(plugin: AgentHarnessPlugin) -> set[str]:
+    """The activity names a plugin contributes to a worker, before it sees one."""
+    return {
+        getattr(fn, "__temporal_activity_definition").name
+        for fn in plugin._worker_activities
+    }
+
+
+def _registered_activity_names(worker: Worker) -> set[str]:
+    """The activity names a built ``Worker`` will actually serve.
+
+    ``active_config=True`` is the post-plugin view; the default returns the arguments the
+    caller passed, which is exactly what the plugin is meant to shrink.
+    """
+    return {
+        name
+        for name in (
+            getattr(
+                getattr(fn, "__temporal_activity_definition", None), "name", None
+            )
+            for fn in worker.config(active_config=True)["activities"]
+        )
+        if name is not None
+    }
+
+
+# ---------------------------------------------------------------- data converter
+
+
+def test_data_converter_fills_in_pydantic_and_offload():
+    converter = AgentHarnessPlugin().data_converter(None)
+    assert converter.payload_converter_class is PydanticPayloadConverter
+    assert converter.external_storage is not None
+    [driver] = converter.external_storage.drivers
+    assert driver.name() == "local-file"
+
+
+def test_data_converter_upgrades_a_default_converter_in_place():
+    # A caller who passed `data_converter=DataConverter.default` still gets both requirements.
+    converter = AgentHarnessPlugin().data_converter(DataConverter.default)
+    assert converter.payload_converter_class is PydanticPayloadConverter
+    assert converter.external_storage is not None
+
+
+def test_data_converter_keeps_an_ai_sdk_payload_converter():
+    """The plugin runs LAST, so an AI SDK's payload converter must survive it."""
+    openai_agents = pytest.importorskip(
+        "temporal_agent_harness.ai_sdks.openai_agents._temporal_openai_agents"
+    )
+    sdk_converter = DataConverter(
+        payload_converter_class=openai_agents.OpenAIPayloadConverter
+    )
+
+    converter = AgentHarnessPlugin().data_converter(sdk_converter)
+
+    assert converter.payload_converter_class is openai_agents.OpenAIPayloadConverter
+    assert converter.external_storage is not None, "offload is still added"
+
+
+def test_data_converter_keeps_an_existing_external_storage(tmp_path):
+    import dataclasses
+
+    mine = local_payload_storage(base_dir=tmp_path)
+    converter = AgentHarnessPlugin().data_converter(
+        dataclasses.replace(pydantic_data_converter, external_storage=mine)
+    )
+    assert converter.external_storage is mine
+
+
+def test_the_offload_target_is_configuration_not_a_flag(tmp_path):
+    """The caller hands the plugin an ``ExternalStorage``; the harness reads no env vars."""
+    mine = local_payload_storage(base_dir=tmp_path, payload_size_threshold=64)
+    converter = AgentHarnessPlugin(large_payload_offload=mine).data_converter(None)
+    assert converter.external_storage is mine
+    assert converter.external_storage.payload_size_threshold == 64
+
+
+def test_the_default_offload_target_is_the_shared_local_storage():
+    converter = AgentHarnessPlugin().data_converter(None)
+    assert converter.external_storage is DEFAULT_PAYLOAD_STORAGE
+
+
+def test_offload_can_be_turned_off():
+    converter = AgentHarnessPlugin(large_payload_offload=None).data_converter(None)
+    assert converter.payload_converter_class is PydanticPayloadConverter
+    assert converter.external_storage is None
+
+
+# ---------------------------------------------------------------- tools
+
+
+def test_tools_registers_activity_bodies_and_skips_bodiless_tools():
+    plugin = AgentHarnessPlugin(tools=[durable_tool, inline_tool, callback_tool])
+    names = _plugin_activity_names(plugin)
+    assert names - _CODE_MODE_NAMES == {"durable_tool"}
+
+
+def test_tools_rejects_a_non_harness_tool():
+    with pytest.raises(TypeError, match="not a harness tool"):
+        AgentHarnessPlugin(tools=[plain_function])
+
+
+# ---------------------------------------------------------------- code mode
+
+
+def test_code_mode_activities_are_registered_unconditionally(monkeypatch):
+    """Registration never branches on the extra — the check lives inside the activity.
+
+    Registering the names is what matters: the driver dispatches Code Mode by name, and
+    leaving them unregistered would make Temporal retry "not registered" forever.
+    """
+    assert set(AgentHarnessPlugin()._worker_activities) == set(CODE_MODE_ACTIVITIES)
+
+    _pretend_extra_missing(monkeypatch)
+    plugin = AgentHarnessPlugin()
+    assert set(plugin._worker_activities) == set(CODE_MODE_ACTIVITIES)
+    assert _plugin_activity_names(plugin) == _CODE_MODE_NAMES
+
+
+async def test_a_code_mode_call_fails_actionably_without_the_extra(monkeypatch):
+    """One immediate, actionable failure instead of a hung turn.
+
+    Runs the REAL ``code_start_batch`` against an import that fails, asserting the developer
+    is told what to install and that the failure is non-retryable — so the turn ends instead
+    of retrying a missing dependency forever, which is what leaving the activity names
+    unregistered would do.
+    """
+    _pretend_extra_missing(monkeypatch)
+
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=pydantic_data_converter
+    ) as env:
+        async with Worker(
+            env.client,
+            task_queue="plugin-no-code-mode",
+            workflows=[_CodeModeStepWorkflow],
+            plugins=[AgentHarnessPlugin()],
+        ):
+            with pytest.raises(WorkflowFailureError) as caught:
+                await env.client.execute_workflow(
+                    _CodeModeStepWorkflow.run,
+                    id="plugin-no-code-mode-1",
+                    task_queue="plugin-no-code-mode",
+                )
+
+    # ActivityError -> ApplicationError, non-retryable, naming the extra to install.
+    cause = caught.value.cause.cause
+    assert isinstance(cause, ApplicationError)
+    assert cause.type == CODE_MODE_MISSING_EXTRA_ERROR
+    assert cause.non_retryable
+    assert "temporal-agent-harness[code-mode]" in str(cause)
+
+
+# ---------------------------------------------------------------- worker wiring
+
+
+async def test_worker_gets_every_harness_activity_from_the_plugin():
+    """The headline claim: add the plugin, declare only workflows, get the capabilities."""
+    pytest.importorskip("pydantic_monty")
+    plugin = AgentHarnessPlugin(tools=[durable_tool, inline_tool])
+
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=pydantic_data_converter
+    ) as env:
+        worker = Worker(
+            env.client, task_queue="plugin-test", workflows=[_StubWorkflow], plugins=[plugin]
+        )
+        assert _registered_activity_names(worker) == {
+            "durable_tool",
+            CODE_START_BATCH_ACTIVITY,
+            CODE_RESUME_BATCH_ACTIVITY,
+            RUN_SUBAGENT_TURN_ACTIVITY,
+        }
+
+
+async def test_hand_registered_harness_activities_are_not_duplicated():
+    """A half-migrated worker that still passes the harness activities itself must start.
+
+    Temporal rejects two activities with one name, so the plugin merges by name and lets the
+    explicitly passed function win.
+    """
+    from temporal_agent_harness.harness.subagent_activities import SubagentActivities
+
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=pydantic_data_converter
+    ) as env:
+        hand_written = [
+            *CODE_MODE_ACTIVITIES,
+            SubagentActivities(env.client).run_subagent_turn,
+            agent.tool_activity(durable_tool),
+        ]
+        worker = Worker(
+            env.client,
+            task_queue="plugin-test",
+            workflows=[_StubWorkflow],
+            activities=hand_written,
+            plugins=[AgentHarnessPlugin(tools=[durable_tool])],
+        )
+        activities = worker.config(active_config=True)["activities"]
+        assert len(activities) == len(hand_written)
+        assert _registered_activity_names(worker) == {
+            "durable_tool",
+            CODE_START_BATCH_ACTIVITY,
+            CODE_RESUME_BATCH_ACTIVITY,
+            RUN_SUBAGENT_TURN_ACTIVITY,
+        }
+
+
+async def test_unrelated_worker_activities_survive():
+    @activity.defn(name="unrelated")
+    async def unrelated() -> None: ...
+
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=pydantic_data_converter
+    ) as env:
+        worker = Worker(
+            env.client,
+            task_queue="plugin-test",
+            workflows=[_StubWorkflow],
+            activities=[unrelated],
+            plugins=[AgentHarnessPlugin()],
+        )
+        assert _registered_activity_names(worker) == {
+            "unrelated",
+            RUN_SUBAGENT_TURN_ACTIVITY,
+            *_CODE_MODE_NAMES,
+        }
+
+
+# ---------------------------------------------------------------- end to end
+
+
+@workflow.defn(name="PluginBigPayloadWorkflow")
+class _BigPayloadWorkflow:
+    """Returns a payload well past Temporal's ~2 MB limit, so it must be offloaded."""
+
+    @workflow.run
+    async def run(self, size: int) -> str:
+        return "z" * size
+
+
+async def test_client_registered_plugin_reaches_the_worker():
+    """Every example registers the plugin on the CLIENT only — Temporal must carry it through.
+
+    A client's plugins are applied to the workers built from that client, which is what lets an
+    agent worker declare nothing but its workflows.
+    """
+    async with await WorkflowEnvironment.start_time_skipping(
+        plugins=[AgentHarnessPlugin(tools=[durable_tool])]
+    ) as env:
+        worker = Worker(env.client, task_queue="plugin-test", workflows=[_StubWorkflow])
+        assert _registered_activity_names(worker) == {
+            "durable_tool",
+            RUN_SUBAGENT_TURN_ACTIVITY,
+            *_CODE_MODE_NAMES,
+        }
+
+
+async def test_plugins_configured_storage_offloads_a_large_payload(tmp_path):
+    """The storage the caller passes has to work inside a real, connected client.
+
+    Exercises the whole path end to end — plugin config → data converter → an oversized
+    workflow result — and checks the payload really left the event history and landed in the
+    directory the test chose (no env var in sight).
+    """
+    storage = local_payload_storage(base_dir=tmp_path)
+
+    size = 2_000_000
+    async with await WorkflowEnvironment.start_time_skipping(
+        plugins=[AgentHarnessPlugin(large_payload_offload=storage)]
+    ) as env:
+        async with Worker(
+            env.client, task_queue="plugin-offload", workflows=[_BigPayloadWorkflow]
+        ):
+            result = await env.client.execute_workflow(
+                _BigPayloadWorkflow.run,
+                size,
+                id="plugin-offload-1",
+                task_queue="plugin-offload",
+            )
+    assert result == "z" * size
+    assert list(tmp_path.glob("*.bin")), "the payload should have been offloaded"

--- a/tests/utils/test_large_payload.py
+++ b/tests/utils/test_large_payload.py
@@ -1,41 +1,39 @@
-"""Tests for the large-payload storage-driver selection.
+"""Tests for the large-payload storage factories.
 
 The S3 round-trip uses a threaded moto server (the reliable way to exercise
 aioboto3/aiobotocore, which talk real HTTP) reached via the standard AWS
-endpoint env var — the same mechanism _s3_storage_driver() relies on in prod.
+endpoint env var — the same mechanism s3_payload_storage() relies on in prod.
 
 Run with: `uv run pytest tests/utils/test_large_payload.py -v`
 """
 
-import importlib
 import os
 
 import pytest
 from moto.server import ThreadedMotoServer
 from temporalio.api.common.v1 import Payload
+from temporalio.contrib.pydantic import pydantic_data_converter
+
+from temporal_agent_harness.utils.large_payload import (
+    DEFAULT_PAYLOAD_SIZE_THRESHOLD,
+    DEFAULT_PAYLOAD_STORAGE,
+    LocalFileStorageDriver,
+    local_payload_storage,
+    s3_payload_storage,
+    with_large_payload_offload,
+)
 
 BUCKET = "large-payload-test-bucket"
 
 
-def _reload_with_driver(kind: str):
-    """Reimport large_payload so module-level _DRIVER_KIND picks up LARGE_PAYLOAD_DRIVER."""
-    os.environ["LARGE_PAYLOAD_DRIVER"] = kind
-    from temporal_agent_harness.utils import large_payload
-
-    return importlib.reload(large_payload)
-
-
 @pytest.fixture(autouse=True)
 def _restore_env():
-    """Snapshot/restore the env this module mutates, so the reload-based driver
-    selection can't leak LARGE_PAYLOAD_DRIVER (etc.) into other test files."""
+    """Snapshot/restore the AWS env the S3 fixture sets, so it can't leak between files."""
     keys = (
         "AWS_ENDPOINT_URL",
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_DEFAULT_REGION",
-        "LARGE_PAYLOAD_DRIVER",
-        "LARGE_PAYLOAD_S3_BUCKET",
     )
     prev = {k: os.environ.get(k) for k in keys}
     try:
@@ -58,7 +56,6 @@ def s3_server():
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-    os.environ["LARGE_PAYLOAD_S3_BUCKET"] = BUCKET
     try:
         import boto3
 
@@ -68,11 +65,65 @@ def s3_server():
         server.stop()
 
 
-async def test_s3_driver_round_trip(s3_server):
+# ---------------------------------------------------------------- local
+
+
+def test_local_storage_defaults():
+    storage = local_payload_storage()
+    [driver] = storage.drivers
+    assert isinstance(driver, LocalFileStorageDriver)
+    assert driver.name() == "local-file"
+    assert storage.payload_size_threshold == DEFAULT_PAYLOAD_SIZE_THRESHOLD
+
+
+def test_local_storage_takes_its_config_as_arguments(tmp_path):
+    """No env vars: the directory and threshold are passed in by the caller."""
+    storage = local_payload_storage(base_dir=tmp_path, payload_size_threshold=10)
+    assert storage.payload_size_threshold == 10
+    assert storage.drivers[0]._base == tmp_path
+
+
+async def test_local_driver_round_trip(tmp_path):
+    [driver] = local_payload_storage(base_dir=tmp_path).drivers
+
+    payload = Payload(metadata={"encoding": b"json/plain"}, data=b"y" * 2_000_000)
+    claims = await driver.store(_ctx(), [payload])
+    assert len(claims) == 1
+    assert list(tmp_path.glob("*.bin")), "payload should have landed on disk"
+
+    [restored] = await driver.retrieve(_ctx(), claims)
+    assert restored.data == payload.data
+    assert restored.metadata["encoding"] == b"json/plain"
+
+
+async def test_local_driver_rejects_a_traversing_claim_key(tmp_path):
+    [driver] = local_payload_storage(base_dir=tmp_path).drivers
+    from temporalio.converter import StorageDriverClaim
+
+    with pytest.raises(ValueError, match="invalid storage claim key"):
+        await driver.retrieve(_ctx(), [StorageDriverClaim(claim_data={"key": "../x"})])
+
+
+def test_the_shared_default_is_local_storage():
+    """Everything that doesn't configure a backend must land on the SAME instance.
+
+    The plugin, the packaged web app, and any hand-built converter all default to this one
+    object; an offloaded payload is only readable by a process using the matching backend.
+    """
+    [driver] = DEFAULT_PAYLOAD_STORAGE.drivers
+    assert isinstance(driver, LocalFileStorageDriver)
+    assert DEFAULT_PAYLOAD_STORAGE.payload_size_threshold == DEFAULT_PAYLOAD_SIZE_THRESHOLD
+
+
+# ---------------------------------------------------------------- s3
+
+
+async def test_s3_storage_round_trip(s3_server):
     import boto3
 
-    large_payload = _reload_with_driver("s3")
-    driver = await large_payload._s3_storage_driver()
+    storage = await s3_payload_storage(bucket=BUCKET)
+    assert storage.payload_size_threshold == DEFAULT_PAYLOAD_SIZE_THRESHOLD
+    [driver] = storage.drivers
 
     payload = Payload(metadata={"encoding": b"json/plain"}, data=b"x" * 3_000_000)
 
@@ -89,23 +140,22 @@ async def test_s3_driver_round_trip(s3_server):
     assert restored.metadata["encoding"] == b"json/plain"
 
 
-async def test_s3_driver_requires_bucket(s3_server):
-    large_payload = _reload_with_driver("s3")
-    os.environ.pop("LARGE_PAYLOAD_S3_BUCKET")
-    with pytest.raises(RuntimeError, match="LARGE_PAYLOAD_S3_BUCKET"):
-        await large_payload._s3_storage_driver()
+# ---------------------------------------------------------------- converter helper
 
 
-async def test_default_local_driver():
-    large_payload = _reload_with_driver("local")
-    driver = await large_payload._build_storage_driver()
-    assert isinstance(driver, large_payload.LocalFileStorageDriver)
+def test_with_large_payload_offload_applies_the_given_storage(tmp_path):
+    storage = local_payload_storage(base_dir=tmp_path)
+    converted = with_large_payload_offload(pydantic_data_converter, storage)
+    assert converted.external_storage is storage
+    assert pydantic_data_converter.external_storage is None, "must not mutate the input"
 
 
-async def test_unknown_driver_rejected():
-    large_payload = _reload_with_driver("bogus")
-    with pytest.raises(ValueError, match="unknown LARGE_PAYLOAD_DRIVER"):
-        await large_payload._build_storage_driver()
+def test_with_large_payload_offload_refuses_to_clobber_existing_storage(tmp_path):
+    already = with_large_payload_offload(
+        pydantic_data_converter, local_payload_storage(base_dir=tmp_path)
+    )
+    with pytest.raises(ValueError, match="already has external_storage"):
+        with_large_payload_offload(already, local_payload_storage(base_dir=tmp_path))
 
 
 def _ctx():


### PR DESCRIPTION
The harness was a loose collection of activities every worker had to assemble by hand: the tool activity bodies, the Code Mode stepping activities, a client-bound subagent activity, and a data converter that had to match across every process. Miss one and the failure surfaces late, as an unregistered activity or an unreadable payload.

AgentHarnessPlugin replaces that assembly with one registration, in the same shape as the AI SDK integrations (GoogleGenAIPlugin, OpenAIAgentsPlugin). Add it to the client and a worker declares only its workflows.

```python
client = await Client.connect(
  **connect_config,
  plugins=[GoogleGenAIPlugin(gemini), AgentHarnessPlugin(tools=MY_TOOLS)],
)
Worker(client, task_queue=..., workflows=[MyAgent])
```

The plugin supplies:
  * the data converter — Pydantic payload converter plus large-payload offload. Only fills in what isn't already set, so an AI SDK plugin's converter survives (order the harness plugin last).
  * the durable activity body of each @agent.activity_tool_defn tool in tools=. Takes a whole toolset; inline and callback tools are skipped.
  * run_subagent_turn, bound to the worker's own client. This is why the plugin overrides configure_worker rather than passing an activities callable to SimplePlugin — that hook never sees the worker config.
  * the two Code Mode stepping activities.

Activity registration merges by name, so a worker that still passes the harness activities itself keeps starting instead of failing on a duplicate.

Large-payload offload is now configuration rather than environment. utils/large_payload reads no env vars: local_payload_storage() and s3_payload_storage(bucket=...) return an ExternalStorage that callers build in their own startup and hand to large_payload_offload=.

Code Mode's monty dependency moves behind the activity boundary. code_mode/activities no longer imports pydantic_monty; it checks the extra and delegates to the new code_mode/monty_stepper, which imports Monty normally and stays fully type-checked. So the activities are always registered, and a worker missing the extra fails a Code Mode call with a non-retryable error naming what to install — rather than leaving the activity names unregistered, which Temporal answers with a *retryable* NotFoundError and retries forever.