### PR TITLE
Cut the 0.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ see [Versioning and stability](#versioning-and-stability) for why that matters.
 Clone at a release tag. No Node/pnpm needed: the browser UI ships prebuilt.
 
 ```bash
-git clone --branch 0.1.0 https://github.com/temporal-community/temporal-agent-harness.git
+git clone --branch 0.2.0 https://github.com/temporal-community/temporal-agent-harness.git
 cd temporal-agent-harness
 ```
 
@@ -55,7 +55,7 @@ project:
 
 ```bash
 # core harness — define and run agent workflows
-uv add "temporal-agent-harness @ git+https://github.com/temporal-community/temporal-agent-harness.git@0.1.0"
+uv add "temporal-agent-harness @ git+https://github.com/temporal-community/temporal-agent-harness.git@0.2.0"
 ```
 
 Or declare it in `pyproject.toml` — depend on the package (with any extras you need) and point
@@ -68,7 +68,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-temporal-agent-harness = { git = "https://github.com/temporal-community/temporal-agent-harness.git", tag = "0.1.0" }
+temporal-agent-harness = { git = "https://github.com/temporal-community/temporal-agent-harness.git", tag = "0.2.0" }
 ```
 
 Then run `uv sync`.

--- a/docs/internal/development.md
+++ b/docs/internal/development.md
@@ -96,8 +96,8 @@ just package
 The resulting artifacts are written to `dist/`:
 
 ```text
-dist/temporal_agent_harness-0.1.0.tar.gz
-dist/temporal_agent_harness-0.1.0-py3-none-any.whl
+dist/temporal_agent_harness-0.2.0.tar.gz
+dist/temporal_agent_harness-0.2.0-py3-none-any.whl
 ```
 
 The wheel and sdist include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "temporal-agent-harness"
-version = "0.1.0"
+version = "0.2.0"
 description = "Temporal-native agent harness (experimental) — durable agents on Temporal, with the AI SDKs you already use."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/web/test_packaged_ui.py
+++ b/tests/web/test_packaged_ui.py
@@ -480,7 +480,14 @@ def test_built_distributions_include_packaged_ui_assets(
         _assert_ui_assets_present(names)
         assert "temporal_agent_harness/web/worker.py" in names
 
-        metadata = wheel.read("temporal_agent_harness-0.1.0.dist-info/METADATA").decode()
+        # The dist-info directory name embeds the package version, so match it rather than
+        # hardcoding it — cutting a release shouldn't require editing this test.
+        (metadata_name,) = [
+            name
+            for name in names
+            if re.fullmatch(r"temporal_agent_harness-[^/]+\.dist-info/METADATA", name)
+        ]
+        metadata = wheel.read(metadata_name).decode()
         assert "Provides-Extra: ui" in metadata
         assert 'Requires-Dist: fastapi[standard]>=0.136.3; extra == "ui"' in metadata
 

--- a/uv.lock
+++ b/uv.lock
@@ -2943,7 +2943,7 @@ wheels = [
 
 [[package]]
 name = "temporal-agent-harness"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Bump the package version and bring everything that names the current release along with it, so the tagged tree documents the version someone is actually sitting on.

  * pyproject.toml and uv.lock: 0.1.0 -> 0.2.0.
  * README.md: the three install snippets in Installation — the `git clone --branch`, the `uv add ...@<tag>`, and the `[tool.uv.sources]` tag — now point at 0.2.0. The illustrative `git diff 0.1.0 0.2.0` line stays as written.
  * docs/internal/development.md: refresh the example `just package` output filenames.

tests/web/test_packaged_ui.py read the wheel's metadata through a hardcoded `temporal_agent_harness-0.1.0.dist-info/METADATA` path, so it failed the moment the version moved — a release-time tripwire that only fires on the commit least able to absorb the noise. It now matches the sole `*.dist-info/METADATA` entry in the wheel's namelist, and future bumps leave it alone.