### PR TITLE
Keep the suite green below Python 3.13 and pin the release interpreter

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,12 @@ jobs:
     # Must match the environment name given to PyPI's trusted publisher. Also the place to add
     # required reviewers if you want a human gate on every upload.
     environment: pypi
+    env:
+      # Pin the interpreter instead of taking the runner's default (3.12), which silently
+      # excluded 28 tests: temporal-nexus-mcp is declared `python_version >= '3.13'`, so on 3.12
+      # the tests/nexus_mcp modules skip collection entirely. A release gate that quietly runs
+      # 302 of 330 tests is not a gate — and 3.13 is what the project develops against.
+      UV_PYTHON: "3.13"
     permissions:
       contents: read
       # Mints the short-lived OIDC token PyPI exchanges for an upload token. Without this the

--- a/tests/ai_sdks/openai_agents/conftest.py
+++ b/tests/ai_sdks/openai_agents/conftest.py
@@ -1,0 +1,10 @@
+# ABOUTME: Skips the Nexus-brokered MCP test when temporal-nexus-mcp isn't importable.
+#
+# Same reason as tests/nexus_mcp/conftest.py, but scoped to the one module that needs
+# `nexus_mcp`: test_stream_observer.py alongside it must still run on every interpreter.
+
+from __future__ import annotations
+
+from importlib.util import find_spec
+
+collect_ignore = [] if find_spec("nexus_mcp") is not None else ["test_nexus_mcp.py"]

--- a/tests/nexus_mcp/conftest.py
+++ b/tests/nexus_mcp/conftest.py
@@ -1,0 +1,13 @@
+# ABOUTME: Skips this directory when temporal-nexus-mcp isn't importable.
+#
+# The dependency is declared `temporal-nexus-mcp; python_version >= '3.13'` — that package's own
+# floor — so on 3.11/3.12 the `nexus_mcp` module is simply absent and every test module here
+# fails at import. The package supports 3.11+, so `uv run pytest` has to be green on 3.11 and
+# 3.12 too; skipping collection is what makes the marker's consequence explicit instead of a
+# wall of ImportErrors.
+
+from __future__ import annotations
+
+from importlib.util import find_spec
+
+collect_ignore_glob = [] if find_spec("nexus_mcp") is not None else ["*"]


### PR DESCRIPTION
temporal-nexus-mcp is declared `python_version >= '3.13'` — its own floor — so on 3.11 and 3.12 the `nexus_mcp` module is absent and six test modules failed at import, not just in CI but for any contributor on an older interpreter. The package claims 3.11+, so the suite has to run there.

  * tests/nexus_mcp/conftest.py: skips the directory when nexus_mcp is not importable. All five modules there need it.
  * tests/ai_sdks/openai_agents/conftest.py: skips only test_nexus_mcp.py, so test_stream_observer.py beside it still runs on every interpreter.
  * .github/workflows/publish.yml: pin UV_PYTHON to 3.13. The runner's default is 3.12, where those guards drop 28 of 330 tests — a release gate that silently runs 302 of them is not a gate, and 3.13 is what the project develops against.

Verified on both: 330 passed on 3.13, 302 on 3.12.